### PR TITLE
79 database development container

### DIFF
--- a/.copilot/plans/local-devcontainer-postgres-plan.md
+++ b/.copilot/plans/local-devcontainer-postgres-plan.md
@@ -1,0 +1,95 @@
+<!-- markdownlint-disable-file -->
+# Plan: Local Dev Container with PostgreSQL Sidecar
+
+## Goal
+
+Convert the single-image dev container into a Docker Compose setup with the existing
+`app` service plus a `postgres:14` `db` sidecar, so local full-stack development runs
+against a containerized database (no Azure, no cost). No application code changes are
+required — `backend/app/db/pool.js` already honors `DB_SSL=false`, and `.env.example`
+already documents the `DB_*` variables.
+
+## Branch Workflow (do first)
+
+1. PR the current branch (`49-database-initialization`: repositories, Husky, `.vscode`, formatting).
+2. After merge:
+
+   ```bash
+   git checkout main && git pull && git checkout -b feature/local-devcontainer-postgres
+   ```
+
+   Do all the work below on that new branch.
+
+## Current State (investigated)
+
+- `.devcontainer/devcontainer.json`: single `image`
+  (`mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye`), features git + gh,
+  `forwardPorts` 3000/3001/8080, `postCreateCommand` commented out, and
+  `runArgs: ["--env-file", ".devcontainer/devcontainer.env"]`.
+- `.devcontainer/devcontainer.env` EXISTS (gitignored): `GOOGLE_API_KEY`,
+  `REACT_APP_GOOGLE_API_KEY`, `NODE_ENV`, `NODE_OPTIONS`, `BACKEND_PORT`,
+  `FRONTEND_PORT`, and a commented `DATABASE_URL` placeholder.
+- SECURITY: the Google API key value appears in git history (6 commits, some pushed).
+  Rotate the key before continuing.
+- `backend/` and `frontend/` have PRODUCTION Dockerfiles — separate concern; do NOT
+  reuse them for the dev container.
+- Schema lives at `docs/database/schema.sql` (PostgreSQL 14; includes demo data,
+  which is acceptable for local dev).
+
+## Files to Create / Modify
+
+1. CREATE `.devcontainer/docker-compose.yml`
+   - Service `app`: image `mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye`;
+     `command: sleep infinity`; bind-mount `..:/workspaces/jauntdetour`;
+     `env_file: devcontainer.env`; `depends_on: db` (condition `service_healthy`);
+     shared network.
+   - Service `db`: image `postgres:14`; environment `POSTGRES_USER=dbadmin`,
+     `POSTGRES_PASSWORD=localdev`, `POSTGRES_DB=jauntdetour`; volume
+     `pgdata:/var/lib/postgresql/data`; mount
+     `../docs/database/schema.sql -> /docker-entrypoint-initdb.d/init.sql:ro`
+     (auto-load on first init only); `ports: 5432:5432`; healthcheck
+     `pg_isready -U dbadmin`.
+   - Volumes: `pgdata` (named; persists across restarts).
+2. MODIFY `.devcontainer/devcontainer.json`
+   - Remove `image` and `runArgs` (`--env-file`); env now flows via Compose `env_file`.
+   - Add `dockerComposeFile: "docker-compose.yml"`, `service: "app"`,
+     `workspaceFolder: "/workspaces/jauntdetour"`.
+   - Keep features, customizations (extensions/settings), `portsAttributes`.
+   - `forwardPorts`: add `5432` (host DB GUI tools); keep 3000/3001/8080.
+   - Re-enable `postCreateCommand`:
+     `npm install --prefix ./backend && npm install --prefix ./frontend && npm install`.
+3. MODIFY `.devcontainer/devcontainer.env` (gitignored) — add:
+   `DB_HOST=db`, `DB_PORT=5432`, `DB_NAME=jauntdetour`, `DB_USER=dbadmin`,
+   `DB_PASSWORD=localdev`, `DB_SSL=false`.
+4. CREATE `.devcontainer/devcontainer.env.example` (committed) — same keys, placeholder
+   secrets, so teammates know what to fill in. Ensure the real `devcontainer.env` stays
+   gitignored.
+5. (Optional) Update `DEV-SETUP.md` / `README.md` with "Open in Dev Container"
+   local-DB instructions.
+
+## Key Decisions / Considerations
+
+- Pin `postgres:14` to match Azure + the schema.
+- `node_modules`: bind-mounting the workspace is simplest; if host/container
+  native-module conflicts appear, switch to a named volume for `node_modules`
+  (decide during implementation).
+- `depends_on` with `service_healthy` + a healthcheck so the backend never races the DB.
+- Schema auto-load runs ONLY when the `pgdata` volume is empty (first create); demo
+  data is included.
+- Reset the DB: `docker compose down -v` (wipes `pgdata`), then reopen/rebuild.
+- Local DB credentials are throwaway/local-only — safe to keep in the compose/env file.
+- Do NOT reuse the production `backend`/`frontend` Dockerfiles for the dev container.
+- Windows: ensure any mounted `.sql`/scripts use LF line endings.
+
+## Verification
+
+1. Dev Containers: Rebuild and Reopen in Container — builds `app` + `db`.
+2. `docker compose ps` (or VS Code) shows `db` healthy.
+3. From the `app` container:
+   `psql -h db -U dbadmin -d jauntdetour -c "\dt"` shows `users`/`trips`/`detours`;
+   `SELECT email FROM users;` returns `demo@jauntdetour.com`.
+4. Backend: with `DB_*` env set, run a quick query (or start the backend) — connects,
+   no SSL error.
+5. Frontend: `npm start` serves on 3001; forwarded.
+6. Persistence: restart the container — data remains. `down -v` resets and reloads schema.
+7. Confirm `devcontainer.env` is NOT tracked (`git check-ignore`) and the `.example` IS tracked.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.7",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a",
+      "integrity": "sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,0 +1,29 @@
+# Environment variables for Jauntdetour development.
+# Copy this file to devcontainer.env and fill in the secret values.
+#   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+# devcontainer.env is gitignored; never commit real secrets.
+
+# Google Maps API Key (required for both frontend and backend)
+GOOGLE_API_KEY=your_google_api_key_here
+REACT_APP_GOOGLE_API_KEY=your_google_api_key_here
+
+# Node.js environment
+NODE_ENV=development
+NODE_OPTIONS=--openssl-legacy-provider
+
+# Backend server configuration
+BACKEND_PORT=3000
+
+# Frontend development server configuration
+FRONTEND_PORT=3001
+
+# Local containerized database (see .devcontainer/docker-compose.yml).
+# These are local-only development values, safe to use as-is. The backend
+# connects as the least-privilege app user; DB_PASSWORD must match the password
+# in .devcontainer/init/02-create-app-user.sql.
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=jauntdetour
+DB_USER=jauntdetour_app
+DB_PASSWORD=localdevapp
+DB_SSL=false

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
   "name": "Jauntdetour Full Stack",
-  // Use the Node.js image with additional tools
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+  // Use Docker Compose: the `app` dev container plus a PostgreSQL `db` sidecar.
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/jauntdetour",
 
   // Features to add to the dev container
   "features": {
@@ -12,7 +14,7 @@
   },
 
   // Forward ports for both frontend and backend
