### PR TITLE
add PostgreSQL sidecar and local DB setup to dev container

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.7",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a",
+      "integrity": "sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,0 +1,29 @@
+# Environment variables for Jauntdetour development.
+# Copy this file to devcontainer.env and fill in the secret values.
+#   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+# devcontainer.env is gitignored; never commit real secrets.
+
+# Google Maps API Key (required for both frontend and backend)
+GOOGLE_API_KEY=your_google_api_key_here
+REACT_APP_GOOGLE_API_KEY=your_google_api_key_here
+
+# Node.js environment
+NODE_ENV=development
+NODE_OPTIONS=--openssl-legacy-provider
+
+# Backend server configuration
+BACKEND_PORT=3000
+
+# Frontend development server configuration
+FRONTEND_PORT=3001
+
+# Local containerized database (see .devcontainer/docker-compose.yml).
+# These are local-only development values, safe to use as-is. The backend
+# connects as the least-privilege app user; DB_PASSWORD must match the password
+# in .devcontainer/init/02-create-app-user.sql.
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=jauntdetour
+DB_USER=jauntdetour_app
+DB_PASSWORD=localdevapp
+DB_SSL=false

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
   "name": "Jauntdetour Full Stack",
-  // Use the Node.js image with additional tools
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+  // Use Docker Compose: the `app` dev container plus a PostgreSQL `db` sidecar.
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/jauntdetour",
 
   // Features to add to the dev container
   "features": {
@@ -12,7 +14,7 @@
   },
 
   // Forward ports for both frontend and backend
-  "forwardPorts": [3000, 3001, 8080],
+  "forwardPorts": [3000, 3001, 8080, 5432],
   "portsAttributes": {
     "3000": {
       "label": "Backend API",
@@ -25,10 +27,19 @@
     "8080": {
       "label": "Frontend Production",
       "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "PostgreSQL",
+      "onAutoForward": "silent"
     }
   },
-  // Install dependencies for both frontend and backend after container creation
-  //"postCreateCommand": "npm install --prefix ./backend && npm install --prefix ./frontend && npm install",
+  // Install system packages once at container creation. postgresql-client provides
+  // the `psql` CLI for inspecting the local database.
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client",
+  // Install dependencies for root, backend, and frontend after the container is created.
+  // The node_modules named volumes are created root-owned, so hand them to the `node`
+  // user first (they're empty at this point, so the chown is instant).
+  "postCreateCommand": "sudo chown node:node node_modules backend/node_modules frontend/node_modules && npm install && npm install --prefix ./backend && npm install --prefix ./frontend",
 
   // Configure VS Code extensions and settings
   "customizations": {
@@ -56,11 +67,13 @@
   // Set environment variables for development
   "containerEnv": {
     "NODE_ENV": "development",
-    "NODE_OPTIONS": "--openssl-legacy-provider"
+    "NODE_OPTIONS": "--openssl-legacy-provider",
+    // Let VS Code's port forwarding open the browser for 3001; stop react-scripts
+    // from opening a second one.
+    "BROWSER": "none"
   },
-  // Load .env file if it exists
-  //"onCreateCommand": "if [ -f .env ]; then echo 'Found .env file for environment variables'; else echo 'No .env file found - create one with GOOGLE_API_KEY=your_key_here'; fi",
+  // Environment variables (Google keys, DB_*, ports) are also provided via the
+  // Compose `env_file` (.devcontainer/devcontainer.env). See devcontainer.env.example.
 
-  "remoteUser": "node",
-  "runArgs": ["--env-file", ".devcontainer/devcontainer.env"]
+  "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,8 +34,9 @@
     }
   },
   // Install system packages once at container creation. postgresql-client provides