-  "forwardPorts": [3000, 3001, 8080],
+  "forwardPorts": [3000, 3001, 8080, 5432],
   "portsAttributes": {
     "3000": {
       "label": "Backend API",
@@ -25,10 +27,19 @@
     "8080": {
       "label": "Frontend Production",
       "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "PostgreSQL",
+      "onAutoForward": "silent"
     }
   },
-  // Install dependencies for both frontend and backend after container creation
-  //"postCreateCommand": "npm install --prefix ./backend && npm install --prefix ./frontend && npm install",
+  // Install system packages once at container creation. postgresql-client provides
+  // the `psql` CLI for inspecting the local database.
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client",
+  // Install dependencies for root, backend, and frontend after the container is created.
+  // The node_modules named volumes are created root-owned, so hand them to the `node`
+  // user first (they're empty at this point, so the chown is instant).
+  "postCreateCommand": "sudo chown node:node node_modules backend/node_modules frontend/node_modules && npm install && npm install --prefix ./backend && npm install --prefix ./frontend",
 
   // Configure VS Code extensions and settings
   "customizations": {
@@ -56,11 +67,13 @@
   // Set environment variables for development
   "containerEnv": {
     "NODE_ENV": "development",
-    "NODE_OPTIONS": "--openssl-legacy-provider"
+    "NODE_OPTIONS": "--openssl-legacy-provider",
+    // Let VS Code's port forwarding open the browser for 3001; stop react-scripts
+    // from opening a second one.
+    "BROWSER": "none"
   },
-  // Load .env file if it exists
-  //"onCreateCommand": "if [ -f .env ]; then echo 'Found .env file for environment variables'; else echo 'No .env file found - create one with GOOGLE_API_KEY=your_key_here'; fi",
+  // Environment variables (Google keys, DB_*, ports) are also provided via the
+  // Compose `env_file` (.devcontainer/devcontainer.env). See devcontainer.env.example.
 
-  "remoteUser": "node",
-  "runArgs": ["--env-file", ".devcontainer/devcontainer.env"]
+  "remoteUser": "node"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,55 @@
+# Docker Compose for the local development container.
+# Provides the Node dev environment (`app`) plus a PostgreSQL 14 sidecar (`db`).
+# This is for LOCAL DEVELOPMENT ONLY — it does not use the production Dockerfiles.
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye
+    init: true
+    # Keep the container running so VS Code can attach and open a shell.
+    command: sleep infinity
+    volumes:
+      # Mount the repository into the container workspace.
+      - ..:/workspaces/jauntdetour:cached
+      # Container-only node_modules (named volumes) so the container's Linux-built
+      # dependencies never collide with the host's copies via the bind mount.
+      - node_modules_root:/workspaces/jauntdetour/node_modules
+      - node_modules_backend:/workspaces/jauntdetour/backend/node_modules
+      - node_modules_frontend:/workspaces/jauntdetour/frontend/node_modules
+    env_file:
+      # Local secrets + config (gitignored). See devcontainer.env.example.
+      - devcontainer.env
+    # Wait for the database to be accepting connections before the app is usable.
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:14
+    restart: unless-stopped
+    environment:
+      # Superuser used only for initialization; the app connects as jauntdetour_app.
+      POSTGRES_USER: dbadmin
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: jauntdetour
+    volumes:
+      # Persist database data across container restarts.
+      - pgdata:/var/lib/postgresql/data
+      # Init scripts run in filename order, and ONLY when pgdata is empty (first boot).
+      # 01 creates the schema (tables must exist before 02 grants on them).
+      - ../docs/database/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./init/02-create-app-user.sql:/docker-entrypoint-initdb.d/02-create-app-user.sql:ro
+    ports:
+      # Exposed to the host so GUI tools (DBeaver/pgAdmin) can connect on localhost:5432.
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dbadmin -d jauntdetour"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:
+  node_modules_root:
+  node_modules_backend:
+  node_modules_frontend:

--- a/.devcontainer/init/02-create-app-user.sql
+++ b/.devcontainer/init/02-create-app-user.sql
@@ -1,0 +1,16 @@
+-- Local development only: create the least-privilege application user.
+-- Mirrors the production setup (the app connects as jauntdetour_app, never as the
+-- superuser). Runs after 01-schema.sql so the tables it grants on already exist.
+-- The password here is a throwaway LOCAL value and must match DB_PASSWORD in
+-- .devcontainer/devcontainer.env.
+
+CREATE USER jauntdetour_app WITH PASSWORD 'localdevapp';
+
+GRANT CONNECT ON DATABASE jauntdetour TO jauntdetour_app;
+GRANT USAGE ON SCHEMA public TO jauntdetour_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO jauntdetour_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO jauntdetour_app;
+
+-- Ensure the app user also gets privileges on any tables created later.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO jauntdetour_app;

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,12 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
-# Optional: Database connection string if you add a database later
-# DATABASE_URL=your_database_url_here
+# Database connection (Azure Database for PostgreSQL - Flexible Server)
+# DB_HOST is the server FQDN from `terraform output server_fqdn`
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+# Set to "false" only for a local non-SSL Postgres; Azure requires SSL (leave unset).
+# DB_SSL=true

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,19 @@ typings/
 .env
 .env.production
 
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+!*.tfvars.example
+.terraform.lock.hcl
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
 # next.js build output
 .next
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+# Run the root-pinned lint-staged. It auto-discovers each package's config
+# (backend/, frontend/) and applies it to that package's staged files, using
+# that package's local ESLint/Prettier. --no-install keeps it deterministic:
+# it uses the installed root binary and never downloads an arbitrary version.
+npx --no-install lint-staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.requireConfig": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
+}

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -48,6 +48,36 @@ export NODE_OPTIONS=--openssl-legacy-provider
 - Nodemon for backend auto-restart on file changes
 - React fast refresh for frontend live reloading
 
+## Local Database (Dev Container)
+
+The dev container runs a PostgreSQL 14 sidecar (via `.devcontainer/docker-compose.yml`),
+so you can develop against a local database with no Azure dependency or cost.
+
+### First-time setup
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   # edit GOOGLE_API_KEY / REACT_APP_GOOGLE_API_KEY (DB_* values work as-is)
+   ```
+2. In VS Code, run **Dev Containers: Reopen in Container**. On first build the database
+   is created and seeded automatically:
+   - `01-schema.sql` loads the schema (tables, indexes, triggers, demo data).
+   - `02-create-app-user.sql` creates the least-privilege `jauntdetour_app` user.
+3. `npm run dev` starts the frontend and backend, which connect to the `db` service.
+
+### Connecting to the database
+- **From the app container:** host `db`, port `5432`.
+- **From your host machine** (DBeaver, pgAdmin, psql): `localhost:5432`.
+- The backend connects as `jauntdetour_app` (least privilege). The `dbadmin` superuser
+  (password `localdev`) is used only for initialization.
+
+### Resetting the database
+Init scripts run only when the data volume is empty (first boot). To wipe and reseed:
+```bash
+docker compose -f .devcontainer/docker-compose.yml down -v
+```
+Then rebuild/reopen the container.
+
 ## Development Tips
 1. The backend will auto-restart when you change files (thanks to nodemon)
 2. The frontend has fast refresh enabled for live updates

--- a/backend/app/db/pool.js
+++ b/backend/app/db/pool.js
@@ -1,0 +1,49 @@
+/**
+ * PostgreSQL connection pool.
+ *
+ * Creates a single shared `pg` Pool for the application. Pooling keeps a set of
+ * open connections ready so each request reuses one instead of paying a fresh
+ * TCP + TLS + auth handshake. Configuration is read from environment variables
+ * (see `.env.example`). Azure Database for PostgreSQL requires SSL.
+ */
+
+const { Pool } = require("pg");
+const logger = require("../utils/logger");
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT || 5432,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD, // from Key Vault in production
+  ssl: process.env.DB_SSL === "false" ? false : { rejectUnauthorized: true }, // Azure requires SSL; disable only for local Postgres
+  max: 20, // maximum number of clients in the pool
+  idleTimeoutMillis: 30000, // close idle clients after 30s
+  connectionTimeoutMillis: 2000, // fail fast if a connection can't be acquired
+});
+
+// Surface unexpected errors on idle clients (e.g. a dropped network/DB restart).
+pool.on("error", (err) => {
+  logger.error("Unexpected error on idle PostgreSQL client", err);
+  process.exit(-1);
+});
+
+module.exports = {
+  /**
+   * Run a parameterized query against the pool.
+   *
+   * @param {string} text - SQL with $1, $2, ... placeholders.
+   * @param {Array} [params] - Parameter values.
+   * @returns {Promise<import('pg').QueryResult>}
+   */
+  query: (text, params) => pool.query(text, params),
+
+  /**
+   * Acquire a dedicated client (for transactions). Caller must release it.
+   *
+   * @returns {Promise<import('pg').PoolClient>}
+   */
+  getClient: () => pool.connect(),
+
+  pool,
+};

--- a/backend/app/repositories/DetourRepository.js
+++ b/backend/app/repositories/DetourRepository.js
@@ -1,0 +1,270 @@
+/**
+ * DetourRepository — data access layer for the `detours` table.
+ *
+ * Encapsulates all SQL for detour records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * Detours belong to a user only transitively, through their parent trip. Every
+ * operation is therefore scoped by `user_id` — the authorization boundary — by
+ * verifying ownership via the `trips` table. A user can only read or modify
+ * detours on trips they own. All queries use parameterized placeholders
+ * ($1, $2, ...) — prepared statements that prevent SQL injection.
+ */
+
+const logger = require("../utils/logger");
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  placeId: "place_id",
+  placeName: "place_name",
+  placeType: "place_type",
+  latitude: "latitude",
+  longitude: "longitude",
+  address: "address",
+  positionOnRoute: "position_on_route",
+  estimatedDetourDurationSeconds: "estimated_detour_duration_seconds",
+  estimatedDetourDistanceMeters: "estimated_detour_distance_meters",
+  rating: "rating",
+  priceLevel: "price_level",
+  stopDurationMinutes: "stop_duration_minutes",
+  visitTime: "visit_time",
+  notes: "notes",
+  metadata: "metadata",
+};
+
+// Columns returned to callers. Shared by every query that returns a full row.
+// Prefixed with `d.` so it can be reused inside JOIN queries against trips.
+const RETURNING_COLUMNS = `
+      detour_id, trip_id, place_id, place_name, place_type, latitude, longitude,
+      address, position_on_route, estimated_detour_duration_seconds,
+      estimated_detour_distance_meters, rating, price_level, stop_duration_minutes,
+      visit_time, notes, created_at, updated_at, metadata
+`;
+const RETURNING_COLUMNS_PREFIXED = RETURNING_COLUMNS.replace(/(\w+)/g, "d.$1");
+
+class DetourRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "DetourRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a detour on a trip the user owns. The insert only succeeds if the
+   * parent trip exists and belongs to the given user; otherwise it is a no-op
+   * and null is returned (trip not found or not owned).
+   *
+   * @param {object} detour
+   * @param {string} detour.tripId - Parent trip UUID.
+   * @param {string} detour.userId - Owning user's UUID (authorization scope).
+   * @param {string} detour.placeName - Name of the place.
+   * @param {number} detour.latitude - Latitude (-90..90).
+   * @param {number} detour.longitude - Longitude (-180..180).
+   * @param {string} [detour.placeId] - Google Places ID.
+   * @param {string} [detour.placeType] - e.g. restaurant, park.
+   * @param {string} [detour.address] - Formatted address.
+   * @param {number} [detour.positionOnRoute] - Normalized 0.0-1.0.
+   * @param {number} [detour.estimatedDetourDurationSeconds]
+   * @param {number} [detour.estimatedDetourDistanceMeters]
+   * @param {number} [detour.rating] - Google rating 0.0-5.0.
+   * @param {number} [detour.priceLevel] - 1-4.
+   * @param {number} [detour.stopDurationMinutes] - Defaults to 30.
+   * @param {string|Date} [detour.visitTime]
+   * @param {string} [detour.notes]
+   * @param {object} [detour.metadata] - Arbitrary JSON blob.
+   * @returns {Promise<object|null>} The created detour row, or null if the trip
+   *   was not found / not owned by the user.
+   */
+  async createDetour({
+    tripId,
+    userId,
+    placeName,
+    latitude,
+    longitude,
+    placeId = null,
+    placeType = null,
+    address = null,
+    positionOnRoute = null,
+    estimatedDetourDurationSeconds = null,
+    estimatedDetourDistanceMeters = null,
+    rating = null,
+    priceLevel = null,
+    stopDurationMinutes = 30,
+    visitTime = null,
+    notes = null,
+    metadata = {},
+  }) {
+    // INSERT ... SELECT ... WHERE EXISTS enforces trip ownership atomically:
+    // no row is inserted unless the parent trip belongs to the user.
+    const text = `
+      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude,
+                           longitude, address, position_on_route,
+                           estimated_detour_duration_seconds,
+                           estimated_detour_distance_meters, rating, price_level,
+                           stop_duration_minutes, visit_time, notes, metadata)
+      SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+      WHERE EXISTS (
+        SELECT 1 FROM trips WHERE trip_id = $1 AND user_id = $17
+      )
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+    const params = [
+      tripId,
+      placeId,
+      placeName,
+      placeType,
+      latitude,
+      longitude,
+      address,
+      positionOnRoute,
+      estimatedDetourDurationSeconds,
+      estimatedDetourDistanceMeters,
+      rating,
+      priceLevel,
+      stopDurationMinutes,
+      visitTime,
+      notes,
+      metadata,
+      userId,
+    ];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("createDetour failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a single detour, scoped to the owning user via its parent trip.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The detour row, or null if not found / not owned.
+   */
+  async getDetourById(detourId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS_PREFIXED}
+      FROM detours d
+      JOIN trips t ON d.trip_id = t.trip_id
+      WHERE d.detour_id = $1 AND t.user_id = $2
+    `;
+    try {
+      const result = await this.pool.query(text, [detourId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getDetourById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * List all detours on a trip, ordered by position along the route. Scoped to
+   * the owning user via the parent trip, so passing a trip the user does not own
+   * returns an empty array.
+   *
+   * @param {string} tripId - Parent trip UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object[]>} Array of detour rows (empty if none / not owned).
+   */
+  async getDetoursByTripId(tripId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS_PREFIXED}
+      FROM detours d
+      JOIN trips t ON d.trip_id = t.trip_id
+      WHERE d.trip_id = $1 AND t.user_id = $2
+      ORDER BY d.position_on_route ASC NULLS LAST
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows;
+    } catch (err) {
+      logger.error("getDetoursByTripId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a detour's columns. `updated_at` is maintained
+   * by a database trigger. Scoped by user_id via the parent trip so a user
+   * cannot modify detours on another user's trips.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} fields - Any of the updatable detour columns.
+   * @returns {Promise<object|null>} The updated detour row, or null if not found / not owned.
+   * @throws {Error} If no valid fields are supplied.
+   */
+  async updateDetour(detourId, userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateDetour requires at least one updatable field");
+    }
+
+    params.push(detourId);
+    const detourPosition = position;
+    position += 1;
+    params.push(userId);
+    const text = `
+      UPDATE detours
+      SET ${setClauses.join(", ")}
+      WHERE detour_id = $${detourPosition}
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $${position})
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("updateDetour failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a detour. Scoped by user_id via the parent trip.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The deleted detour's id, or null if not found / not owned.
+   */
+  async deleteDetour(detourId, userId) {
+    const text = `
+      DELETE FROM detours
+      WHERE detour_id = $1
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)
+      RETURNING detour_id
+    `;
+    try {
+      const result = await this.pool.query(text, [detourId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteDetour failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = DetourRepository;

--- a/backend/app/repositories/DetourRepository.test.js
+++ b/backend/app/repositories/DetourRepository.test.js
@@ -1,0 +1,295 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const DetourRepository = require("./DetourRepository");
+
+describe("DetourRepository", () => {
+  let pool;
+  let repo;
+
+  const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const TRIP_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  const DETOUR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new DetourRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new DetourRepository()).toThrow(
+        "DetourRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new DetourRepository({})).toThrow(
+        "DetourRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createDetour", () => {
+    it("inserts only when the parent trip is owned, with parameterized values", async () => {
+      const newDetour = { detour_id: DETOUR_ID, trip_id: TRIP_ID };
+      pool.query.mockResolvedValue({ rows: [newDetour] });
+
+      const result = await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: USER_ID,
+        placeName: "Yosemite Falls",
+        latitude: 37.7455,
+        longitude: -119.5967,
+        placeId: "gp1",
+        placeType: "park",
+        address: "Yosemite Valley, CA",
+        positionOnRoute: 0.85,
+        estimatedDetourDurationSeconds: 300,
+        estimatedDetourDistanceMeters: 500,
+        rating: 4.8,
+        priceLevel: 2,
+        stopDurationMinutes: 120,
+        visitTime: "2026-07-04T12:00:00Z",
+        notes: "Bring water",
+        metadata: { source: "test" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO detours");
+      // Ownership enforced atomically via EXISTS against trips.
+      expect(sql).toContain("WHERE EXISTS");
+      expect(sql).toContain("FROM trips WHERE trip_id = $1 AND user_id = $17");
+      expect(params).toEqual([
+        TRIP_ID,
+        "gp1",
+        "Yosemite Falls",
+        "park",
+        37.7455,
+        -119.5967,
+        "Yosemite Valley, CA",
+        0.85,
+        300,
+        500,
+        4.8,
+        2,
+        120,
+        "2026-07-04T12:00:00Z",
+        "Bring water",
+        { source: "test" },
+        USER_ID,
+      ]);
+      expect(result).toBe(newDetour);
+    });
+
+    it("applies defaults for optional fields", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: USER_ID,
+        placeName: "Rest Stop",
+        latitude: 40,
+        longitude: -100,
+      });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual([
+        TRIP_ID,
+        null, // placeId
+        "Rest Stop",
+        null, // placeType
+        40,
+        -100,
+        null, // address
+        null, // positionOnRoute
+        null, // estimatedDetourDurationSeconds
+        null, // estimatedDetourDistanceMeters
+        null, // rating
+        null, // priceLevel
+        30, // stopDurationMinutes default
+        null, // visitTime
+        null, // notes
+        {}, // metadata default
+        USER_ID,
+      ]);
+    });
+
+    it("returns null when the trip is not found or not owned", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: "not-the-owner",
+        placeName: "X",
+        latitude: 1,
+        longitude: 2,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createDetour({
+          tripId: TRIP_ID,
+          userId: USER_ID,
+          placeName: "X",
+          latitude: 1,
+          longitude: 2,
+        })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getDetourById", () => {
+    it("joins trips and scopes by detour_id and user_id", async () => {
+      const detour = { detour_id: DETOUR_ID };
+      pool.query.mockResolvedValue({ rows: [detour] });
+
+      const result = await repo.getDetourById(DETOUR_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("JOIN trips t ON d.trip_id = t.trip_id");
+      expect(sql).toContain("WHERE d.detour_id = $1 AND t.user_id = $2");
+      expect(params).toEqual([DETOUR_ID, USER_ID]);
+      expect(result).toBe(detour);
+    });
+
+    it("returns null when no detour is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getDetourById("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getDetourById(DETOUR_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("getDetoursByTripId", () => {
+    it("joins trips, scopes by trip_id and user_id, ordered by position", async () => {
+      const detours = [{ detour_id: DETOUR_ID }];
+      pool.query.mockResolvedValue({ rows: detours });
+
+      const result = await repo.getDetoursByTripId(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("JOIN trips t ON d.trip_id = t.trip_id");
+      expect(sql).toContain("WHERE d.trip_id = $1 AND t.user_id = $2");
+      expect(sql).toContain("ORDER BY d.position_on_route ASC NULLS LAST");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(detours);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getDetoursByTripId(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("updateDetour", () => {
+    it("builds a dynamic SET clause scoped via the parent trip", async () => {
+      const updated = { detour_id: DETOUR_ID, notes: "Updated" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "Updated",
+        stopDurationMinutes: 45,
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("UPDATE detours");
+      // SET columns follow the allow-list declaration order, not input order:
+      // stopDurationMinutes precedes notes in UPDATABLE_COLUMNS.
+      expect(sql).toContain("stop_duration_minutes = $1");
+      expect(sql).toContain("notes = $2");
+      expect(sql).toContain("WHERE detour_id = $3");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $4)"
+      );
+      expect(params).toEqual([45, "Updated", DETOUR_ID, USER_ID]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores fields that are not in the allow-list", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "OK",
+        detour_id: "hacked",
+        trip_id: "hacked",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("notes = $1");
+      expect(params).toEqual(["OK", DETOUR_ID, USER_ID]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateDetour(DETOUR_ID, USER_ID, {})).rejects.toThrow(
+        "updateDetour requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no detour is updated", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      const result = await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "X",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(
+        repo.updateDetour(DETOUR_ID, USER_ID, { notes: "X" })
+      ).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("deleteDetour", () => {
+    it("deletes a detour scoped via the parent trip", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      const result = await repo.deleteDetour(DETOUR_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM detours");
+      expect(sql).toContain("WHERE detour_id = $1");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)"
+      );
+      expect(params).toEqual([DETOUR_ID, USER_ID]);
+      expect(result).toEqual({ detour_id: DETOUR_ID });
+    });
+
+    it("returns null when no detour is deleted", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteDetour("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteDetour(DETOUR_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+});

--- a/backend/app/repositories/TripRepository.js
+++ b/backend/app/repositories/TripRepository.js
@@ -1,0 +1,240 @@
+/**
+ * TripRepository — data access layer for the `trips` table.
+ *
+ * Encapsulates all SQL for trip records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * Every operation is scoped by `user_id` — the authorization boundary. A user
+ * can only read or modify their own trips. All queries use parameterized
+ * placeholders ($1, $2, ...) — prepared statements that prevent SQL injection.
+ */
+
+const logger = require("../utils/logger");
+
+// PostgreSQL error code for a foreign-key-constraint violation.
+const PG_FK_VIOLATION = "23503";
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  tripName: "trip_name",
+  origin: "origin",
+  destination: "destination",
+  routePolyline: "route_polyline",
+  distanceMeters: "distance_meters",
+  durationSeconds: "duration_seconds",
+  departureTime: "departure_time",
+  status: "status",
+  metadata: "metadata",
+};
+
+// Columns returned to callers. Shared by every query that returns a full row.
+const RETURNING_COLUMNS = `
+      trip_id, user_id, trip_name, origin, destination, route_polyline,
+      distance_meters, duration_seconds, departure_time, status,
+      created_at, updated_at, metadata
+`;
+
+class TripRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "TripRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a new trip for a user.
+   *
+   * @param {object} trip
+   * @param {string} trip.userId - Owning user's UUID.
+   * @param {string} trip.tripName - Human-readable trip name.
+   * @param {object} trip.origin - JSON { lat, lng, address }.
+   * @param {object} trip.destination - JSON { lat, lng, address }.
+   * @param {string} [trip.routePolyline] - Google encoded polyline.
+   * @param {number} [trip.distanceMeters] - Cached distance.
+   * @param {number} [trip.durationSeconds] - Cached duration.
+   * @param {string|Date} [trip.departureTime] - Planned departure.
+   * @param {string} [trip.status] - One of planned|active|completed|cancelled.
+   * @param {object} [trip.metadata] - Arbitrary JSON blob.
+   * @returns {Promise<object>} The created trip row.
+   * @throws {Error} `INVALID_USER` if the user_id does not reference a user.
+   */
+  async createTrip({
+    userId,
+    tripName,
+    origin,
+    destination,
+    routePolyline = null,
+    distanceMeters = null,
+    durationSeconds = null,
+    departureTime = null,
+    status = "planned",
+    metadata = {},
+  }) {
+    const text = `
+      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline,
+                         distance_meters, duration_seconds, departure_time, status, metadata)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+    const params = [
+      userId,
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      departureTime,
+      status,
+      metadata,
+    ];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0];
+    } catch (err) {
+      if (err.code === PG_FK_VIOLATION) {
+        logger.warn(`createTrip: invalid user_id (${err.constraint || "fk"})`);
+        const fkErr = new Error("The specified user does not exist");
+        fkErr.code = "INVALID_USER";
+        throw fkErr;
+      }
+      logger.error("createTrip failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a single trip owned by the given user.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The trip row, or null if not found / not owned.
+   */
+  async getTripById(tripId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE trip_id = $1 AND user_id = $2
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getTripById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * List a user's trips, newest first. Optionally filter by status.
+   *
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} [options]
+   * @param {string} [options.status] - Filter to a single status value.
+   * @returns {Promise<object[]>} Array of trip rows (empty if none).
+   */
+  async getTripsByUserId(userId, { status } = {}) {
+    const params = [userId];
+    let text = `
+      SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE user_id = $1
+    `;
+    if (status !== undefined) {
+      params.push(status);
+      text += ` AND status = $2`;
+    }
+    text += ` ORDER BY created_at DESC`;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows;
+    } catch (err) {
+      logger.error("getTripsByUserId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a trip's columns. `updated_at` is maintained by
+   * a database trigger. Scoped by user_id so a user cannot modify another user's
+   * trips.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} fields - Any of the updatable trip columns.
+   * @returns {Promise<object|null>} The updated trip row, or null if not found / not owned.
+   * @throws {Error} If no valid fields are supplied.
+   */
+  async updateTrip(tripId, userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateTrip requires at least one updatable field");
+    }
+
+    params.push(tripId);
+    const tripPosition = position;
+    position += 1;
+    params.push(userId);
+    const text = `
+      UPDATE trips
+      SET ${setClauses.join(", ")}
+      WHERE trip_id = $${tripPosition} AND user_id = $${position}
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("updateTrip failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a trip. Cascades to the trip's detours via
+   * ON DELETE CASCADE. Scoped by user_id. To "cancel" a trip without deleting
+   * it, use updateTrip with status = 'cancelled'.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The deleted trip's id, or null if not found / not owned.
+   */
+  async deleteTrip(tripId, userId) {
+    const text = `
+      DELETE FROM trips
+      WHERE trip_id = $1 AND user_id = $2
+      RETURNING trip_id
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteTrip failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = TripRepository;

--- a/backend/app/repositories/TripRepository.test.js
+++ b/backend/app/repositories/TripRepository.test.js
@@ -1,0 +1,273 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const TripRepository = require("./TripRepository");
+
+describe("TripRepository", () => {
+  let pool;
+  let repo;
+
+  const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const TRIP_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new TripRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new TripRepository()).toThrow(
+        "TripRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new TripRepository({})).toThrow(
+        "TripRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createTrip", () => {
+    it("inserts a trip with parameterized values and returns the row", async () => {
+      const newTrip = { trip_id: TRIP_ID, user_id: USER_ID };
+      pool.query.mockResolvedValue({ rows: [newTrip] });
+
+      const origin = { lat: 1, lng: 2, address: "A" };
+      const destination = { lat: 3, lng: 4, address: "B" };
+      const result = await repo.createTrip({
+        userId: USER_ID,
+        tripName: "Road Trip",
+        origin,
+        destination,
+        routePolyline: "poly",
+        distanceMeters: 1000,
+        durationSeconds: 600,
+        departureTime: "2026-07-04T00:00:00Z",
+        status: "active",
+        metadata: { source: "test" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO trips");
+      expect(sql).toContain("$1, $2, $3, $4, $5, $6, $7, $8, $9, $10");
+      expect(params).toEqual([
+        USER_ID,
+        "Road Trip",
+        origin,
+        destination,
+        "poly",
+        1000,
+        600,
+        "2026-07-04T00:00:00Z",
+        "active",
+        { source: "test" },
+      ]);
+      expect(result).toBe(newTrip);
+    });
+
+    it("applies defaults for optional fields", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      await repo.createTrip({
+        userId: USER_ID,
+        tripName: "Minimal",
+        origin: { lat: 1, lng: 2 },
+        destination: { lat: 3, lng: 4 },
+      });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual([
+        USER_ID,
+        "Minimal",
+        { lat: 1, lng: 2 },
+        { lat: 3, lng: 4 },
+        null,
+        null,
+        null,
+        null,
+        "planned",
+        {},
+      ]);
+    });
+
+    it("maps a foreign-key violation to an INVALID_USER error", async () => {
+      const pgError = new Error("insert or update violates foreign key");
+      pgError.code = "23503";
+      pgError.constraint = "trips_user_id_fkey";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.createTrip({
+          userId: "missing",
+          tripName: "X",
+          origin: {},
+          destination: {},
+        })
+      ).rejects.toMatchObject({ code: "INVALID_USER" });
+    });
+
+    it("rethrows non-foreign-key database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createTrip({
+          userId: USER_ID,
+          tripName: "X",
+          origin: {},
+          destination: {},
+        })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getTripById", () => {
+    it("selects a trip scoped by trip_id and user_id", async () => {
+      const trip = { trip_id: TRIP_ID, user_id: USER_ID };
+      pool.query.mockResolvedValue({ rows: [trip] });
+
+      const result = await repo.getTripById(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE trip_id = $1 AND user_id = $2");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(trip);
+    });
+
+    it("returns null when no trip is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getTripById("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getTripById(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("getTripsByUserId", () => {
+    it("selects all of a user's trips newest first", async () => {
+      const trips = [{ trip_id: TRIP_ID }];
+      pool.query.mockResolvedValue({ rows: trips });
+
+      const result = await repo.getTripsByUserId(USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(sql).toContain("ORDER BY created_at DESC");
+      expect(sql).not.toContain("status = $2");
+      expect(params).toEqual([USER_ID]);
+      expect(result).toBe(trips);
+    });
+
+    it("adds a status filter when provided", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, { status: "completed" });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(params).toEqual([USER_ID, "completed"]);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getTripsByUserId(USER_ID)).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("updateTrip", () => {
+    it("builds a dynamic SET clause scoped by trip_id and user_id", async () => {
+      const updated = { trip_id: TRIP_ID, trip_name: "Renamed" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "Renamed",
+        status: "completed",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("UPDATE trips");
+      expect(sql).toContain("trip_name = $1");
+      expect(sql).toContain("status = $2");
+      expect(sql).toContain("WHERE trip_id = $3 AND user_id = $4");
+      expect(params).toEqual(["Renamed", "completed", TRIP_ID, USER_ID]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores fields that are not in the allow-list", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "OK",
+        trip_id: "hacked",
+        userId: "hacked",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("trip_name = $1");
+      // Only the allow-listed field, plus the trip_id and user_id scope.
+      expect(params).toEqual(["OK", TRIP_ID, USER_ID]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateTrip(TRIP_ID, USER_ID, {})).rejects.toThrow(
+        "updateTrip requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no trip is updated", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      const result = await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "X",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(
+        repo.updateTrip(TRIP_ID, USER_ID, { tripName: "X" })
+      ).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("deleteTrip", () => {
+    it("deletes a trip scoped by trip_id and user_id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      const result = await repo.deleteTrip(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM trips");
+      expect(sql).toContain("WHERE trip_id = $1 AND user_id = $2");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toEqual({ trip_id: TRIP_ID });
+    });
+
+    it("returns null when no trip is deleted", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteTrip("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteTrip(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+});

--- a/backend/app/repositories/UserRepository.js
+++ b/backend/app/repositories/UserRepository.js
@@ -1,0 +1,248 @@
+/**
+ * UserRepository — data access layer for the `users` table.
+ *
+ * Encapsulates all SQL for user records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * All queries use parameterized placeholders ($1, $2, ...) — prepared statements
+ * that prevent SQL injection. There is no password column; identity is keyed off
+ * the Entra `external_id` (the token `sub` claim). See
+ * ../../../docs/authentication/authentication.md.
+ */
+
+const logger = require("../utils/logger");
+
+// PostgreSQL error code for a unique-constraint violation.
+const PG_UNIQUE_VIOLATION = "23505";
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  email: "email",
+  displayName: "display_name",
+  preferences: "preferences",
+  isActive: "is_active",
+  lastLogin: "last_login",
+};
+
+class UserRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "UserRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a new user.
+   *
+   * @param {object} user
+   * @param {string} user.externalId - Entra `sub` claim (unique).
+   * @param {string} user.email - User email (unique).
+   * @param {string} [user.displayName] - Display name.
+   * @param {object} [user.preferences] - JSON preferences blob.
+   * @returns {Promise<object>} The created user row.
+   * @throws {Error} `DUPLICATE_USER` if external_id or email already exists.
+   */
+  async createUser({
+    externalId,
+    email,
+    displayName = null,
+    preferences = {},
+  }) {
+    const text = `
+      INSERT INTO users (external_id, email, display_name, preferences)
+      VALUES ($1, $2, $3, $4)
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
+    `;
+    const params = [externalId, email, displayName, preferences];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0];
+    } catch (err) {
+      if (err.code === PG_UNIQUE_VIOLATION) {
+        logger.warn(
+          `createUser: duplicate user (${err.constraint || "unique"})`
+        );
+        const dupErr = new Error(
+          "A user with that email or external ID already exists"
+        );
+        dupErr.code = "DUPLICATE_USER";
+        throw dupErr;
+      }
+      logger.error("createUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch an active user by primary key.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserById(userId) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE user_id = $1 AND is_active = true
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch an active user by email.
+   *
+   * @param {string} email
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserByEmail(email) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE email = $1 AND is_active = true
+    `;
+    try {
+      const result = await this.pool.query(text, [email]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserByEmail failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a user by Entra external ID (the token `sub` claim).
+   *
+   * @param {string} externalId
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserByExternalId(externalId) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE external_id = $1
+    `;
+    try {
+      const result = await this.pool.query(text, [externalId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserByExternalId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a user's columns. `updated_at` is maintained by
+   * a database trigger.
+   *
+   * @param {string} userId - UUID.
+   * @param {object} fields - Any of: email, displayName, preferences, isActive, lastLogin.
+   * @returns {Promise<object|null>} The updated user row, or null if not found.
+   * @throws {Error} If no valid fields are supplied, or `DUPLICATE_USER` on email clash.
+   */
+  async updateUser(userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateUser requires at least one updatable field");
+    }
+
+    params.push(userId);
+    const text = `
+      UPDATE users
+      SET ${setClauses.join(", ")}
+      WHERE user_id = $${position} AND is_active = true
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      if (err.code === PG_UNIQUE_VIOLATION) {
+        logger.warn("updateUser: duplicate email");
+        const dupErr = new Error("A user with that email already exists");
+        dupErr.code = "DUPLICATE_USER";
+        throw dupErr;
+      }
+      logger.error("updateUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Soft-delete a user by marking the account inactive. Preserves the row (and
+   * its trips/detours) for audit and potential reactivation.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The deactivated user row, or null if not found.
+   */
+  async deleteUser(userId) {
+    const text = `
+      UPDATE users
+      SET is_active = false
+      WHERE user_id = $1 AND is_active = true
+      RETURNING user_id, external_id, email, is_active
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a user row. Cascades to the user's trips and detours via
+   * ON DELETE CASCADE. Use for GDPR account erasure, not routine deletes.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The deleted user's id, or null if not found.
+   */
+  async hardDeleteUser(userId) {
+    const text = `
+      DELETE FROM users
+      WHERE user_id = $1
+      RETURNING user_id
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("hardDeleteUser failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = UserRepository;

--- a/backend/app/repositories/UserRepository.test.js
+++ b/backend/app/repositories/UserRepository.test.js
@@ -1,0 +1,262 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const UserRepository = require("./UserRepository");
+
+describe("UserRepository", () => {
+  let pool;
+  let repo;
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new UserRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new UserRepository()).toThrow(
+        "UserRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new UserRepository({})).toThrow(
+        "UserRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createUser", () => {
+    it("inserts a user with parameterized values and returns the row", async () => {
+      const newUser = {
+        user_id: "11111111-1111-1111-1111-111111111111",
+        external_id: "entra-sub-1",
+        email: "alice@example.com",
+        display_name: "Alice",
+        preferences: {},
+      };
+      pool.query.mockResolvedValue({ rows: [newUser] });
+
+      const result = await repo.createUser({
+        externalId: "entra-sub-1",
+        email: "alice@example.com",
+        displayName: "Alice",
+        preferences: { theme: "dark" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO users");
+      expect(sql).toContain("$1, $2, $3, $4");
+      expect(params).toEqual([
+        "entra-sub-1",
+        "alice@example.com",
+        "Alice",
+        { theme: "dark" },
+      ]);
+      expect(result).toBe(newUser);
+    });
+
+    it("defaults displayName to null and preferences to an empty object", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      await repo.createUser({ externalId: "x", email: "b@example.com" });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual(["x", "b@example.com", null, {}]);
+    });
+
+    it("maps a unique-violation to a DUPLICATE_USER error", async () => {
+      const pgError = new Error("duplicate key value");
+      pgError.code = "23505";
+      pgError.constraint = "users_email_key";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.createUser({ externalId: "x", email: "dup@example.com" })
+      ).rejects.toMatchObject({ code: "DUPLICATE_USER" });
+    });
+
+    it("rethrows non-unique database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createUser({ externalId: "x", email: "c@example.com" })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getUserById", () => {
+    it("selects an active user by id and returns the row", async () => {
+      const user = { user_id: "u1", email: "a@example.com" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserById("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE user_id = $1 AND is_active = true");
+      expect(params).toEqual(["u1"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserById("missing")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getUserById("u1")).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("getUserByEmail", () => {
+    it("selects an active user by email", async () => {
+      const user = { user_id: "u1", email: "a@example.com" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserByEmail("a@example.com");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE email = $1 AND is_active = true");
+      expect(params).toEqual(["a@example.com"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserByEmail("nope@example.com")).toBeNull();
+    });
+  });
+
+  describe("getUserByExternalId", () => {
+    it("selects a user by external_id (no active filter)", async () => {
+      const user = { user_id: "u1", external_id: "entra-sub-1" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserByExternalId("entra-sub-1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE external_id = $1");
+      expect(params).toEqual(["entra-sub-1"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserByExternalId("missing")).toBeNull();
+    });
+  });
+
+  describe("updateUser", () => {
+    it("builds a parameterized SET clause for provided fields only", async () => {
+      const updated = { user_id: "u1", display_name: "New Name" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateUser("u1", {
+        displayName: "New Name",
+        preferences: { theme: "light" },
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("display_name = $1");
+      expect(sql).toContain("preferences = $2");
+      expect(sql).toContain("WHERE user_id = $3 AND is_active = true");
+      expect(params).toEqual(["New Name", { theme: "light" }, "u1"]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores unknown fields and only updates allowed columns", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      await repo.updateUser("u1", {
+        email: "new@example.com",
+        hacker: "DROP TABLE",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("email = $1");
+      expect(sql).not.toContain("hacker");
+      expect(params).toEqual(["new@example.com", "u1"]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateUser("u1", {})).rejects.toThrow(
+        "updateUser requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the user does not exist", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.updateUser("missing", { displayName: "X" })).toBeNull();
+    });
+
+    it("maps a unique-violation to a DUPLICATE_USER error", async () => {
+      const pgError = new Error("duplicate key value");
+      pgError.code = "23505";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.updateUser("u1", { email: "taken@example.com" })
+      ).rejects.toMatchObject({ code: "DUPLICATE_USER" });
+    });
+  });
+
+  describe("deleteUser (soft delete)", () => {
+    it("sets is_active = false and returns the row", async () => {
+      const row = { user_id: "u1", is_active: false };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await repo.deleteUser("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("SET is_active = false");
+      expect(sql).toContain("WHERE user_id = $1 AND is_active = true");
+      expect(params).toEqual(["u1"]);
+      expect(result).toBe(row);
+    });
+
+    it("returns null when the user is already inactive or missing", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteUser("u1")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB error"));
+      await expect(repo.deleteUser("u1")).rejects.toThrow("DB error");
+    });
+  });
+
+  describe("hardDeleteUser", () => {
+    it("deletes the row and returns its id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      const result = await repo.hardDeleteUser("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM users");
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(params).toEqual(["u1"]);
+      expect(result).toEqual({ user_id: "u1" });
+    });
+
+    it("returns null when the user does not exist", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.hardDeleteUser("missing")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("FK violation"));
+      await expect(repo.hardDeleteUser("u1")).rejects.toThrow("FK violation");
+    });
+  });
+});

--- a/backend/app/utils/logger.js
+++ b/backend/app/utils/logger.js
@@ -1,0 +1,30 @@
+/**
+ * Minimal leveled logger for the backend.
+ *
+ * Wraps the console with timestamped, level-prefixed output so application code
+ * has a single place to send logs (and a single place to later swap in a real
+ * logging library such as winston or pino). Levels: info, warn, error.
+ */
+
+/**
+ * Format a log line with an ISO timestamp and uppercase level prefix.
+ *
+ * @param {string} level - Log level label.
+ * @param {string} message - Human-readable message.
+ * @returns {string} The formatted prefix + message.
+ */
+function format(level, message) {
+  return `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}`;
+}
+
+module.exports = {
+  info: function (message, ...meta) {
+    console.log(format("info", message), ...meta);
+  },
+  warn: function (message, ...meta) {
+    console.warn(format("warn", message), ...meta);
+  },
+  error: function (message, ...meta) {
+    console.error(format("error", message), ...meta);
+  },
+};

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,5 +1,12 @@
 var config = {
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  db: {
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT || 5432,
+    name: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+  },
 };
 
 module.exports = config;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "capstone-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capstone-backend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
+        "dotenv": "16.4.7",
         "express": "5.1.0",
         "express-session": "1.18.2",
         "https": "1.0.0",
+        "pg": "8.13.1",
         "polyline-encoded": "0.0.9"
       },
       "devDependencies": {
@@ -2874,6 +2876,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -6611,6 +6625,95 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
+      "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6725,6 +6828,45 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -7502,6 +7644,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8471,6 +8622,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,10 @@
     "format": "prettier --write \"**/*.{js,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,json,md}\""
   },
+  "lint-staged": {
+    "**/*.{js,json,md}": "prettier --write",
+    "**/*.js": "eslint --fix"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -21,9 +25,11 @@
     "body-parser": "2.2.0",
     "cookie-parser": "1.4.7",
     "cors": "2.8.5",
+    "dotenv": "16.4.7",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "https": "1.0.0",
+    "pg": "8.13.1",
     "polyline-encoded": "0.0.9"
   },
   "devDependencies": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,96 @@
+# JauntDetour Documentation
+
+Technical documentation for the JauntDetour road trip planning application.
+
+JauntDetour uses the Google Maps APIs to build routes and find detours along them. The backend persists user accounts and their saved trips and detours so users can save and load their plans.
+
+---
+
+## Architecture Decisions
+
+| Area | Decision |
+|------|----------|
+| **Database** | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS |
+| **Authentication** | Microsoft Entra External ID (email/password + social login) |
+
+---
+
+## 📁 database/
+
+Persistence for users, trips, and detours.
+
+1. **[Selection](database/selection.md)** — recommendation and rationale (why PostgreSQL, options considered, data model, query patterns, backup/DR, cost summary).
+2. **[Schema](database/schema.sql)** — PostgreSQL schema: `users`, `trips`, `detours`. UUID keys, JSONB for Google payloads, plain `DECIMAL` lat/lng, B-tree indexes, timestamp triggers. **No PostGIS.**
+3. **[Cost Comparison](database/cost-comparison.md)** — free-tier and production pricing, 3-year TCO, optimization tips.
+4. **[Implementation Guide](database/implementation-guide.md)** — provisioning, schema deployment, and Node.js integration.
+
+## 📁 authentication/
+
+Managed identity for end users.
+
+1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, user experience, how tokens map to the `users` table, setup overview, security essentials).
+2. **[Implementation Guide](authentication/implementation-guide.md)** — Node.js login/callback flow, token verification, and per-user route scoping.
+
+---
+
+## Key Findings
+
+### Database — Azure Database for PostgreSQL
+- **Right fit:** Google APIs handle all geospatial work, so the data model is plainly relational (`users → trips → detours`) with JSONB for API responses — no spatial extension needed.
+- **Cost-effective:** lowest 3-year TCO of all options (~$5,484 vs ~$21,624 for Cosmos DB). Free for the first 12 months (B1ms, 32 GB).
+- **Future-ready:** `pgvector` + the `azure_ai` extension add semantic search in-place if the AI agent needs it later — no second datastore.
+
+### Authentication — Microsoft Entra External ID
+- **Managed and secure:** Microsoft hosts sign-up/sign-in and handles password storage, MFA, lockout, and reset. We never store credentials.
+- **Flexible login:** email/password **and** Google (plus Apple/Facebook/Microsoft) in one hosted, brandable flow.
+- **Clean DB tie-in:** the token's `sub` claim is stored as `users.external_id` — no `password_hash`. The resolved `user_id` is the authorization boundary for both the API and a future Foundry agent tool.
+
+---
+
+## Data Model
+
+```
+┌──────────────┐
+│    Users     │
+│ - user_id    │──┐
+│ - external_id│  │   (Entra "sub" claim — no password stored)
+│ - email      │  │
+└──────────────┘  │ 1:N
+                  ▼
+┌───────────────────────┐
+│        Trips          │
+│ - trip_id             │──┐
+│ - user_id (FK)        │  │
+│ - origin (JSONB)      │  │
+│ - destination (JSONB) │  │
+│ - route_polyline      │  │
+└───────────────────────┘  │ 1:N
+                           ▼
+┌──────────────────────────────┐
+│         Detours              │
+│ - detour_id                  │
+│ - trip_id (FK)               │
+│ - place_name                 │
+│ - latitude / longitude       │   (plain DECIMAL — no spatial index)
+│ - rating                     │
+└──────────────────────────────┘
+```
+
+---
+
+## Document Status
+
+| Document | Status | Last Updated |
+|----------|--------|--------------|
+| database/selection.md | ✅ | Jun 2, 2026 |
+| database/schema.sql | ✅ | Jun 2, 2026 |
+| database/cost-comparison.md | ✅ | Jun 2, 2026 |
+| database/implementation-guide.md | ✅ | Jun 2, 2026 |
+| authentication/authentication.md | ✅ | Jun 2, 2026 |
+| authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
+
+---
+
+**Document Version:** 2.0
+**Last Updated:** June 2, 2026
+**Maintained by:** JauntDetour Development Team

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,11 @@ Persistence for users, trips, and detours.
 
 Managed identity for end users.
 
-1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, user experience, how tokens map to the `users` table, setup overview, security essentials).
+1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, options compared, cost, user experience, how tokens map to the `users` table, setup overview).
 2. **[Implementation Guide](authentication/implementation-guide.md)** — Node.js login/callback flow, token verification, and per-user route scoping.
+3. **[Security](authentication/security.md)** — token storage, validation, CSRF, CORS, rate limiting, MFA, secrets, logging.
+4. **[Session Management](authentication/session-management.md)** — token lifetimes, logout/revocation, timeouts (lean IdP-managed default, optional Redis store).
+5. **[Compliance](authentication/compliance.md)** — GDPR data-subject rights, retention, cookie policy, data residency.
 
 ---
 
@@ -88,6 +91,9 @@ Managed identity for end users.
 | database/implementation-guide.md | ✅ | Jun 2, 2026 |
 | authentication/authentication.md | ✅ | Jun 2, 2026 |
 | authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
+| authentication/security.md | ✅ | Jun 2, 2026 |
+| authentication/session-management.md | ✅ | Jun 2, 2026 |
+| authentication/compliance.md | ✅ | Jun 2, 2026 |
 
 ---
 

--- a/docs/authentication/authentication.md
+++ b/docs/authentication/authentication.md
@@ -12,6 +12,8 @@ Use **Microsoft Entra External ID** as the managed identity provider for JauntDe
 
 We do **not** build our own password authentication, and we do **not** store credentials in our database.
 
+> **Note on naming:** Microsoft Entra External ID is the **successor to Azure AD B2C**. Microsoft stopped onboarding new B2C tenants (May 2025) and B2C is on a retirement path, so new builds use External ID. Earlier spike material that says "Azure AD B2C" refers to the same Azure CIAM platform — the recommendation is unchanged, only the product name and tenant URLs (`*.ciamlogin.com`, not `*.b2clogin.com`).
+
 > Verified against Microsoft Learn (External ID supported features and Google federation, docs updated March 2026).
 
 ---
@@ -26,6 +28,38 @@ Rolling our own username/password auth means owning hashing/salting, reset flows
 | Auth0 / Clerk | Excellent DX and free tiers; viable, but adds a separate vendor outside Azure. |
 | Social OAuth directly (e.g. Google only) | Simple if we only ever want Google; we own more plumbing and no local accounts. |
 | Roll your own password auth | Avoid — high security burden, easy to get wrong. |
+
+### Detailed comparison
+
+| Capability | **Entra External ID** ✅ | Auth0 | Firebase Auth | Custom JWT |
+|------------|:---:|:---:|:---:|:---:|
+| Azure-native | ✅ | ❌ 3rd-party | ❌ Google | ⚠️ self-hosted |
+| Email/password + social in one flow | ✅ | ✅ | ✅ | ❌ build |
+| MFA built in | ✅ | ✅ | ⚠️ limited | ❌ build |
+| GDPR tooling (DPA, residency) | ✅ | ✅ | ⚠️ config | ❌ build |
+| Cost at 50K MAU | ✅ free | ❌ paid | ✅ free | ⚠️ dev/maint |
+| Build effort | ⚠️ moderate | ✅ fast | ✅ fast | ❌ weeks |
+| Maintenance burden | ✅ minimal | ✅ minimal | ✅ minimal | ❌ high |
+
+Firebase is ruled out by the Azure-first preference; Auth0 is a viable non-Azure fallback; custom auth is rejected on security and maintenance grounds.
+
+---
+
+## Cost
+
+External ID bills on **monthly active users (MAU)** — a user counts once no matter how many times they sign in. JauntDetour's expected volume sits comfortably in the free tier.
+
+| MAU | Indicative monthly cost |
+|-----|------------------------|
+| Up to 50,000 | **$0** (free tier) |
+| 50,001 – 100,000 | low per-MAU tiered rate |
+| 100,000+ | progressively lower per-MAU rate |
+
+- The first **50,000 MAU are free**; MFA via the Authenticator app is included.
+- SMS-based MFA and some premium (P1/P2) features carry add-on charges.
+- Figures are **point-in-time** — confirm current rates on the [Azure pricing page](https://azure.microsoft.com/pricing/details/microsoft-entra-external-id/) before a budget decision.
+
+For comparison, Auth0 starts charging well before 50K MAU and a custom build costs roughly $19K+/year in development and maintenance — External ID is both the cheapest and the lowest-effort option.
 
 ---
 
@@ -103,6 +137,8 @@ These matter as much as authentication for a public app:
 - **TLS in transit** — Azure databases enforce SSL by default; keep it on.
 - **Network isolation** — DB behind a VNet/private endpoint in production.
 - **Restrict the Google Maps API key** — scope to specific APIs and referrers.
+
+See [security.md](security.md) for the full hardening detail (token storage, CSRF, CORS, rate limiting, MFA, logging), [session-management.md](session-management.md) for the session lifecycle, and [compliance.md](compliance.md) for GDPR/privacy.
 
 ---
 

--- a/docs/authentication/authentication.md
+++ b/docs/authentication/authentication.md
@@ -1,0 +1,111 @@
+# Authentication for JauntDetour
+
+**Status:** Decided
+**Decision:** Microsoft Entra External ID (customer/external tenant)
+**Last Updated:** June 2, 2026
+
+---
+
+## Decision
+
+Use **Microsoft Entra External ID** as the managed identity provider for JauntDetour's end users. It hosts sign-up and sign-in, supports **email + password local accounts** and **social login (Google, Apple, Facebook, Microsoft)** in the same flow, and handles password storage, hashing, MFA, smart lockout, banned-password checks, and password reset on our behalf.
+
+We do **not** build our own password authentication, and we do **not** store credentials in our database.
+
+> Verified against Microsoft Learn (External ID supported features and Google federation, docs updated March 2026).
+
+---
+
+## Why a managed provider
+
+Rolling our own username/password auth means owning hashing/salting, reset flows, MFA, brute-force protection, breach response, and session security — the most common source of security incidents. A managed provider removes that entire surface area. For a new consumer app, this is the strong default.
+
+| Option | Verdict |
+|--------|---------|
+| **Microsoft Entra External ID** ✅ | Azure-native, one ecosystem, email/password + social in one hosted flow. **Chosen.** |
+| Auth0 / Clerk | Excellent DX and free tiers; viable, but adds a separate vendor outside Azure. |
+| Social OAuth directly (e.g. Google only) | Simple if we only ever want Google; we own more plumbing and no local accounts. |
+| Roll your own password auth | Avoid — high security burden, easy to get wrong. |
+
+---
+
+## What users see
+
+A single hosted **user flow** can present local accounts and social providers together:
+
+```
+┌─────────────────────────────────────┐
+│         Sign in to JauntDetour      │
+│   Email    [____________________]   │
+│   Password [____________________]   │
+│                  [ Sign in ]        │
+│   ──────────  or  ──────────        │
+│   [  🔵  Continue with Google  ]    │
+│   No account?  Sign up              │
+└─────────────────────────────────────┘
+```
+
+The page is **hosted by Microsoft** on `*.ciamlogin.com`, brandable with our logo and colors. The app redirects users there using **OpenID Connect / authorization-code + PKCE**.
+
+---
+
+## How it connects to the database
+
+Whether a user signs in with a password or Google, the backend receives the **same kind of token (JWT)**. From the app's perspective the path is identical:
+
+1. Verify the token.
+2. Read the stable subject (`sub`) claim and email.
+3. Upsert the matching row in `users`, keyed by `external_id` (= the `sub`).
+
+This is why the schema stores **`external_id`, not `password_hash`** (see [../database/schema.sql](../database/schema.sql)). A Google user and an email/password user both become a `users` row identified by their token subject.
+
+### Authorization boundary
+
+Authentication proves *who* the user is; **authorization stays in our app/DB**. Every trip/detour query is scoped:
+
+```sql
+WHERE user_id = <id resolved from the verified token>
+```
+
+The same boundary protects both the REST API and a future Foundry agent tool — the agent calls a parameterized, `user_id`-scoped function, never raw data access.
+
+---
+
+## Setup overview
+
+One-time, in the Microsoft Entra admin center:
+
+1. Create an **external tenant**.
+2. Create a **sign-up and sign-in user flow** (generates the hosted login page).
+3. Enable identity providers:
+   - Email + password is available out of the box.
+   - For Google: create an OAuth client in Google Cloud Console, copy the **Client ID + secret** into Entra (*External Identities → All identity providers → Google*), then add Google to the user flow.
+4. Register the app and point it at the authority `https://<tenant-name>.ciamlogin.com/`.
+
+See [implementation-guide.md](implementation-guide.md) for the Node.js redirect and token-verification code.
+
+---
+
+## Scope notes
+
+- JauntDetour's needs (email/password + Google for consumers) are in the **GA core** of External ID.
+- During the current preview, some premium features are unavailable in external tenants; a few items (Azure Monitor log export, invited-user MFA) are preview/limited.
+- External-tenant auth **log retention is 7 days** on the free side — export to Azure Monitor if longer auth audit history is required.
+
+---
+
+## Security essentials (beyond login)
+
+These matter as much as authentication for a public app:
+
+- **Secrets in Azure Key Vault** — DB password, Google API key, Entra client secret. Not in `.env` for production.
+- **Always parameterized queries** — `$1, $2` placeholders; never concatenate user input into SQL.
+- **TLS in transit** — Azure databases enforce SSL by default; keep it on.
+- **Network isolation** — DB behind a VNet/private endpoint in production.
+- **Restrict the Google Maps API key** — scope to specific APIs and referrers.
+
+---
+
+## Impact on the database decision
+
+**None.** PostgreSQL, Azure SQL, and Cosmos all sit behind the provider identically — they never see credentials, only the resolved user ID. Authentication was decided independently and can change later without touching the data store.

--- a/docs/authentication/compliance.md
+++ b/docs/authentication/compliance.md
@@ -1,0 +1,120 @@
+# GDPR & Privacy Compliance
+
+**Applies to:** Microsoft Entra External ID + JauntDetour backend
+**Last Updated:** June 2, 2026
+
+How JauntDetour meets GDPR obligations. Microsoft is the **data processor** for identity (under its Data Processing Agreement); JauntDetour is the **data controller** for user accounts, trips, and detours.
+
+---
+
+## Data we hold
+
+We deliberately store the **minimum** (see [../database/schema.sql](../database/schema.sql)):
+
+| Field | Purpose |
+|-------|---------|
+| `external_id` (Entra `sub`) | Link the account to the identity provider — **no password is ever stored** |
+| `email` | Account identification and recovery |
+| `display_name` | Personalization |
+| `preferences` (JSONB) | Units, defaults |
+| trips / detours | The user's saved plans |
+
+We do **not** store credentials, payment data, or precise device location.
+
+---
+
+## Data subject rights
+
+| Right | How we satisfy it |
+|-------|-------------------|
+| **Access** | Endpoint returns the user's profile, trips, and detours as JSON |
+| **Portability** | Same data exported as a downloadable JSON file |
+| **Erasure** | Delete the user's rows, then delete the user in Entra |
+| **Rectification** | Profile editing; email changes go through Entra |
+| **Restriction** | Allow disabling optional processing while keeping the account |
+
+```javascript
+// Right to access / portability — scoped to the authenticated user
+router.get('/api/user/export', requireAuth, async (req, res) => {
+  const data = {
+    profile: await User.findById(req.userId),
+    trips: await Trip.findByUserId(req.userId),
+    exportedAt: new Date().toISOString(),
+  };
+  res.setHeader('Content-Disposition', 'attachment; filename=jauntdetour-data.json');
+  res.json(data);
+});
+
+// Right to erasure
+router.delete('/api/user/account', requireAuth, async (req, res) => {
+  await Trip.deleteByUserId(req.userId);   // cascades to detours
+  await User.deleteById(req.userId);
+  await deleteEntraUser(req.userId);       // remove from the identity provider
+  res.json({ message: 'Account deleted' });
+});
+```
+
+Every request is scoped to `req.userId` — the same authorization boundary used everywhere else.
+
+---
+
+## Data minimization & retention
+
+- Collect only what features require; optional fields (e.g. phone) only with explicit consent.
+- **Active accounts:** retained while active.
+- **Inactive accounts:** delete after 2 years of inactivity (with prior warning).
+- **Deleted accounts:** purge within 30 days; remove from backups within 90 days.
+
+---
+
+## Cookie policy
+
+| Category | Consent needed? | Examples |
+|----------|:---:|----------|
+| Essential | No | Auth session cookie (`httpOnly`), CSRF token |
+| Non-essential | Yes | Analytics, UI preference cookies |
+
+Show a consent banner before setting any non-essential cookie; only the essential auth/session cookies load without consent.
+
+---
+
+## Data residency & transfers
+
+- Entra External ID offers **data residency** options; provision the tenant in the region matching the primary user base (EU vs US).
+- Keep the PostgreSQL instance in the same geography as the identity tenant where practical.
+- For transfers outside the EU, rely on Microsoft's Standard Contractual Clauses (covered by the DPA).
+
+Recommended regions: **EU users** → West/North Europe; **US users** → East/West US.
+
+---
+
+## What Microsoft provides vs. what we implement
+
+| Microsoft (Entra) | JauntDetour |
+|-------------------|-------------|
+| DPA, encryption at rest/in transit | Privacy policy & terms of service |
+| Credential storage, MFA, lockout | Cookie consent banner |
+| Identity audit logging | Data export & account-deletion endpoints |
+| Data residency options | Retention enforcement (inactivity cleanup) |
+| SOC 2 / ISO 27001 certifications | Breach-notification process |
+
+---
+
+## Compliance checklist
+
+- [ ] Privacy policy and terms published
+- [ ] Cookie consent banner for non-essential cookies
+- [ ] `/api/user/export` (access + portability) implemented
+- [ ] `/api/user/account` deletion implemented (app rows **and** Entra user)
+- [ ] Retention policy automated (inactive-account cleanup)
+- [ ] Tenant + database provisioned in the appropriate region
+- [ ] Breach-notification procedure documented
+- [ ] Data Protection Officer designated if required
+
+---
+
+## Resources
+
+- [GDPR official text](https://gdpr-info.eu/)
+- [Microsoft data protection & GDPR](https://learn.microsoft.com/compliance/regulatory/gdpr)
+- [Entra External ID data residency](https://learn.microsoft.com/entra/external-id/)

--- a/docs/authentication/implementation-guide.md
+++ b/docs/authentication/implementation-guide.md
@@ -1,0 +1,171 @@
+# Entra External ID — Node.js Implementation Guide
+
+**Target:** Microsoft Entra External ID (external tenant) + Express backend
+**Last Updated:** June 2, 2026
+
+How the JauntDetour frontend redirects users to the hosted login flow, and how the backend verifies the returned token and resolves it to a `users` row.
+
+---
+
+## Flow overview
+
+```
+Browser ──(1) redirect──▶ Entra hosted login (*.ciamlogin.com)
+        ◀─(2) auth code──
+Browser ──(3) code──▶ Backend ──(4) exchange for tokens──▶ Entra
+Backend  ─(5) verify JWT, upsert user, issue app session ──▶ Browser
+Browser ──(6) call API with bearer token ──▶ Backend (verify + scope by user_id)
+```
+
+We use **OpenID Connect / authorization-code + PKCE**. Most teams use **MSAL** (`@azure/msal-node`) so they don't hand-roll the OAuth exchange.
+
+---
+
+## 1. Configuration
+
+`backend/.env.example`:
+```bash
+ENTRA_TENANT_SUBDOMAIN=jauntdetour           # <subdomain>.ciamlogin.com
+ENTRA_CLIENT_ID=00001111-aaaa-2222-bbbb-3333cccc4444
+ENTRA_CLIENT_SECRET=                          # from Key Vault in production
+ENTRA_REDIRECT_URI=https://app.jauntdetour.com/auth/callback
+```
+
+Authority URL format for external tenants:
+`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/`
+
+---
+
+## 2. MSAL client — `backend/config/auth.js`
+
+```javascript
+const { ConfidentialClientApplication } = require('@azure/msal-node');
+require('dotenv').config();
+
+const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/`;
+
+const msalClient = new ConfidentialClientApplication({
+  auth: {
+    clientId: process.env.ENTRA_CLIENT_ID,
+    clientSecret: process.env.ENTRA_CLIENT_SECRET,  // from Key Vault in prod
+    authority,
+    knownAuthorities: [`${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com`],
+  },
+});
+
+module.exports = { msalClient, authority };
+```
+
+---
+
+## 3. Login + callback routes
+
+```javascript
+const express = require('express');
+const { msalClient } = require('../config/auth');
+const User = require('../app/models/User');
+
+const router = express.Router();
+const SCOPES = ['openid', 'profile', 'email'];
+
+// (1) Redirect the browser to the hosted Entra login flow.
+router.get('/auth/login', async (req, res) => {
+  const url = await msalClient.getAuthCodeUrl({
+    scopes: SCOPES,
+    redirectUri: process.env.ENTRA_REDIRECT_URI,
+  });
+  res.redirect(url);
+});
+
+// (3-5) Exchange the code, verify the token, upsert the user.
+router.get('/auth/callback', async (req, res, next) => {
+  try {
+    const result = await msalClient.acquireTokenByCode({
+      code: req.query.code,
+      scopes: SCOPES,
+      redirectUri: process.env.ENTRA_REDIRECT_URI,
+    });
+
+    // MSAL validates the token signature/issuer/audience for us.
+    const { sub, email, name } = result.idTokenClaims;
+
+    const user = await User.upsertByExternalId({
+      externalId: sub,       // stable subject claim → users.external_id
+      email,
+      displayName: name,
+    });
+
+    req.session.userId = user.user_id;  // or issue your own signed JWT
+    res.redirect('/');
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;
+```
+
+---
+
+## 4. Protecting API routes
+
+For APIs called with a bearer access token, validate it against the tenant's JWKS. `jose` keeps this small:
+
+```javascript
+const { createRemoteJWKSet, jwtVerify } = require('jose');
+const { authority } = require('../config/auth');
+
+const JWKS = createRemoteJWKSet(
+  new URL(`${authority}discovery/v2.0/keys`)
+);
+
+async function requireAuth(req, res, next) {
+  try {
+    const token = (req.headers.authorization || '').replace('Bearer ', '');
+    const { payload } = await jwtVerify(token, JWKS, {
+      audience: process.env.ENTRA_CLIENT_ID,
+    });
+
+    const user = await User.upsertByExternalId({
+      externalId: payload.sub,
+      email: payload.email,
+      displayName: payload.name,
+    });
+
+    req.userId = user.user_id;  // the authorization boundary
+    next();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}
+
+module.exports = requireAuth;
+```
+
+Usage — every data route is scoped to `req.userId`:
+
+```javascript
+router.get('/api/trips', requireAuth, async (req, res) => {
+  const trips = await Trip.findByUserId(req.userId);  // WHERE user_id = $1
+  res.json(trips);
+});
+```
+
+---
+
+## 5. Production checklist
+
+- [ ] `ENTRA_CLIENT_SECRET` and DB credentials injected from **Azure Key Vault**.
+- [ ] Redirect URIs registered for every environment (dev, staging, prod).
+- [ ] Sessions/cookies set `httpOnly`, `secure`, `sameSite`.
+- [ ] Token `audience` and `issuer` validated on every request.
+- [ ] Brand the hosted user flow (logo, colors) in the Entra admin center.
+- [ ] Export auth logs to Azure Monitor if >7-day retention is needed.
+
+---
+
+## Resources
+
+- [Microsoft Entra External ID](https://learn.microsoft.com/entra/external-id/)
+- [Add Google as an identity provider](https://learn.microsoft.com/entra/external-id/customers/how-to-google-federation-customers)
+- [MSAL for Node.js](https://learn.microsoft.com/entra/identity-platform/msal-node-overview)

--- a/docs/authentication/security.md
+++ b/docs/authentication/security.md
@@ -1,0 +1,166 @@
+# Authentication Security
+
+**Applies to:** Microsoft Entra External ID + Express backend
+**Last Updated:** June 2, 2026
+
+Hardening guidance that sits alongside the [authentication decision](authentication.md) and [implementation guide](implementation-guide.md). Entra hosts sign-in and handles password storage, hashing, MFA, and lockout; everything here covers what **our** app is still responsible for.
+
+---
+
+## Protocol
+
+Use **OAuth 2.0 / OpenID Connect, authorization-code flow with PKCE** — the standard for browser apps. PKCE prevents authorization-code interception, and MSAL implements it for us. We never handle raw passwords.
+
+---
+
+## Token storage
+
+| Token | Where | Lifetime | Why |
+|-------|-------|----------|-----|
+| **Access token** | Browser memory (React state/context) | 15–60 min | Lost on refresh; not readable by injected scripts |
+| **Refresh token** | `httpOnly` + `secure` + `sameSite` cookie, or held by MSAL | 7–30 days | Not reachable from JavaScript (XSS-resistant) |
+
+**Never** store tokens in `localStorage` or `sessionStorage` — both are readable by any script and are a classic XSS exfiltration target.
+
+```javascript
+// Refresh-token cookie (when the backend manages it)
+res.cookie('refreshToken', token, {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict',
+  maxAge: 7 * 24 * 60 * 60 * 1000,
+  path: '/auth',
+});
+```
+
+> With MSAL, Entra issues and rotates refresh tokens for us, so a hand-rolled refresh-token store is optional. See [session-management.md](session-management.md).
+
+---
+
+## Token validation
+
+Every protected request validates the JWT against the tenant's published keys (JWKS). The [implementation guide](implementation-guide.md#4-protecting-api-routes) uses `jose`; always check **signature, expiry, audience, and issuer**, and require `RS256`.
+
+- Issuer/JWKS host is `https://<tenant>.ciamlogin.com/...` (External ID), **not** `b2clogin.com`.
+- Audience must equal our `ENTRA_CLIENT_ID`.
+
+---
+
+## Transport security
+
+- **HTTPS everywhere.** Redirect HTTP→HTTPS; Azure Web Apps terminate TLS.
+- **HSTS** via `helmet.hsts({ maxAge: 31536000, includeSubDomains: true, preload: true })`.
+- TLS 1.2+ only.
+
+```javascript
+const helmet = require('helmet');
+app.use(helmet()); // sets HSTS, CSP defaults, X-Content-Type-Options, etc.
+```
+
+---
+
+## CSRF protection
+
+- **SameSite cookies** are the first line of defense for cookie-based auth.
+- Add **anti-CSRF tokens** for state-changing routes (`POST/PUT/DELETE`) if cookies are used to authenticate them.
+- Validate the `Origin`/`Referer` header on sensitive operations.
+
+---
+
+## CORS
+
+```javascript
+const cors = require('cors');
+app.use(cors({
+  origin: process.env.FRONTEND_URL,   // never '*' with credentials
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'CSRF-Token'],
+}));
+```
+
+Never combine `origin: '*'` with `credentials: true`. Whitelist explicit origins.
+
+---
+
+## Rate limiting
+
+Throttle auth endpoints to blunt brute-force and token-abuse:
+
+```javascript
+const rateLimit = require('express-rate-limit');
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 5,                   // per IP per window
+  message: 'Too many authentication attempts, please try again later',
+});
+
+app.use('/auth', authLimiter);
+```
+
+Back the limiter with Redis (`rate-limit-redis`) when running multiple instances. Note Entra already applies smart lockout on its hosted sign-in pages.
+
+---
+
+## MFA
+
+MFA is configured in the **Entra user flow**, not in our code. Recommended policy:
+
+- Optional for regular users, **required** for any admin/elevated role.
+- Authenticator app (TOTP) is included free; SMS carries per-message cost.
+
+Enforce role-sensitive operations in the app by checking the resolved user's role before allowing the action.
+
+---
+
+## Secrets
+
+- `ENTRA_CLIENT_SECRET`, the DB password, and the Google Maps API key live in **Azure Key Vault** in production — never in committed `.env` files.
+- Restrict the Google Maps API key to specific APIs and HTTP referrers.
+
+---
+
+## Logging & monitoring
+
+Log security-relevant events (without logging tokens or secrets):
+
+- Sign-in success/failure, token refresh, logout
+- Session revocation, role changes
+- Failed authorization (`403`) attempts
+
+```javascript
+securityLogger.info({
+  event: 'login_success',
+  userId: user.user_id,
+  ip: req.ip,
+  userAgent: req.headers['user-agent'],
+  at: new Date().toISOString(),
+});
+```
+
+Export Entra sign-in/audit logs to **Azure Monitor** if you need more than the 7-day external-tenant retention.
+
+---
+
+## Pre-production checklist
+
+- [ ] All traffic over HTTPS; HSTS enabled
+- [ ] `helmet` security headers configured
+- [ ] JWT signature/expiry/audience/issuer validated on every request
+- [ ] Rate limiting on `/auth` routes
+- [ ] CORS locked to known origins; no `*` with credentials
+- [ ] CSRF protection on cookie-authenticated state changes
+- [ ] No tokens in `localStorage`/`sessionStorage`
+- [ ] Secrets sourced from Key Vault
+- [ ] MFA enforced for admin roles
+- [ ] Security event logging in place
+- [ ] Dependencies scanned for known vulnerabilities
+
+---
+
+## Resources
+
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [OAuth 2.0 for Browser-Based Apps](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)
+- [Microsoft Entra External ID](https://learn.microsoft.com/entra/external-id/)

--- a/docs/authentication/session-management.md
+++ b/docs/authentication/session-management.md
@@ -1,0 +1,98 @@
+# Session Management
+
+**Applies to:** Microsoft Entra External ID + Express backend
+**Last Updated:** June 2, 2026
+
+How JauntDetour keeps a user signed in after the [hosted login flow](implementation-guide.md), and how sessions end. **Default approach is lean** — let Entra/MSAL own the token lifecycle and keep only a thin app session. A heavier server-side store is described at the end as an optional upgrade.
+
+---
+
+## Default: lean, IdP-managed tokens
+
+Entra (via MSAL) issues, validates, and **rotates** tokens for us. The backend's job is small:
+
+1. After `/auth/callback`, store the resolved `user_id` in a signed, `httpOnly` session cookie (or issue our own short app JWT).
+2. On each API call, verify the bearer/access token and scope every query to `user_id` (see [implementation guide](implementation-guide.md#4-protecting-api-routes)).
+3. On logout, clear the app session and redirect through Entra's logout endpoint.
+
+```
+Browser ──login──▶ Entra hosted UI ──code──▶ Backend
+Backend ──verify, upsert user, set httpOnly session cookie──▶ Browser
+Browser ──API + access token──▶ Backend (verify JWT, scope by user_id)
+```
+
+This needs **no Redis** and no hand-rolled refresh logic.
+
+---
+
+## Token lifetimes
+
+| Token | Lifetime | Storage |
+|-------|----------|---------|
+| Access token | 15–60 min | Browser memory |
+| Refresh token | 7–30 days (rotated by Entra) | MSAL cache / `httpOnly` cookie |
+| App session | Match refresh window; absolute cap 90 days | `httpOnly` cookie |
+
+The frontend refreshes the access token shortly before expiry (MSAL `acquireTokenSilent` handles this transparently).
+
+---
+
+## Logout & revocation
+
+- **User logout** — clear the app session cookie and call Entra's `logout` endpoint to end the IdP session.
+- **Password change / account deletion** — handled in the Entra user flow; our app simply stops accepting the old session on next verification.
+- **Force sign-out everywhere** — see the optional server-side store below; without it, revocation is bounded by access-token lifetime (keep it short, 15 min).
+
+```javascript
+router.post('/auth/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.clearCookie('connect.sid');
+    const logoutUrl =
+      `${authority}oauth2/v2.0/logout` +
+      `?post_logout_redirect_uri=${encodeURIComponent(process.env.FRONTEND_URL)}`;
+    res.redirect(logoutUrl);
+  });
+});
+```
+
+---
+
+## Timeouts
+
+- **Idle timeout:** 30 minutes of inactivity.
+- **Absolute timeout:** 12 hours for sensitive sessions, 90 days hard cap before forced re-authentication.
+
+Short access-token lifetimes (15 min) mean a revoked or expired session is rejected quickly even in the lean model.
+
+---
+
+## Optional: server-side session store
+
+Adopt this only if you need **immediate, global revocation** or **concurrent-session limits** — e.g. an admin "sign out all devices" feature. It adds a Redis dependency and rotation code.
+
+```javascript
+// Store session metadata for revocation
+await redis.setex(`session:${userId}:${sessionId}`, 7 * 24 * 60 * 60,
+  JSON.stringify({ userId, createdAt: Date.now(), lastActivity: Date.now(), ip: req.ip }));
+
+// Revoke a single session or all of a user's sessions
+async function revokeAllUserSessions(userId) {
+  const keys = await redis.keys(`session:${userId}:*`);
+  if (keys.length) await redis.del(...keys);
+}
+```
+
+What it buys you:
+
+- Revoke a refresh token **before** it expires (logout, password change, security incident).
+- Enforce a max number of concurrent sessions per user (evict the oldest).
+- Track last-activity for idle enforcement server-side.
+
+For JauntDetour's MVP this is **not required** — the lean model is the default. Revisit if/when an admin console or strict device management is on the roadmap.
+
+---
+
+## Resources
+
+- [MSAL token lifecycle](https://learn.microsoft.com/entra/identity-platform/msal-acquire-cache-tokens)
+- [Entra External ID sign-out](https://learn.microsoft.com/entra/external-id/customers/how-to-user-flow-sign-up-sign-in-customers)

--- a/docs/database/cost-comparison.md
+++ b/docs/database/cost-comparison.md
@@ -1,0 +1,77 @@
+# Azure Database Cost Comparison
+
+**Purpose:** Pricing reference behind the PostgreSQL decision.
+**Last Updated:** June 2, 2026
+
+> Prices are approximate and change over time. Verify with the
+> [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/) before committing.
+
+---
+
+## Summary
+
+| Database | Free tier | Small | Medium | Large |
+|----------|-----------|-------|--------|-------|
+| **Azure PostgreSQL** ✅ | 12 mo free (B1ms, 32 GB) | $50–75/mo | $150–200/mo | $350–450/mo |
+| Azure Cosmos DB | 1000 RU/s + 25 GB | $100–200/mo | $400–600/mo | $1000–1500/mo |
+| Azure SQL Database | Serverless (auto-pause) | $75–100/mo | $200–350/mo | $500–750/mo |
+| MongoDB Atlas | M0 forever (512 MB) | $60–90/mo | $150–220/mo | $350–500/mo |
+
+PostgreSQL has the best cost-to-performance ratio at every tier.
+
+---
+
+## PostgreSQL configurations
+
+| Environment | Config | Monthly |
+|-------------|--------|---------|
+| Development | Burstable B1ms, 32 GB, 7-day backups, no HA | **$0** (12-mo free tier) |
+| Small (1–10K users) | D2s_v3, 128 GB, zone-redundant HA, geo backups | ~$152 |
+| Medium (10–50K users) | D4s_v3, 256 GB, zone-redundant HA, geo backups | ~$305 |
+| Large (50–200K users) | D8s_v3, 512 GB, zone-redundant HA, geo backups | ~$610 |
+
+**Cost drivers:** compute tier, HA (~2x compute), backup retention/geo-redundancy, optional read replicas.
+
+---
+
+## 3-year TCO
+
+Assumptions: Y1 = 1K users/1 GB (dev → small); Y2 = 10K users/10 GB; Y3 = 50K users/50 GB.
+
+| Database | Year 1 | Year 2 | Year 3 | **3-Year Total** |
+|----------|--------|--------|--------|------------------|
+| **Azure PostgreSQL** ✅ | $0 | $1,824 | $3,660 | **$5,484** |
+| MongoDB Atlas | $720 | $1,800 | $4,200 | $6,720 |
+| Azure SQL Database | $900 | $3,600 | $7,080 | $11,580 |
+| Azure Cosmos DB | $648 | $4,896 | $16,080 | $21,624 |
+
+**PostgreSQL saves ~$1,236–$16,140 over 3 years** versus the alternatives.
+
+---
+
+## Cost optimization
+
+- Use the 12-month **free tier** (B1ms) for development.
+- Enable **HA only in production** (saves ~50% in dev/staging).
+- Keep **7-day backups** in non-prod; 14–35 days in prod.
+- Add **read replicas** only when read load demands it.
+- Archive old data to **Azure Blob Storage**.
+
+**Potential savings:** 40–60% in non-production environments.
+
+---
+
+## Hidden costs
+
+| Category | Estimated impact |
+|----------|------------------|
+| Networking (private endpoints, egress) | $5–50/mo |
+| Monitoring (Azure Monitor logs/alerts) | $10–50/mo |
+| Long-term backup retention | varies |
+
+---
+
+## Verify current pricing
+
+- [Azure PostgreSQL pricing](https://azure.microsoft.com/pricing/details/postgresql/)
+- [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/)

--- a/docs/database/implementation-guide.md
+++ b/docs/database/implementation-guide.md
@@ -9,14 +9,52 @@ A concise, step-by-step path from provisioning to a working Node.js integration.
 
 ## Prerequisites
 
-- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 16+
+- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 18+
+- Terraform 1.5+ (for the Infrastructure-as-Code path below)
 - An active Azure subscription with Contributor/Owner on the target resource group
 
 ---
 
 ## 1. Provision the server
 
-### Development (free tier)
+Two paths are documented: the **Terraform path (recommended)** for repeatable
+Infrastructure-as-Code, and the **manual Azure CLI path** as a fallback or for
+one-off experimentation.
+
+### Option A — Terraform (recommended)
+
+The Terraform configuration lives in [`/infra`](../../infra/README.md) and
+references an existing resource group and provisions the Flexible Server (dev
+free tier), the database, firewall rules, and enforced TLS.
+
+> **The resource group must already exist.** Terraform reads it via a
+> `data "azurerm_resource_group"` source (read-only) and will **error** if it is
+> not found — it does not create the resource group.
+
+```pwsh
+az login
+az account set --subscription "<your-subscription-id>"
+
+cd infra
+Copy-Item terraform.tfvars.example terraform.tfvars   # then edit values
+$env:TF_VAR_admin_password = "<strong-password>"      # keep secrets out of files
+
+terraform init
+terraform validate
+terraform plan
+terraform apply        # type "yes" to confirm
+```
+
+Read the connection details back out:
+
+```pwsh
+terraform output server_fqdn      # -> DB_HOST
+terraform output database_name    # -> DB_NAME
+```
+
+### Option B — Manual Azure CLI
+
+#### Development (free tier)
 ```bash
 az group create --name jauntdetour-rg --location eastus
 
@@ -32,7 +70,7 @@ az postgres flexible-server create \
   --tags Environment=Development Project=JauntDetour
 ```
 
-### Production
+#### Production
 ```bash
 az postgres flexible-server create \
   --resource-group jauntdetour-rg \
@@ -76,28 +114,33 @@ psql "...dbname=jauntdetour..." -c "\dt"
 ### Install the driver
 ```bash
 cd backend
-npm install pg dotenv
+npm install   # pg and dotenv are declared in package.json
 ```
 
-### Connection module — `backend/config/database.js`
+### Connection pool — `backend/app/db/pool.js`
+
+A single shared `pg` Pool is created from environment variables. Pooling keeps a
+set of open connections ready so each request reuses one instead of paying a fresh
+TCP + TLS + auth handshake. Azure requires SSL.
+
 ```javascript
-const { Pool } = require('pg');
-require('dotenv').config();
+const { Pool } = require("pg");
+const logger = require("../utils/logger");
 
 const pool = new Pool({
   host: process.env.DB_HOST,
   port: process.env.DB_PORT || 5432,
   database: process.env.DB_NAME,
   user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,        // from Key Vault in production
-  ssl: { rejectUnauthorized: true },        // Azure requires SSL
+  password: process.env.DB_PASSWORD, // from Key Vault in production
+  ssl: process.env.DB_SSL === "false" ? false : { rejectUnauthorized: true },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
 });
 
-pool.on('error', (err) => {
-  console.error('Unexpected idle client error', err);
+pool.on("error", (err) => {
+  logger.error("Unexpected error on idle PostgreSQL client", err);
   process.exit(-1);
 });
 
@@ -108,151 +151,107 @@ module.exports = {
 };
 ```
 
-### Environment variables — `backend/.env.example`
+### Environment variables — root `.env`
+
+Copy `.env.example` to `.env` and fill in the values from the Terraform outputs:
+
 ```bash
 DB_HOST=jauntdetour-db-dev.postgres.database.azure.com
 DB_PORT=5432
 DB_NAME=jauntdetour
 DB_USER=jauntdetour_app
 DB_PASSWORD=            # local dev only; use Key Vault in production
-GOOGLE_API_KEY=
-NODE_ENV=development
 ```
 
-Add `.env` to `.gitignore`. In production, inject secrets from **Azure Key Vault**, not files.
+`.env` is gitignored. In production, inject secrets from **Azure Key Vault**, not files.
 
 ---
 
 ## 4. Data access layer
 
-User records key off the Entra `external_id` (the token `sub` claim) — there is no password column. See [../authentication/authentication.md](../authentication/authentication.md).
+User records key off the Entra `external_id` (the token `sub` claim) — there is no
+password column. See [../authentication/authentication.md](../authentication/authentication.md).
 
-### `backend/app/models/User.js`
+Repositories are ES classes with a **constructor-injected pool**, which keeps them
+trivial to unit test (pass a mock pool). All queries use parameterized placeholders
+(`$1, $2, ...`) to prevent SQL injection.
+
+### `backend/app/repositories/UserRepository.js`
 ```javascript
-const db = require('../../config/database');
+const logger = require("../utils/logger");
 
-class User {
-  // Create or fetch the user that matches a verified token's subject claim.
-  static async upsertByExternalId({ externalId, email, displayName }) {
-    const query = `
-      INSERT INTO users (external_id, email, display_name)
-      VALUES ($1, $2, $3)
-      ON CONFLICT (external_id) DO UPDATE
-        SET email = EXCLUDED.email,
-            last_login = CURRENT_TIMESTAMP
-      RETURNING user_id, external_id, email, display_name, preferences
+class UserRepository {
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error("UserRepository requires a database pool with a query method");
+    }
+    this.pool = pool;
+  }
+
+  async createUser({ externalId, email, displayName = null, preferences = {} }) {
+    const text = `
+      INSERT INTO users (external_id, email, display_name, preferences)
+      VALUES ($1, $2, $3, $4)
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
     `;
-    const result = await db.query(query, [externalId, email, displayName]);
+    const result = await this.pool.query(text, [externalId, email, displayName, preferences]);
     return result.rows[0];
   }
 
-  static async findById(userId) {
-    const result = await db.query(
-      'SELECT * FROM users WHERE user_id = $1 AND is_active = true',
-      [userId]
+  async getUserByExternalId(externalId) {
+    const result = await this.pool.query(
+      "SELECT * FROM users WHERE external_id = $1",
+      [externalId]
     );
     return result.rows[0] || null;
   }
+
+  // getUserById, getUserByEmail, updateUser,
+  // deleteUser (soft: is_active = false), hardDeleteUser (cascade) ...
 }
 
-module.exports = User;
+module.exports = UserRepository;
 ```
 
-### `backend/app/models/Trip.js`
+Wire it up with the shared pool:
+
 ```javascript
-const db = require('../../config/database');
-
-class Trip {
-  static async create({ userId, tripName, origin, destination, routePolyline, distanceMeters, durationSeconds, departureTime }) {
-    const query = `
-      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, departure_time)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING trip_id, trip_name, origin, destination, distance_meters, duration_seconds, status, created_at
-    `;
-    const values = [userId, tripName, JSON.stringify(origin), JSON.stringify(destination),
-                    routePolyline, distanceMeters, durationSeconds, departureTime];
-    const result = await db.query(query, values);
-    return result.rows[0];
-  }
-
-  // Always scope by user_id — the authorization boundary.
-  static async findByUserId(userId) {
-    const result = await db.query(
-      `SELECT trip_id, trip_name, origin, destination, distance_meters,
-              duration_seconds, status, created_at
-       FROM trips WHERE user_id = $1 ORDER BY created_at DESC`,
-      [userId]
-    );
-    return result.rows;
-  }
-
-  static async findByIdWithDetours(tripId, userId) {
-    const query = `
-      SELECT t.*,
-        COALESCE(json_agg(
-          json_build_object(
-            'detour_id', d.detour_id, 'place_name', d.place_name,
-            'place_type', d.place_type, 'latitude', d.latitude,
-            'longitude', d.longitude, 'rating', d.rating,
-            'position_on_route', d.position_on_route, 'notes', d.notes
-          ) ORDER BY d.position_on_route
-        ) FILTER (WHERE d.detour_id IS NOT NULL), '[]') AS detours
-      FROM trips t
-      LEFT JOIN detours d ON t.trip_id = d.trip_id
-      WHERE t.trip_id = $1 AND t.user_id = $2
-      GROUP BY t.trip_id
-    `;
-    const result = await db.query(query, [tripId, userId]);
-    return result.rows[0] || null;
-  }
-}
-
-module.exports = Trip;
+const pool = require("../db/pool");
+const UserRepository = require("../repositories/UserRepository");
+const users = new UserRepository(pool);
 ```
 
-### `backend/app/models/Detour.js`
-```javascript
-const db = require('../../config/database');
-
-class Detour {
-  static async create({ tripId, placeId, placeName, placeType, latitude, longitude, address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes }) {
-    const query = `
-      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude,
-                           address, position_on_route, rating, price_level, stop_duration_minutes, notes)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-      RETURNING detour_id, place_name, place_type, latitude, longitude, rating, created_at
-    `;
-    const values = [tripId, placeId, placeName, placeType, latitude, longitude,
-                    address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes];
-    const result = await db.query(query, values);
-    return result.rows[0];
-  }
-}
-
-module.exports = Detour;
-```
-
-> Note: there is no `findNearby` / `ST_DWithin` method. Proximity search is performed by the Google Places API in `placesAPI.js`; the database only stores the chosen results.
+`deleteUser` performs a **soft delete** (`is_active = false`) for routine
+deactivation; `hardDeleteUser` performs a permanent `DELETE` that cascades to the
+user's trips and detours, intended for GDPR account erasure. Trip and detour
+repositories follow the same pattern and are always scoped by `user_id` — the
+authorization boundary.
 
 ---
 
 ## 5. Testing
 
-```javascript
-// backend/app/models/__tests__/Trip.test.js
-const db = require('../../../config/database');
-jest.mock('../../../config/database');
-const Trip = require('../Trip');
+Unit tests inject a mock pool, so no live database is needed. Assert on the SQL
+text and parameter array captured in `pool.query.mock.calls`.
 
-test('findByUserId scopes by user and orders by created_at', async () => {
-  db.query.mockResolvedValue({ rows: [{ trip_id: 't1' }] });
-  const trips = await Trip.findByUserId('u1');
-  expect(trips).toHaveLength(1);
-  expect(db.query.mock.calls[0][1]).toEqual(['u1']);
+```javascript
+// backend/app/repositories/UserRepository.test.js
+const UserRepository = require("./UserRepository");
+
+test("createUser inserts with parameterized values", async () => {
+  const pool = { query: jest.fn().mockResolvedValue({ rows: [{ user_id: "u1" }] }) };
+  const repo = new UserRepository(pool);
+
+  await repo.createUser({ externalId: "x", email: "a@example.com" });
+
+  const [sql, params] = pool.query.mock.calls[0];
+  expect(sql).toContain("INSERT INTO users");
+  expect(params).toEqual(["x", "a@example.com", null, {}]);
 });
 ```
 
-Run with `npm test`.
+Run with `npm test` (from `backend/`).
 
 ---
 

--- a/docs/database/implementation-guide.md
+++ b/docs/database/implementation-guide.md
@@ -1,0 +1,275 @@
+# PostgreSQL Implementation Guide
+
+**Target:** Azure Database for PostgreSQL (Flexible Server), PostgreSQL 14+
+**Last Updated:** June 2, 2026
+
+A concise, step-by-step path from provisioning to a working Node.js integration. No PostGIS — all geospatial work stays in the Google Maps APIs.
+
+---
+
+## Prerequisites
+
+- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 16+
+- An active Azure subscription with Contributor/Owner on the target resource group
+
+---
+
+## 1. Provision the server
+
+### Development (free tier)
+```bash
+az group create --name jauntdetour-rg --location eastus
+
+az postgres flexible-server create \
+  --resource-group jauntdetour-rg \
+  --name jauntdetour-db-dev \
+  --location eastus \
+  --admin-user dbadmin \
+  --admin-password "$DB_ADMIN_PASSWORD" \
+  --sku-name Standard_B1ms --tier Burstable \
+  --storage-size 32 --version 14 \
+  --backup-retention 7 --high-availability Disabled \
+  --tags Environment=Development Project=JauntDetour
+```
+
+### Production
+```bash
+az postgres flexible-server create \
+  --resource-group jauntdetour-rg \
+  --name jauntdetour-db-prod \
+  --location eastus \
+  --admin-user dbadmin \
+  --admin-password "$DB_ADMIN_PASSWORD" \
+  --sku-name Standard_D2s_v3 --tier GeneralPurpose \
+  --storage-size 128 --version 14 \
+  --public-access None \
+  --backup-retention 14 --geo-redundant-backup Enabled \
+  --high-availability ZoneRedundant \
+  --tags Environment=Production Project=JauntDetour
+```
+
+> Pass `--admin-password` from an environment variable or Azure Key Vault — never hard-code it.
+
+For production, prefer **VNet integration** (`--public-access None` + a delegated subnet) over public firewall rules.
+
+---
+
+## 2. Apply the schema
+
+```bash
+# Create the database, then apply the schema (no PostGIS extension required)
+psql "host=jauntdetour-db-dev.postgres.database.azure.com port=5432 \
+      dbname=jauntdetour user=dbadmin sslmode=require" \
+  < docs/database/schema.sql
+```
+
+The schema enables only `pgcrypto` (for `gen_random_uuid()`). Verify tables:
+
+```bash
+psql "...dbname=jauntdetour..." -c "\dt"
+```
+
+---
+
+## 3. Node.js integration
+
+### Install the driver
+```bash
+cd backend
+npm install pg dotenv
+```
+
+### Connection module — `backend/config/database.js`
+```javascript
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT || 5432,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,        // from Key Vault in production
+  ssl: { rejectUnauthorized: true },        // Azure requires SSL
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+});
+
+pool.on('error', (err) => {
+  console.error('Unexpected idle client error', err);
+  process.exit(-1);
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  getClient: () => pool.connect(),
+  pool,
+};
+```
+
+### Environment variables — `backend/.env.example`
+```bash
+DB_HOST=jauntdetour-db-dev.postgres.database.azure.com
+DB_PORT=5432
+DB_NAME=jauntdetour
+DB_USER=jauntdetour_app
+DB_PASSWORD=            # local dev only; use Key Vault in production
+GOOGLE_API_KEY=
+NODE_ENV=development
+```
+
+Add `.env` to `.gitignore`. In production, inject secrets from **Azure Key Vault**, not files.
+
+---
+
+## 4. Data access layer
+
+User records key off the Entra `external_id` (the token `sub` claim) — there is no password column. See [../authentication/authentication.md](../authentication/authentication.md).
+
+### `backend/app/models/User.js`
+```javascript
+const db = require('../../config/database');
+
+class User {
+  // Create or fetch the user that matches a verified token's subject claim.
+  static async upsertByExternalId({ externalId, email, displayName }) {
+    const query = `
+      INSERT INTO users (external_id, email, display_name)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (external_id) DO UPDATE
+        SET email = EXCLUDED.email,
+            last_login = CURRENT_TIMESTAMP
+      RETURNING user_id, external_id, email, display_name, preferences
+    `;
+    const result = await db.query(query, [externalId, email, displayName]);
+    return result.rows[0];
+  }
+
+  static async findById(userId) {
+    const result = await db.query(
+      'SELECT * FROM users WHERE user_id = $1 AND is_active = true',
+      [userId]
+    );
+    return result.rows[0] || null;
+  }
+}
+
+module.exports = User;
+```
+
+### `backend/app/models/Trip.js`
+```javascript
+const db = require('../../config/database');
+
+class Trip {
+  static async create({ userId, tripName, origin, destination, routePolyline, distanceMeters, durationSeconds, departureTime }) {
+    const query = `
+      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, departure_time)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING trip_id, trip_name, origin, destination, distance_meters, duration_seconds, status, created_at
+    `;
+    const values = [userId, tripName, JSON.stringify(origin), JSON.stringify(destination),
+                    routePolyline, distanceMeters, durationSeconds, departureTime];
+    const result = await db.query(query, values);
+    return result.rows[0];
+  }
+
+  // Always scope by user_id — the authorization boundary.
+  static async findByUserId(userId) {
+    const result = await db.query(
+      `SELECT trip_id, trip_name, origin, destination, distance_meters,
+              duration_seconds, status, created_at
+       FROM trips WHERE user_id = $1 ORDER BY created_at DESC`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  static async findByIdWithDetours(tripId, userId) {
+    const query = `
+      SELECT t.*,
+        COALESCE(json_agg(
+          json_build_object(
+            'detour_id', d.detour_id, 'place_name', d.place_name,
+            'place_type', d.place_type, 'latitude', d.latitude,
+            'longitude', d.longitude, 'rating', d.rating,
+            'position_on_route', d.position_on_route, 'notes', d.notes
+          ) ORDER BY d.position_on_route
+        ) FILTER (WHERE d.detour_id IS NOT NULL), '[]') AS detours
+      FROM trips t
+      LEFT JOIN detours d ON t.trip_id = d.trip_id
+      WHERE t.trip_id = $1 AND t.user_id = $2
+      GROUP BY t.trip_id
+    `;
+    const result = await db.query(query, [tripId, userId]);
+    return result.rows[0] || null;
+  }
+}
+
+module.exports = Trip;
+```
+
+### `backend/app/models/Detour.js`
+```javascript
+const db = require('../../config/database');
+
+class Detour {
+  static async create({ tripId, placeId, placeName, placeType, latitude, longitude, address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes }) {
+    const query = `
+      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude,
+                           address, position_on_route, rating, price_level, stop_duration_minutes, notes)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+      RETURNING detour_id, place_name, place_type, latitude, longitude, rating, created_at
+    `;
+    const values = [tripId, placeId, placeName, placeType, latitude, longitude,
+                    address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes];
+    const result = await db.query(query, values);
+    return result.rows[0];
+  }
+}
+
+module.exports = Detour;
+```
+
+> Note: there is no `findNearby` / `ST_DWithin` method. Proximity search is performed by the Google Places API in `placesAPI.js`; the database only stores the chosen results.
+
+---
+
+## 5. Testing
+
+```javascript
+// backend/app/models/__tests__/Trip.test.js
+const db = require('../../../config/database');
+jest.mock('../../../config/database');
+const Trip = require('../Trip');
+
+test('findByUserId scopes by user and orders by created_at', async () => {
+  db.query.mockResolvedValue({ rows: [{ trip_id: 't1' }] });
+  const trips = await Trip.findByUserId('u1');
+  expect(trips).toHaveLength(1);
+  expect(db.query.mock.calls[0][1]).toEqual(['u1']);
+});
+```
+
+Run with `npm test`.
+
+---
+
+## 6. Production checklist
+
+- [ ] Provision General Purpose tier with zone-redundant HA and geo-redundant backups.
+- [ ] VNet integration / private endpoint — no public access.
+- [ ] Secrets in **Azure Key Vault**, injected at runtime.
+- [ ] Least-privilege `jauntdetour_app` DB user (not `dbadmin`).
+- [ ] Parameterized queries everywhere ( `$1, $2` ) — never string concatenation.
+- [ ] Azure Monitor alerts on CPU, storage, and connection limits.
+- [ ] Quarterly point-in-time restore drill.
+
+---
+
+## Resources
+
+- [Azure PostgreSQL docs](https://docs.microsoft.com/azure/postgresql/)
+- [node-postgres (pg)](https://node-postgres.com/)
+- [PostgreSQL JSONB](https://www.postgresql.org/docs/current/datatype-json.html)

--- a/docs/database/schema.sql
+++ b/docs/database/schema.sql
@@ -1,0 +1,145 @@
+-- ============================================================================
+-- JauntDetour Database Schema
+-- Database: Azure Database for PostgreSQL (Flexible Server), PostgreSQL 14+
+-- No PostGIS / spatial extensions: Google Maps APIs handle all geospatial work.
+-- Authentication: Microsoft Entra External ID (credentials are NOT stored here).
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Extensions
+-- ----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";  -- gen_random_uuid()
+
+-- ----------------------------------------------------------------------------
+-- Users
+-- Profile only. Authentication is delegated to Microsoft Entra External ID;
+-- we store the provider's stable subject ("sub") claim as external_id.
+-- ----------------------------------------------------------------------------
+CREATE TABLE users (
+    user_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id  VARCHAR(255) UNIQUE NOT NULL,        -- Entra "sub" claim
+    email        VARCHAR(255) UNIQUE NOT NULL,
+    display_name VARCHAR(150),
+    created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    last_login   TIMESTAMPTZ,
+    is_active    BOOLEAN DEFAULT true,
+    preferences  JSONB DEFAULT '{}'::jsonb,           -- theme, notifications, etc.
+    CONSTRAINT email_format CHECK (email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+);
+
+-- ----------------------------------------------------------------------------
+-- Trips
+-- Saved road trips. Google API responses stored as JSONB.
+-- ----------------------------------------------------------------------------
+CREATE TABLE trips (
+    trip_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id          UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    trip_name        VARCHAR(255) NOT NULL,
+    origin           JSONB NOT NULL,                  -- {lat, lng, address}
+    destination      JSONB NOT NULL,                  -- {lat, lng, address}
+    route_polyline   TEXT,                            -- Google encoded polyline
+    distance_meters  INTEGER,                         -- cached from Directions API
+    duration_seconds INTEGER,                         -- cached from Directions API
+    departure_time   TIMESTAMPTZ,
+    status           VARCHAR(50) DEFAULT 'planned',
+    created_at       TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    metadata         JSONB DEFAULT '{}'::jsonb,
+    CONSTRAINT valid_status   CHECK (status IN ('planned','active','completed','cancelled')),
+    CONSTRAINT valid_distance CHECK (distance_meters IS NULL OR distance_meters > 0),
+    CONSTRAINT valid_duration CHECK (duration_seconds IS NULL OR duration_seconds > 0)
+);
+
+-- ----------------------------------------------------------------------------
+-- Detours
+-- Points of interest saved along a trip. Plain lat/lng (no spatial index):
+-- proximity search is performed by Google Places, not the database.
+-- ----------------------------------------------------------------------------
+CREATE TABLE detours (
+    detour_id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id                           UUID NOT NULL REFERENCES trips(trip_id) ON DELETE CASCADE,
+    place_id                          VARCHAR(255),     -- Google Places ID
+    place_name                        VARCHAR(255) NOT NULL,
+    place_type                        VARCHAR(100),     -- restaurant, park, etc.
+    latitude                          DECIMAL(10, 8) NOT NULL,
+    longitude                         DECIMAL(11, 8) NOT NULL,
+    address                           VARCHAR(500),
+    position_on_route                 FLOAT,            -- normalized 0.0-1.0
+    estimated_detour_duration_seconds INTEGER,
+    estimated_detour_distance_meters  INTEGER,
+    rating                            DECIMAL(2,1),     -- Google rating 0.0-5.0
+    price_level                       INTEGER,          -- 1-4
+    stop_duration_minutes             INTEGER DEFAULT 30,
+    visit_time                        TIMESTAMPTZ,
+    notes                             TEXT,
+    created_at                        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at                        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    metadata                          JSONB DEFAULT '{}'::jsonb,
+    CONSTRAINT valid_latitude    CHECK (latitude BETWEEN -90 AND 90),
+    CONSTRAINT valid_longitude   CHECK (longitude BETWEEN -180 AND 180),
+    CONSTRAINT valid_position    CHECK (position_on_route IS NULL OR (position_on_route >= 0.0 AND position_on_route <= 1.0)),
+    CONSTRAINT valid_rating      CHECK (rating IS NULL OR (rating >= 0.0 AND rating <= 5.0)),
+    CONSTRAINT valid_price_level CHECK (price_level IS NULL OR (price_level BETWEEN 1 AND 4))
+);
+
+-- ----------------------------------------------------------------------------
+-- Indexes (B-tree only; no spatial/GiST indexes needed)
+-- ----------------------------------------------------------------------------
+CREATE INDEX idx_users_external_id  ON users(external_id);
+CREATE INDEX idx_trips_user_id      ON trips(user_id);
+CREATE INDEX idx_trips_status       ON trips(status);
+CREATE INDEX idx_trips_created_at   ON trips(created_at DESC);
+CREATE INDEX idx_trips_user_status  ON trips(user_id, status) INCLUDE (trip_name, created_at);
+CREATE INDEX idx_detours_trip_id    ON detours(trip_id);
+CREATE INDEX idx_detours_place_type ON detours(place_type);
+
+-- ----------------------------------------------------------------------------
+-- Auto-update updated_at
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_users_updated_at   BEFORE UPDATE ON users   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_trips_updated_at   BEFORE UPDATE ON trips   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_detours_updated_at BEFORE UPDATE ON detours FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ----------------------------------------------------------------------------
+-- Sample data (testing)
+-- ----------------------------------------------------------------------------
+INSERT INTO users (external_id, email, display_name, preferences)
+VALUES ('entra-sub-demo-0001', 'demo@jauntdetour.com', 'Demo User',
+        '{"theme": "light", "notifications": true}'::jsonb);
+
+INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, status)
+SELECT user_id,
+       'San Francisco to Yosemite',
+       '{"lat": 37.7749, "lng": -122.4194, "address": "San Francisco, CA"}'::jsonb,
+       '{"lat": 37.8651, "lng": -119.5383, "address": "Yosemite National Park, CA"}'::jsonb,
+       'encoded_polyline_placeholder', 280000, 12600, 'planned'
+FROM users WHERE email = 'demo@jauntdetour.com';
+
+INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude, address, position_on_route, rating, stop_duration_minutes, notes)
+SELECT trip_id, 'ChIJabcdefg123456789', 'Yosemite Falls Trailhead', 'park',
+       37.74550000, -119.59670000, 'Yosemite Valley, CA', 0.85, 4.8, 120,
+       'Popular waterfall hike - bring water and sunscreen!'
+FROM trips WHERE trip_name = 'San Francisco to Yosemite';
+
+-- ----------------------------------------------------------------------------
+-- Application user (least privilege) — set a real secret from Key Vault
+-- ----------------------------------------------------------------------------
+-- CREATE USER jauntdetour_app WITH PASSWORD '<from Key Vault>';
+-- GRANT CONNECT ON DATABASE jauntdetour TO jauntdetour_app;
+-- GRANT USAGE ON SCHEMA public TO jauntdetour_app;
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO jauntdetour_app;
+-- ALTER DEFAULT PRIVILEGES IN SCHEMA public
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO jauntdetour_app;
+
+-- ============================================================================
+-- End of Schema
+-- ============================================================================

--- a/docs/database/selection.md
+++ b/docs/database/selection.md
@@ -1,0 +1,115 @@
+# Database Selection for JauntDetour
+
+**Status:** Decided
+**Decision:** Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS
+**Last Updated:** June 2, 2026
+
+---
+
+## Decision
+
+Use **Azure Database for PostgreSQL (Flexible Server)** as the system of record for users, trips, and detours. Start on the free/Burstable tier for development and scale to General Purpose with zone-redundant HA for production.
+
+We deliberately **do not** use PostGIS or any spatial extension. Google Maps APIs perform all routing and place-search work at request time; the database only saves and loads the results.
+
+---
+
+## Why this fits JauntDetour
+
+JauntDetour is fundamentally a **"Google Maps API wrapper + save/load"** application:
+
+- `placesAPI.js` calls Google Places for nearby detours (lat/lng + radius).
+- `routeAPI.js` calls Google Directions for routes and distances.
+- The database persists user accounts, saved trips, and chosen detours — nothing more.
+
+This makes the data model a straightforward relational one (`users → trips → detours`), with JSON storage for the Google API payloads.
+
+| Requirement | Why PostgreSQL fits |
+|-------------|---------------------|
+| Store Google API JSON (origin, destination, polyline, places) | `JSONB` is a first-class, indexable binary JSON type |
+| "Get my trips" / "get my detours" queries | Simple, indexed foreign-key lookups by `user_id` / `trip_id` |
+| Node.js backend | Mature `pg` driver; no .NET dependency to justify Azure SQL |
+| Cost | Cheapest option at every tier in our analysis (see cost-comparison.md) |
+| Future semantic search for the AI agent | `pgvector` + the `azure_ai` extension add vector search in-place, no second datastore |
+| Map rendering | Plain `DECIMAL` lat/lng columns — no spatial index needed |
+
+---
+
+## Options considered
+
+| Option | Verdict |
+|--------|---------|
+| **Azure PostgreSQL** ✅ | Relational fit, cheapest, best JSON support, clean path to `pgvector` for the agent. **Chosen.** |
+| Azure SQL Database | Defensible, but its main edge (deep .NET integration) is unused, and JSON handling is more bolted-on. JSONB and cost favor PostgreSQL. |
+| Azure Cosmos DB | Capable but NoSQL — fights our relational shape, loses foreign keys/cascades, and is the most expensive and hardest to cost-predict (RU model). |
+| MongoDB Atlas | Third-party, document model mismatch, weaker Azure integration. |
+
+We do **not** choose a database to be a Foundry "knowledge source." Foundry agents reach app data through a **function/OpenAPI tool** doing parameterized, `user_id`-scoped queries — which works identically against any of these databases. PostgreSQL wins on data-shape fit, cost, and the in-place vector path.
+
+---
+
+## Data model
+
+Three entities with simple 1:N relationships:
+
+```
+Users (1) ──< (N) Trips (1) ──< (N) Detours
+```
+
+Key design points:
+
+- **UUID primary keys** — prevent enumeration, safe for distributed generation.
+- **`external_id` instead of `password_hash`** — authentication is delegated to Microsoft Entra External ID (see ../authentication/authentication.md). We store the provider's `sub` claim, not credentials.
+- **`JSONB` for Google payloads** — `origin`, `destination`, `metadata`, user `preferences`.
+- **Plain `DECIMAL` lat/lng** on detours — sufficient for map display; no spatial index.
+- **Cached Google values** — `route_polyline`, `distance_meters`, `duration_seconds` to reduce API calls.
+- **B-tree indexes** on foreign keys, status, and created date. No GiST/spatial indexes.
+
+See [schema.sql](schema.sql) for the full definition.
+
+---
+
+## Query patterns
+
+| Pattern | Query | Notes |
+|---------|-------|-------|
+| User's trip list | `WHERE user_id = $1 ORDER BY created_at DESC` | Most frequent; covered by composite index |
+| Trip with detours | `WHERE trip_id = $1` + `json_agg` of detours | Foreign-key lookup |
+| Find a user (post-auth) | `WHERE external_id = $1` | Resolves token subject to a row |
+| Find nearby places | ❌ Not a DB query | Google Places API handles this |
+
+---
+
+## Backup & disaster recovery
+
+PostgreSQL Flexible Server provides:
+
+- Automated backups, 7–35 day retention, point-in-time restore.
+- Optional geo-redundant backup storage for cross-region recovery.
+- Zone-redundant HA (automatic failover) in production.
+
+| Tier | Use | RPO / RTO |
+|------|-----|-----------|
+| Dev (Burstable, 7-day backups, no HA) | development | ~minutes / ~1–2 h |
+| Prod (General Purpose, geo-redundant, zone-redundant HA) | production | <5 min / <1 min failover |
+
+---
+
+## Cost summary
+
+| Year | Scale | Monthly | Annual |
+|------|-------|---------|--------|
+| Year 1 | Dev → small | $0 (free tier) | $0 |
+| Year 2 | 10K users, 10 GB | ~$152 | ~$1,824 |
+| Year 3 | 50K users, 50 GB | ~$305 | ~$3,660 |
+
+**3-year TCO: ~$5,484** — the lowest of all options evaluated. Full breakdown in [cost-comparison.md](cost-comparison.md).
+
+---
+
+## Next steps
+
+1. Provision free-tier PostgreSQL and apply [schema.sql](schema.sql).
+2. Integrate with the Node.js backend (see [implementation-guide.md](implementation-guide.md)).
+3. Wire authentication via Entra External ID (see [../authentication/authentication.md](../authentication/authentication.md)).
+4. Revisit `pgvector` if/when we add semantic agent features.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,10 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,json,css,md}\"",
     "eject": "react-scripts eject"
   },
+  "lint-staged": {
+    "src/**/*.{js,jsx,json,css,md}": "prettier --write",
+    "src/**/*.{js,jsx}": "eslint --fix"
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,62 @@
+# JauntDetour Infrastructure (Terraform)
+
+Infrastructure-as-Code for the JauntDetour Azure resources. Currently provisions the
+**Azure Database for PostgreSQL — Flexible Server** (dev free tier) plus its database and
+firewall rules.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) >= 2.30, authenticated:
+  ```pwsh
+  az login
+  az account set --subscription "<your-subscription-id>"
+  ```
+
+## Usage
+
+```pwsh
+cd infra
+Copy-Item terraform.tfvars.example terraform.tfvars   # then edit values
+
+# Provide the admin password without committing it:
+$env:TF_VAR_admin_password = "<strong-password>"
+
+terraform init
+terraform validate
+terraform plan
+terraform apply        # type "yes" to confirm
+```
+
+After apply, read the connection details:
+
+```pwsh
+terraform output server_fqdn
+terraform output database_name
+```
+
+Use those values to populate the backend `.env` (`DB_HOST`, `DB_NAME`) and apply the schema —
+see [../docs/database/implementation-guide.md](../docs/database/implementation-guide.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `providers.tf` | Terraform + azurerm provider versions |
+| `variables.tf` | Input variables (names, SKU, storage, credentials) |
+| `main.tf` | PostgreSQL server, database, firewall, TLS config (deployed into an existing resource group) |
+| `outputs.tf` | Server FQDN, database name, admin login, resource group |
+| `terraform.tfvars.example` | Template for your local variable values |
+
+## Notes
+
+- The `resource_group_name` must be an **existing** resource group. Terraform references it as a
+  data source — it does not create, modify, or delete the resource group or anything else already
+  in it. Only the database server, database, firewall rules, and TLS setting are created. The server 
+  is deployed to `var.location` (default `centralus`), which may differ from the resource group's region.
+- `admin_password` is **sensitive** — pass it via `TF_VAR_admin_password` or a gitignored
+  `terraform.tfvars`. Never commit it.
+- `terraform.tfvars`, `*.tfstate`, and `.terraform/` are gitignored.
+- The dev tier uses Burstable `B_Standard_B1ms`, 32 GB, 7-day backups, no HA — covered by the
+  Azure 12-month free tier. Production hardening (HA, geo-redundant backups, private endpoint)
+  is documented in the implementation guide and is intentionally out of scope here.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,70 @@
+# Reference an existing resource group; Terraform does not create or modify it.
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+# Azure Database for PostgreSQL - Flexible Server.
+# Dev defaults (B1ms / Burstable / 32 GB) are covered by the 12-month free tier.
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = var.server_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+
+  version  = var.postgres_version
+  sku_name = var.sku_name
+
+  storage_mb            = var.storage_mb
+  backup_retention_days = var.backup_retention_days
+
+  administrator_login    = var.admin_login
+  administrator_password = var.admin_password
+
+  # No high availability or geo-redundant backups on the free dev tier.
+  zone = "1"
+
+  tags = {
+    Project     = "JauntDetour"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    # Azure may assign/adjust the availability zone; ignore drift to avoid noisy plans.
+    ignore_changes = [zone]
+  }
+}
+
+# Application database.
+resource "azurerm_postgresql_flexible_server_database" "main" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Allow other Azure services (e.g. the App Service / container) to reach the server.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  name             = "AllowAzureServices"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+# Optional: allow a single developer machine through the firewall for local testing.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "dev_client" {
+  count            = var.dev_client_ip == "" ? 0 : 1
+  name             = "AllowDevClient"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = var.dev_client_ip
+  end_ip_address   = var.dev_client_ip
+}
+
+# Enforce TLS for all connections (Azure default, set explicitly for clarity).
+resource "azurerm_postgresql_flexible_server_configuration" "require_ssl" {
+  name      = "require_secure_transport"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "ON"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "server_fqdn" {
+  description = "Fully qualified domain name of the PostgreSQL server (use as DB_HOST)."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "database_name" {
+  description = "Name of the application database (use as DB_NAME)."
+  value       = azurerm_postgresql_flexible_server_database.main.name
+}
+
+output "admin_login" {
+  description = "Administrator login (use as DB_USER for the initial schema load)."
+  value       = azurerm_postgresql_flexible_server.main.administrator_login
+}
+
+output "resource_group_name" {
+  description = "Resource group containing the database."
+  value       = data.azurerm_resource_group.main.name
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  # The subscription already has resources, so its resource providers are
+  # registered. Skip automatic registration, which requires subscription-level
+  # permissions and otherwise stalls the plan.
+  resource_provider_registrations = "none"
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit real credentials.
+
+# Must be an EXISTING resource group. The database is created inside it;
+# The server's region is controlled by the `location` variable (default: centralus).
+resource_group_name   = "jauntdetour-rg"
+environment           = "development"
+server_name           = "jauntdetour-db-dev"
+database_name         = "jauntdetour"
+postgres_version      = "14"
+sku_name              = "B_Standard_B1ms"
+storage_mb            = 32768
+backup_retention_days = 7
+admin_login           = ""
+
+# Provide the admin password securely instead of storing it here, e.g.:
+#   $env:TF_VAR_admin_password = "<strong-password>"   (PowerShell)
+# admin_password = "set-via-TF_VAR_admin_password"
+
+# Your current public IP, to allow local psql access (optional).
+# dev_client_ip = ""

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,71 @@
+variable "resource_group_name" {
+  description = "Name of the existing Azure resource group to deploy the database into."
+  type        = string
+  default     = "jauntdetour-rg"
+}
+
+variable "environment" {
+  description = "Deployment environment tag (e.g. development, production)."
+  type        = string
+  default     = "production"
+}
+
+variable "location" {
+  description = "Azure region for the PostgreSQL server. May differ from the resource group's region."
+  type        = string
+  default     = "centralus"
+}
+
+variable "server_name" {
+  description = "Globally unique name of the PostgreSQL Flexible Server."
+  type        = string
+  default     = "jauntdetour-db-prod"
+}
+
+variable "database_name" {
+  description = "Name of the application database created on the server."
+  type        = string
+  default     = "jauntdetour"
+}
+
+variable "postgres_version" {
+  description = "Major PostgreSQL version."
+  type        = string
+  default     = "14"
+}
+
+variable "sku_name" {
+  description = "Compute SKU. Burstable B1ms is covered by the 12-month free tier."
+  type        = string
+  default     = "B_Standard_B1ms"
+}
+
+variable "storage_mb" {
+  description = "Provisioned storage in MB (32 GB = 32768)."
+  type        = number
+  default     = 32768
+}
+
+variable "backup_retention_days" {
+  description = "Automated backup retention window in days."
+  type        = number
+  default     = 7
+}
+
+variable "admin_login" {
+  description = "Administrator login for the PostgreSQL server."
+  type        = string
+  default     = "dbadmin"
+}
+
+variable "admin_password" {
+  description = "Administrator password. Provide via TF_VAR_admin_password or a .tfvars file — never commit it."
+  type        = string
+  sensitive   = true
+}
+
+variable "dev_client_ip" {
+  description = "Public IP allowed through the server firewall for local development. Leave empty to skip the rule."
+  type        = string
+  default     = ""
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "devDependencies": {
         "concurrently": "^8.2.0",
         "dotenv": "^16.3.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.5.2",
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -24,6 +26,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -165,6 +183,93 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -200,6 +305,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -233,6 +355,21 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/date-fns": {
@@ -290,6 +427,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -298,6 +448,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -338,6 +519,32 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -359,6 +566,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore-by-default": {
@@ -424,12 +657,374 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -513,6 +1108,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -524,6 +1174,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.1.tgz",
+      "integrity": "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pstree.remy": {
@@ -556,6 +1219,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -579,6 +1282,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -590,6 +1316,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -605,11 +1344,64 @@
         "node": ">=10"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -637,6 +1429,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -702,6 +1507,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -728,6 +1549,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -2,20 +2,25 @@
   "name": "jauntdetour",
   "version": "1.0.0",
   "description": "Road trip planning app with detours",
-  "private": true,  "scripts": {
+  "private": true,
+  "scripts": {
     "dev": "concurrently \"npm run backend:dev\" \"npm run frontend:dev\"",
     "backend:dev": "cd backend && node -r dotenv/config index.js",
     "frontend:dev": "cd frontend && npm start",
     "backend:start": "cd backend && node index.js",
     "frontend:start": "cd frontend && npm start",
     "install:all": "npm install --prefix ./backend && npm install --prefix ./frontend",
-    "build:frontend": "cd frontend && npm run build"
-  },"devDependencies": {
+    "build:frontend": "cd frontend && npm run build",
+    "prepare": "husky"
+  },
+  "devDependencies": {
     "concurrently": "^8.2.0",
     "dotenv": "^16.3.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.5.2",
     "nodemon": "^3.0.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.12.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,20 @@ export NODE_ENV="development"
 export NODE_ENV="production"
 ```
 
+Database connection (backend)
+```
+DB_HOST=<host>
+DB_PORT=5432
+DB_NAME=<database>
+DB_USER=<user>
+DB_PASSWORD=<password>
+DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
+```
+When using the DevContainer, the `DB_*` values are provided automatically from
+`.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
+For the schema, data-access layer, and Azure/production setup, see
+[docs/database/implementation-guide.md](docs/database/implementation-guide.md).
+
 ### Installing
 
 A step by step series of examples that tell you how to get a development env running
@@ -59,11 +73,19 @@ npm install
 For the best development experience, use the provided DevContainer or the convenience scripts:
 
 ### Option 1: DevContainer (VS Code)
-1. Open the project in VS Code
-2. Install the "Dev Containers" extension
-3. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
-4. The container will automatically install all dependencies
-5. Use `Ctrl+Shift+P` → "Tasks: Run Task" → "Start Full Stack Development"
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   ```
+2. Open the project in VS Code
+3. Install the "Dev Containers" extension
+4. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
+5. The container installs all dependencies and starts a local PostgreSQL 14 database (created and seeded automatically)
+6. Run `npm run dev` to start the frontend and backend
+
+The DevContainer includes a PostgreSQL sidecar, so the app runs against a local
+database with no cloud setup required. See [DEV-SETUP.md](DEV-SETUP.md) for details,
+connection info, and how to reset the database.
 
 ### Option 2: Local Development with Scripts
 Install root-level dependencies first:
@@ -88,6 +110,13 @@ npm run backend:dev
 # Frontend only  
 npm run frontend:dev
 ```
+
+### Database
+Local development uses a PostgreSQL database that runs automatically inside the
+DevContainer (see Option 1 above) — no manual database install needed. The backend
+connects through the `DB_*` environment variables. For the schema, the data-access
+layer, resetting local data, and Azure/production provisioning (Terraform), see
+[DEV-SETUP.md](DEV-SETUP.md) and [docs/database/](docs/database/implementation-guide.md).
 
 ## Original Manual Setup
 
@@ -211,6 +240,7 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 * [Node v10.15.3](https://nodejs.org/en/download/) - Runtime environment
 * [Express](https://expressjs.com/) - Web framework used for backend
+* [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
 * [React](https://reactjs.org/) - Library used to build the frontend
 * [Redux](https://redux.js.org/) - State management library
 * [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API


### PR DESCRIPTION
## Add PostgreSQL sidecar to the dev container for local development

### Summary

Converts the dev container from a single Node image to a Docker Compose setup with a **PostgreSQL 14 sidecar**, so the full stack can be developed and tested locally against a real database — no Azure dependency or cost. The app already supported this (`pool.js` honors `DB_SSL=false`); this PR is container/config wiring only.

### What changed

**Dev container → Docker Compose**
- New `.devcontainer/docker-compose.yml` with two services:
  - `app` — the Node 20 dev environment (workspace bind-mount, `env_file`, waits for the DB via `depends_on: service_healthy`).
  - `db` — `postgres:14` with a `pgdata` volume, `pg_isready` healthcheck, and port `5432` exposed to the host.
- `.devcontainer/devcontainer.json` rewritten to use `dockerComposeFile` / `service` / `workspaceFolder`; added `5432` to forwarded ports; enabled dependency install; installs `postgresql-client` (`psql`) on create.

**Automatic database setup (first boot only)**
- Mounts `docs/database/schema.sql` → `01-schema.sql` (tables, indexes, triggers, demo data).
- New `.devcontainer/init/02-create-app-user.sql` → creates the least-privilege `jauntdetour_app` user (mirrors production; runs after the schema so grants apply).

**node_modules isolation**
- Container-only named volumes for root/backend/frontend `node_modules`, so Linux-built deps never collide with the Windows host copies via the bind mount. `postCreateCommand` `chown`s them to the `node` user before installing (fixes the root-owned-volume `EACCES` on first install).

**Quality-of-life**
- `BROWSER=none` so `react-scripts` doesn't open a second browser tab (VS Code port forwarding handles it).

**Environment & docs**
- New committed `.devcontainer/devcontainer.env.example` (placeholder Google keys, real local DB values); the real `devcontainer.env` stays gitignored.
- `DEV-SETUP.md` — new "Local Database (Dev Container)" section (setup, connecting, reset).
- `readme.md` — DB + dev-container updates (env file step, bundled Postgres, `DB_*` vars, Built With), kept light with links to the deeper docs.

### How to use

1. `cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env` and add your Google Maps API key.
2. **Dev Containers: Reopen in Container** — deps install and the DB is created + seeded automatically.
3. `npm run dev` — backend (3000) and frontend (3001) run against the local `db`.
4. Reset the DB anytime: `docker compose -f .devcontainer/docker-compose.yml down -v`.

### Testing / verification

Validated with Docker 28.3.0:
- ✅ Compose config valid; `db` reaches healthy
- ✅ Schema + demo data loaded (`users`/`trips`/`detours`, `demo@jauntdetour.com`)
- ✅ Least privilege: `jauntdetour_app` can `SELECT`, **cannot** `DROP TABLE`
- ✅ Backend connects via `pool.js` using the `env_file` values (no SSL error)
- ✅ Frontend serves on 3001 with a single browser open

### Notes

- No application code changes; production `backend`/`frontend` Dockerfiles are untouched.
- Local DB credentials are throwaway/local-only, safe to commit in the compose/init/example files.
- ⚠️ Unrelated follow-up: the Google Maps API key still needs rotating (exposed in older git history).
- Follow-up idea: bump the stale Node references / clean up duplicated sections in `readme.md`.