-  // the `psql` CLI for inspecting the local database.
-  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client",
+  // the `psql` CLI for inspecting the local database. Clean up apt lists afterward
+  // to keep the container lean.
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client && sudo rm -rf /var/lib/apt/lists/*",
   // Install dependencies for root, backend, and frontend after the container is created.
   // The node_modules named volumes are created root-owned, so hand them to the `node`
   // user first (they're empty at this point, so the chown is instant).

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,55 @@
+# Docker Compose for the local development container.
+# Provides the Node dev environment (`app`) plus a PostgreSQL 14 sidecar (`db`).
+# This is for LOCAL DEVELOPMENT ONLY — it does not use the production Dockerfiles.
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye
+    init: true
+    # Keep the container running so VS Code can attach and open a shell.
+    command: sleep infinity
+    volumes:
+      # Mount the repository into the container workspace.
+      - ..:/workspaces/jauntdetour:cached
+      # Container-only node_modules (named volumes) so the container's Linux-built
+      # dependencies never collide with the host's copies via the bind mount.
+      - node_modules_root:/workspaces/jauntdetour/node_modules
+      - node_modules_backend:/workspaces/jauntdetour/backend/node_modules
+      - node_modules_frontend:/workspaces/jauntdetour/frontend/node_modules
+    env_file:
+      # Local secrets + config (gitignored). See devcontainer.env.example.
+      - devcontainer.env
+    # Wait for the database to be accepting connections before the app is usable.
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:14
+    restart: unless-stopped
+    environment:
+      # Superuser used only for initialization; the app connects as jauntdetour_app.
+      POSTGRES_USER: dbadmin
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: jauntdetour
+    volumes:
+      # Persist database data across container restarts.
+      - pgdata:/var/lib/postgresql/data
+      # Init scripts run in filename order, and ONLY when pgdata is empty (first boot).
+      # 01 creates the schema (tables must exist before 02 grants on them).
+      - ../docs/database/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./init/02-create-app-user.sql:/docker-entrypoint-initdb.d/02-create-app-user.sql:ro
+    ports:
+      # Exposed to the host so GUI tools (DBeaver/pgAdmin) can connect on localhost:5432.
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dbadmin -d jauntdetour"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:
+  node_modules_root:
+  node_modules_backend:
+  node_modules_frontend:

--- a/.devcontainer/init/02-create-app-user.sql
+++ b/.devcontainer/init/02-create-app-user.sql
@@ -1,0 +1,16 @@
+-- Local development only: create the least-privilege application user.
+-- Mirrors the production setup (the app connects as jauntdetour_app, never as the
+-- superuser). Runs after 01-schema.sql so the tables it grants on already exist.
+-- The password here is a throwaway LOCAL value and must match DB_PASSWORD in
+-- .devcontainer/devcontainer.env.
+
+CREATE USER jauntdetour_app WITH PASSWORD 'localdevapp';
+
+GRANT CONNECT ON DATABASE jauntdetour TO jauntdetour_app;
+GRANT USAGE ON SCHEMA public TO jauntdetour_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO jauntdetour_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO jauntdetour_app;
+
+-- Ensure the app user also gets privileges on any tables created later.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO jauntdetour_app;

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -48,6 +48,36 @@ export NODE_OPTIONS=--openssl-legacy-provider
 - Nodemon for backend auto-restart on file changes
 - React fast refresh for frontend live reloading
 
+## Local Database (Dev Container)
+
+The dev container runs a PostgreSQL 14 sidecar (via `.devcontainer/docker-compose.yml`),
+so you can develop against a local database with no Azure dependency or cost.
+
+### First-time setup
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   # edit GOOGLE_API_KEY / REACT_APP_GOOGLE_API_KEY (DB_* values work as-is)
+   ```
+2. In VS Code, run **Dev Containers: Reopen in Container**. On first build the database
+   is created and seeded automatically:
+   - `01-schema.sql` loads the schema (tables, indexes, triggers, demo data).
+   - `02-create-app-user.sql` creates the least-privilege `jauntdetour_app` user.
+3. `npm run dev` starts the frontend and backend, which connect to the `db` service.
+
+### Connecting to the database
+- **From the app container:** host `db`, port `5432`.
+- **From your host machine** (DBeaver, pgAdmin, psql): `localhost:5432`.
+- The backend connects as `jauntdetour_app` (least privilege). The `dbadmin` superuser
+  (password `localdev`) is used only for initialization.
+
+### Resetting the database
+Init scripts run only when the data volume is empty (first boot). To wipe and reseed:
+```bash
+docker compose -f .devcontainer/docker-compose.yml down -v
+```
+Then rebuild/reopen the container.
+
 ## Development Tips
 1. The backend will auto-restart when you change files (thanks to nodemon)
 2. The frontend has fast refresh enabled for live updates

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -72,7 +72,7 @@ so you can develop against a local database with no Azure dependency or cost.
   (password `localdev`) is used only for initialization.
 
 ### Resetting the database
-Init scripts run only when the data volume is empty (first boot). To wipe and reseed:
+Init scripts run only when the data volume is empty (first boot). To wipe and reseed (note: `-v` also removes node_modules_* volumes, so deps will reinstall on next start):
 ```bash
 docker compose -f .devcontainer/docker-compose.yml down -v
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Local development uses a PostgreSQL database that runs automatically inside the
 DevContainer (see Option 1 above) — no manual database install needed. The backend
 connects through the `DB_*` environment variables. For the schema, the data-access
 layer, resetting local data, and Azure/production provisioning (Terraform), see
-[DEV-SETUP.md](DEV-SETUP.md) and [docs/database/](docs/database/implementation-guide.md).
+[DEV-SETUP.md](DEV-SETUP.md) and [docs/database/implementation-guide.md](docs/database/implementation-guide.md).
 
 ## Original Manual Setup
 

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,20 @@ export NODE_ENV="development"
 export NODE_ENV="production"
 ```
 
+Database connection (backend)
+```
+DB_HOST=<host>
+DB_PORT=5432
+DB_NAME=<database>
+DB_USER=<user>
+DB_PASSWORD=<password>
+DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
+```
+When using the DevContainer, the `DB_*` values are provided automatically from
+`.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
+For the schema, data-access layer, and Azure/production setup, see
+[docs/database/implementation-guide.md](docs/database/implementation-guide.md).
+
 ### Installing
 
 A step by step series of examples that tell you how to get a development env running
@@ -59,11 +73,19 @@ npm install
 For the best development experience, use the provided DevContainer or the convenience scripts:
 
 ### Option 1: DevContainer (VS Code)
-1. Open the project in VS Code
-2. Install the "Dev Containers" extension
-3. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
-4. The container will automatically install all dependencies
-5. Use `Ctrl+Shift+P` → "Tasks: Run Task" → "Start Full Stack Development"
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   ```
+2. Open the project in VS Code
+3. Install the "Dev Containers" extension
+4. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
+5. The container installs all dependencies and starts a local PostgreSQL 14 database (created and seeded automatically)
+6. Run `npm run dev` to start the frontend and backend
+
+The DevContainer includes a PostgreSQL sidecar, so the app runs against a local
+database with no cloud setup required. See [DEV-SETUP.md](DEV-SETUP.md) for details,
+connection info, and how to reset the database.
 
 ### Option 2: Local Development with Scripts
 Install root-level dependencies first:
@@ -88,6 +110,13 @@ npm run backend:dev
 # Frontend only  
 npm run frontend:dev
 ```
+
+### Database
+Local development uses a PostgreSQL database that runs automatically inside the
+DevContainer (see Option 1 above) — no manual database install needed. The backend
+connects through the `DB_*` environment variables. For the schema, the data-access
+layer, resetting local data, and Azure/production provisioning (Terraform), see
+[DEV-SETUP.md](DEV-SETUP.md) and [docs/database/](docs/database/implementation-guide.md).
 
 ## Original Manual Setup
 
@@ -211,6 +240,7 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 * [Node v10.15.3](https://nodejs.org/en/download/) - Runtime environment
 * [Express](https://expressjs.com/) - Web framework used for backend
+* [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
 * [React](https://reactjs.org/) - Library used to build the frontend
 * [Redux](https://redux.js.org/) - State management library
 * [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,7 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 ## Built With
 
-* [Node v10.15.3](https://nodejs.org/en/download/) - Runtime environment
+* [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
 * [Express](https://expressjs.com/) - Web framework used for backend
 * [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
 * [React](https://reactjs.org/) - Library used to build the frontend


### PR DESCRIPTION
## Add PostgreSQL sidecar to the dev container for local development

### Summary

Converts the dev container from a single Node image to a Docker Compose setup with a **PostgreSQL 14 sidecar**, so the full stack can be developed and tested locally against a real database — no Azure dependency or cost. The app already supported this (`pool.js` honors `DB_SSL=false`); this PR is container/config wiring only.

### What changed

**Dev container → Docker Compose**
- New `.devcontainer/docker-compose.yml` with two services:
  - `app` — the Node 20 dev environment (workspace bind-mount, `env_file`, waits for the DB via `depends_on: service_healthy`).
  - `db` — `postgres:14` with a `pgdata` volume, `pg_isready` healthcheck, and port `5432` exposed to the host.
- `.devcontainer/devcontainer.json` rewritten to use `dockerComposeFile` / `service` / `workspaceFolder`; added `5432` to forwarded ports; enabled dependency install; installs `postgresql-client` (`psql`) on create.

**Automatic database setup (first boot only)**
- Mounts `docs/database/schema.sql` → `01-schema.sql` (tables, indexes, triggers, demo data).
- New `.devcontainer/init/02-create-app-user.sql` → creates the least-privilege `jauntdetour_app` user (mirrors production; runs after the schema so grants apply).

**node_modules isolation**
- Container-only named volumes for root/backend/frontend `node_modules`, so Linux-built deps never collide with the Windows host copies via the bind mount. `postCreateCommand` `chown`s them to the `node` user before installing (fixes the root-owned-volume `EACCES` on first install).

**Quality-of-life**
- `BROWSER=none` so `react-scripts` doesn't open a second browser tab (VS Code port forwarding handles it).

**Environment & docs**
- New committed `.devcontainer/devcontainer.env.example` (placeholder Google keys, real local DB values); the real `devcontainer.env` stays gitignored.
- `DEV-SETUP.md` — new "Local Database (Dev Container)" section (setup, connecting, reset).
- `readme.md` — DB + dev-container updates (env file step, bundled Postgres, `DB_*` vars, Built With), kept light with links to the deeper docs.

### How to use

1. `cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env` and add your Google Maps API key.
2. **Dev Containers: Reopen in Container** — deps install and the DB is created + seeded automatically.
3. `npm run dev` — backend (3000) and frontend (3001) run against the local `db`.
4. Reset the DB anytime: `docker compose -f .devcontainer/docker-compose.yml down -v`.

### Testing / verification

Validated with Docker 28.3.0:
- ✅ Compose config valid; `db` reaches healthy
- ✅ Schema + demo data loaded (`users`/`trips`/`detours`, `demo@jauntdetour.com`)
- ✅ Least privilege: `jauntdetour_app` can `SELECT`, **cannot** `DROP TABLE`
- ✅ Backend connects via `pool.js` using the `env_file` values (no SSL error)
- ✅ Frontend serves on 3001 with a single browser open

### Notes

- No application code changes; production `backend`/`frontend` Dockerfiles are untouched.
- Local DB credentials are throwaway/local-only, safe to commit in the compose/init/example files.
- ⚠️ Unrelated follow-up: the Google Maps API key still needs rotating (exposed in older git history).
- Follow-up idea: bump the stale Node references / clean up duplicated sections in `readme.md`.