### PR TITLE
Entra auth setup with signin and sign out

### DIFF
--- a/.copilot/plans/auth-implementation-plan.md
+++ b/.copilot/plans/auth-implementation-plan.md
@@ -1,0 +1,150 @@
+<!-- markdownlint-disable-file -->
+# Plan: End-to-End User Authentication (Entra External ID)
+
+## Goal
+
+Wire real user registration, login, and logout into the app using the
+already-provisioned Microsoft Entra External ID tenant. Use a **backend-driven
+confidential-client flow** (MSAL Node) with a server-side session, prove the whole chain
+with one protected, `user_id`-scoped data route, then add a minimal frontend login/logout
+UI. Email/password only for this pass; Google/social login is deferred (it is additive
+later with no code change).
+
+## Status / Context
+
+- **Phase 0 (provisioning) is DONE** by the user: external tenant, `SignUpSignIn` user
+  flow (Email with password, collecting Email + Display Name), app registration associated
+  with the flow, admin consent granted, and the four `ENTRA_*` values collected.
+- **Single tenant** is used for both dev and prod for now (no users yet, low risk; split
+  later is a config-only change).
+- **Secrets** live in `.devcontainer/devcontainer.env` (user runs inside the dev
+  container).
+
+## Confirmed Decisions
+
+- **Option A — backend-driven**: Express performs the OAuth authorization-code + PKCE
+  exchange (MSAL Node) and issues a server session cookie. App registration platform =
+  **Web** (uses a client secret). Chosen over an MSAL-React SPA approach.
+- **Session-based authorization**: `req.session.userId` is the boundary; `requireAuth`
+  middleware resolves it to `req.userId`.
+- **Env vars collected**: `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_CLIENT_ID`,
+  `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback`.
+
+## Current State (investigated)
+
+- `backend/index.js`: Express 5.1, `express-session` 1.18 with a **hardcoded**
+  `"temporarySecretKey"`, wide-open `app.use(cors())`, only `/test`, `/route`, `/places`.
+  Listens on port 3000.
+- `backend/app/db/pool.js`: shared `pg` pool from env vars; exports
+  `{ query, getClient, pool }`; `DB_SSL=false` disables SSL for local Postgres.
+- `backend/app/repositories/UserRepository.js`: has `getUserByExternalId`, `createUser`,
+  `updateUser` (`UPDATABLE_COLUMNS` includes `email`, `displayName`, `lastLogin`). **No
+  `upsertByExternalId`** — this is the one real gap.
+- Repository test pattern: `pool = { query: jest.fn() }`; assert SQL substrings + params;
+  `logger` mocked. 74 tests currently passing.
+- Frontend: CRA + Redux; `axios` to an absolute backend base (`getUrlBase()` in
+  `RouteRequester`); frontend on `:3001`, backend on `:3000` (cross-origin). No
+  client-side callback route needed — the backend handles `/auth/callback`.
+- Cookie note: `localhost:3000` and `localhost:3001` are the **same site** (site =
+  eTLD+1, port-agnostic), so a `sameSite=lax` cookie **is** sent on XHR. CORS must still
+  use `credentials: true` with an explicit origin (not `*`), and axios needs
+  `withCredentials: true`. (Alt: add a CRA `proxy` for same-origin dev.)
+
+## Phase 1 — Backend Auth Foundation
+
+1. Add dependencies to `backend/`: `@azure/msal-node`, `jose`.
+2. **CREATE** `backend/config/auth.js`: MSAL `ConfidentialClientApplication`
+   (`clientId`, `clientSecret`, `authority = https://<sub>.ciamlogin.com/`,
+   `knownAuthorities`). Export `msalClient`, `authority`, and a `CryptoProvider` for
+   PKCE/state. Also export a `jose` `JWKS` (`createRemoteJWKSet` on
+   `authority + discovery/v2.0/keys`) for future bearer-token verification.
+3. **`UserRepository.upsertByExternalId({ externalId, email, displayName })`**:
+   `getUserByExternalId`; if found → `updateUser(user_id, { email, displayName, lastLogin: now })`;
+   else `createUser`. Return the row. Add unit tests (found path, create path,
+   update-on-login path).
+4. **CREATE** `backend/app/routes/auth.js`:
+   - `GET /auth/login`: PKCE (verifier + challenge) + state stored in `req.session` →
+     `msalClient.getAuthCodeUrl({ scopes: [openid, profile, email], redirectUri,
+     codeChallenge, codeChallengeMethod: "S256", state })` → `res.redirect`.
+   - `GET /auth/callback`: validate `state`; `acquireTokenByCode({ code, scopes,
+     redirectUri, codeVerifier })`; read `idTokenClaims { sub, email, name }`;
+     `upsertByExternalId`; set `req.session.userId`; redirect to `FRONTEND_URL`.
+   - `POST /auth/logout`: `req.session.destroy` → redirect to the Entra logout endpoint
+     (`authority + oauth2/v2.0/logout?post_logout_redirect_uri=FRONTEND_URL`).
+   - `GET /auth/me`: return the current user (`getUserById(req.session.userId)`) or 401 —
+     lets the SPA know login state.
+5. **CREATE** `backend/app/middleware/requireAuth.js`: if `req.session.userId` → set
+   `req.userId` and `next()`; else `401 { error: "Unauthorized" }`.
+6. **MODIFY** `backend/index.js`: `SESSION_SECRET` from env; `resave: false`;
+   `saveUninitialized: false`; `cookie { httpOnly: true, sameSite: "lax", secure: prod,
+   maxAge }`. Replace wide-open `cors()` with `{ origin: FRONTEND_URL, credentials: true }`.
+   Mount the auth and API routes. Keep the existing `/route` and `/places`.
+
+## Phase 2 — Prove the Chain (protected data route)
+
+7. **CREATE** `backend/app/routes/trips.js`: `GET /api/trips` (behind `requireAuth`) →
+   `TripRepository.getTripsByUserId(req.userId)`; optional `POST /api/trips`.
+8. Composition: instantiate the pool + `UserRepository`/`TripRepository` once (small module
+   or in `index.js`) and inject into the routes.
+
+## Phase 3 — Frontend Login/Logout UI
+
+9. On app load, call `GET /auth/me` (axios `withCredentials`) → store the user in
+   Redux/state.
+10. "Sign in" button → `window.location = ${backendBase}/auth/login` (full-page redirect).
+    "Sign out" → `POST /auth/logout` then clear the user/redirect.
+11. Header (`frontend/src/components/header/Header.jsx`) or a new `AuthButton`: show
+    "Sign in" when logged out; display name + "Sign out" when logged in.
+12. Set axios `withCredentials: true` (global or per auth call). Add
+    `REACT_APP_BACKEND_URL` to `frontend/src/config/config.js` (currently only `NODE_ENV`
+    and `GOOGLE_API_KEY`).
+
+## Phase 4 — Config, Docs, Tests
+
+13. **UPDATE** `backend/.env.example` (create if missing) and
+    `.devcontainer/devcontainer.env.example` with `ENTRA_*` + `SESSION_SECRET` +
+    `FRONTEND_URL` (placeholders / local values).
+14. Reconcile docs: `docs/authentication/implementation-guide.md` references
+    `app/models/User` and `Trip.findByUserId` → update to `repositories/UserRepository`
+    and `getTripsByUserId`.
+15. Tests: `upsertByExternalId` (repository); `requireAuth` (unit); auth routes (mock
+    `msalClient` + upsert). Keep the existing 74 passing.
+
+## Relevant Files
+
+- `backend/index.js` — session/CORS hardening, mount routes.
+- `backend/app/db/pool.js` — reuse the shared pool (no change).
+- `backend/app/repositories/UserRepository.js` — add `upsertByExternalId` (+ `.test.js`).
+- `backend/app/repositories/TripRepository.js` — reuse `getTripsByUserId`.
+- **New**: `backend/config/auth.js`, `backend/app/routes/auth.js`,
+  `backend/app/routes/trips.js`, `backend/app/middleware/requireAuth.js`.
+- `frontend/src/config/config.js` — add backend URL; `frontend/src/App.js` /
+  `frontend/src/components/header/Header.jsx` — auth UI.
+- `docs/authentication/implementation-guide.md` — naming reconcile.
+
+## Verification
+
+1. `npm test` in `backend/` — new tests pass, 74 existing still green.
+2. Manual E2E: start the stack → **Sign in** → Entra hosted sign-up → create a test
+   account → callback → `GET /auth/me` returns the user → a row appears in `users` keyed
+   by `external_id` → `GET /api/trips` returns `[]` scoped to that user → **Sign out**
+   clears the session.
+3. Confirm the session cookie is `httpOnly`, and an unauthenticated `GET /api/trips`
+   returns 401.
+
+## Further Considerations (decide during build)
+
+1. **Logout scope** — full Entra logout (ends the IdP SSO session, user re-enters password
+   next time) vs. local-only (clears the app session, Entra still remembers).
+   **Recommendation: full Entra logout** for a true "logout" story.
+2. **Session contents** — store `userId` only and fetch via `/auth/me` (DB = source of
+   truth) vs. store the whole user object. **Recommendation: `userId` only.**
+3. **Dev cross-origin cookie** — explicit CORS `origin` + `credentials: true`
+   (**recommended**) vs. a CRA `proxy` for same-origin dev.
+4. **Frontend state** — a small Redux auth reducer (matches the existing pattern,
+   **recommended**) vs. local component state.
+
+## Out of Scope (this pass)
+
+- Google/social login. A second (prod) Entra tenant. Azure Key Vault wiring. DB
+  migrations. Full trip/detour REST CRUD beyond the one proof route. Node version bump.

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -17,6 +17,23 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
+# Frontend origin used by the backend for CORS and post-login/logout redirects.
+FRONTEND_URL=http://localhost:3001
+
+# Express session signing secret. Generate a long random value, e.g.
+#   openssl rand -base64 32
+SESSION_SECRET=change_me_to_a_long_random_string
+
+# Microsoft Entra External ID (CIAM) — from the app registration + user flow.
+# ENTRA_TENANT_SUBDOMAIN is the tenant subdomain (the "<sub>" in <sub>.ciamlogin.com);
+# the full "<sub>.onmicrosoft.com" form is also accepted.
+# ENTRA_TENANT_ID is the tenant (directory) GUID — required in the CIAM authority path.
+ENTRA_TENANT_SUBDOMAIN=your_tenant_subdomain
+ENTRA_TENANT_ID=your_tenant_directory_guid
+ENTRA_CLIENT_ID=your_app_registration_client_id
+ENTRA_CLIENT_SECRET=your_app_registration_client_secret
+ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
+
 # Local containerized database (see .devcontainer/docker-compose.yml).
 # These are local-only development values, safe to use as-is. The backend
 # connects as the least-privilege app user; DB_PASSWORD must match the password

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,11 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 
+# Shell scripts and Git hooks must use LF, or the shell mis-parses the trailing
+# carriage return (e.g. husky hooks fail with a bogus package name).
+*.sh text eol=lf
+.husky/* text eol=lf
+
 # Denote all files that are truly binary and should not be modified
 *.png binary
 *.jpg binary

--- a/backend/app/middleware/requireAuth.js
+++ b/backend/app/middleware/requireAuth.js
@@ -1,0 +1,21 @@
+/**
+ * requireAuth — session-based authorization middleware.
+ *
+ * The server session is the authorization boundary: a successful sign-in stores
+ * the user's primary key in `req.session.userId`. This middleware promotes that
+ * value to `req.userId` for downstream handlers (so they never read the session
+ * directly) and rejects unauthenticated requests with 401.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+function requireAuth(req, res, next) {
+  if (req.session && req.session.userId) {
+    req.userId = req.session.userId;
+    return next();
+  }
+  return res.status(401).json({ error: "Unauthorized" });
+}
+
+module.exports = requireAuth;

--- a/backend/app/middleware/requireAuth.test.js
+++ b/backend/app/middleware/requireAuth.test.js
@@ -1,0 +1,52 @@
+const requireAuth = require("./requireAuth");
+
+describe("requireAuth", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = { session: {} };
+    res = {
+      statusCode: null,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.body = payload;
+        return this;
+      },
+    };
+    next = jest.fn();
+  });
+
+  it("promotes session.userId to req.userId and calls next when authenticated", () => {
+    req.session.userId = "user-123";
+
+    requireAuth(req, res, next);
+
+    expect(req.userId).toBe("user-123");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it("responds 401 when there is no session", () => {
+    req.session = undefined;
+
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("responds 401 when the session has no userId", () => {
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+});

--- a/backend/app/repositories/UserRepository.js
+++ b/backend/app/repositories/UserRepository.js
@@ -166,11 +166,17 @@ class UserRepository {
     const existing = await this.getUserByExternalId(externalId);
 
     if (existing) {
-      return this.updateUser(existing.user_id, {
-        email,
-        displayName,
-        lastLogin: new Date(),
-      });
+      // Always stamp the login time, but only refresh profile fields the IdP
+      // actually provided — otherwise a missing claim would overwrite existing
+      // non-null data with null.
+      const updates = { lastLogin: new Date() };
+      if (email != null) {
+        updates.email = email;
+      }
+      if (displayName != null) {
+        updates.displayName = displayName;
+      }
+      return this.updateUser(existing.user_id, updates);
     }
 
     return this.createUser({ externalId, email, displayName });

--- a/backend/app/repositories/UserRepository.js
+++ b/backend/app/repositories/UserRepository.js
@@ -150,6 +150,33 @@ class UserRepository {
   }
 
   /**
+   * Create the user if they do not yet exist, otherwise refresh their profile
+   * and login timestamp. Called on every successful sign-in: the Entra
+   * `external_id` (token `sub`) is the identity key. First login creates the
+   * row; subsequent logins update email/display name (in case they changed at
+   * the IdP) and stamp `last_login`.
+   *
+   * @param {object} identity
+   * @param {string} identity.externalId - Entra `sub` claim (unique).
+   * @param {string} identity.email - User email from the ID token.
+   * @param {string} [identity.displayName] - Display name from the ID token.
+   * @returns {Promise<object>} The created or updated user row.
+   */
+  async upsertByExternalId({ externalId, email, displayName = null }) {
+    const existing = await this.getUserByExternalId(externalId);
+
+    if (existing) {
+      return this.updateUser(existing.user_id, {
+        email,
+        displayName,
+        lastLogin: new Date(),
+      });
+    }
+
+    return this.createUser({ externalId, email, displayName });
+  }
+
+  /**
    * Update an allowed subset of a user's columns. `updated_at` is maintained by
    * a database trigger.
    *

--- a/backend/app/repositories/UserRepository.test.js
+++ b/backend/app/repositories/UserRepository.test.js
@@ -156,6 +156,94 @@ describe("UserRepository", () => {
     });
   });
 
+  describe("upsertByExternalId", () => {
+    it("creates a new user when none exists for the external_id", async () => {
+      const created = {
+        user_id: "u-new",
+        external_id: "entra-sub-9",
+        email: "new@example.com",
+        display_name: "New User",
+      };
+      // First query: getUserByExternalId -> no rows. Second query: createUser insert.
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [created] });
+
+      const result = await repo.upsertByExternalId({
+        externalId: "entra-sub-9",
+        email: "new@example.com",
+        displayName: "New User",
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+      const [insertSql, insertParams] = pool.query.mock.calls[1];
+      expect(insertSql).toContain("INSERT INTO users");
+      expect(insertParams).toEqual([
+        "entra-sub-9",
+        "new@example.com",
+        "New User",
+        {},
+      ]);
+      expect(result).toBe(created);
+    });
+
+    it("updates email, display name, and last_login when the user exists", async () => {
+      const existing = {
+        user_id: "u-existing",
+        external_id: "entra-sub-1",
+        email: "old@example.com",
+        display_name: "Old Name",
+      };
+      const updated = {
+        ...existing,
+        email: "fresh@example.com",
+        display_name: "Fresh",
+      };
+      // First query: getUserByExternalId -> the existing row. Second: updateUser.
+      pool.query
+        .mockResolvedValueOnce({ rows: [existing] })
+        .mockResolvedValueOnce({ rows: [updated] });
+
+      const result = await repo.upsertByExternalId({
+        externalId: "entra-sub-1",
+        email: "fresh@example.com",
+        displayName: "Fresh",
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+      const [updateSql, updateParams] = pool.query.mock.calls[1];
+      expect(updateSql).toContain("UPDATE users");
+      expect(updateSql).toContain("email = $1");
+      expect(updateSql).toContain("display_name = $2");
+      expect(updateSql).toContain("last_login = $3");
+      // email, displayName, lastLogin (a Date), then the user_id in the WHERE clause.
+      expect(updateParams[0]).toBe("fresh@example.com");
+      expect(updateParams[1]).toBe("Fresh");
+      expect(updateParams[2]).toBeInstanceOf(Date);
+      expect(updateParams[3]).toBe("u-existing");
+      expect(result).toBe(updated);
+    });
+
+    it("defaults displayName to null when omitted", async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ user_id: "u2" }] });
+
+      await repo.upsertByExternalId({
+        externalId: "entra-sub-2",
+        email: "noname@example.com",
+      });
+
+      const [, insertParams] = pool.query.mock.calls[1];
+      expect(insertParams).toEqual([
+        "entra-sub-2",
+        "noname@example.com",
+        null,
+        {},
+      ]);
+    });
+  });
+
   describe("updateUser", () => {
     it("builds a parameterized SET clause for provided fields only", async () => {
       const updated = { user_id: "u1", display_name: "New Name" };

--- a/backend/app/repositories/UserRepository.test.js
+++ b/backend/app/repositories/UserRepository.test.js
@@ -224,6 +224,24 @@ describe("UserRepository", () => {
       expect(result).toBe(updated);
     });
 
+    it("only stamps last_login (no profile overwrite) when claims are omitted", async () => {
+      const existing = { user_id: "u-existing", external_id: "entra-sub-1" };
+      pool.query
+        .mockResolvedValueOnce({ rows: [existing] })
+        .mockResolvedValueOnce({ rows: [existing] });
+
+      await repo.upsertByExternalId({ externalId: "entra-sub-1" });
+
+      const [updateSql, updateParams] = pool.query.mock.calls[1];
+      expect(updateSql).toContain("UPDATE users");
+      expect(updateSql).not.toContain("email =");
+      expect(updateSql).not.toContain("display_name =");
+      expect(updateSql).toContain("last_login = $1");
+      // Only last_login (a Date), then the user_id in the WHERE clause.
+      expect(updateParams[0]).toBeInstanceOf(Date);
+      expect(updateParams[1]).toBe("u-existing");
+    });
+
     it("defaults displayName to null when omitted", async () => {
       pool.query
         .mockResolvedValueOnce({ rows: [] })

--- a/backend/app/routes/auth.js
+++ b/backend/app/routes/auth.js
@@ -97,6 +97,13 @@ function createAuthRouter({ userRepository }) {
         return res.status(400).json({ error: "Invalid identity token" });
       }
 
+      // email is NOT NULL (and format-checked) in the users table, so a missing
+      // email claim would fail the upsert. Reject before touching the DB.
+      if (!email) {
+        logger.error("/auth/callback: ID token missing email claim");
+        return res.status(400).json({ error: "Invalid identity token" });
+      }
+
       const user = await userRepository.upsertByExternalId({
         externalId,
         email,

--- a/backend/app/routes/auth.js
+++ b/backend/app/routes/auth.js
@@ -1,0 +1,164 @@
+/**
+ * Authentication routes — Entra External ID OAuth 2.0 (authorization-code + PKCE).
+ *
+ * A confidential-client, backend-driven flow. The browser is redirected to the
+ * Entra hosted pages for sign-up/sign-in; Entra redirects back to /auth/callback
+ * with an authorization code, which the server exchanges (with the PKCE verifier
+ * and client secret) for tokens. The user is upserted into the local `users`
+ * table and their primary key is stored in the server session.
+ *
+ * Exported as a factory so the UserRepository can be injected (keeps the routes
+ * unit-testable with a mock repository and a mocked MSAL client).
+ */
+
+const express = require("express");
+const {
+  msalClient,
+  authority,
+  redirectUri,
+  scopes,
+  cryptoProvider,
+} = require("../../config/auth");
+const logger = require("../utils/logger");
+
+// Where to send the browser after login/logout completes.
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+
+/**
+ * @param {object} deps
+ * @param {import('../repositories/UserRepository')} deps.userRepository
+ * @returns {import('express').Router}
+ */
+function createAuthRouter({ userRepository }) {
+  if (!userRepository) {
+    throw new Error("createAuthRouter requires a userRepository");
+  }
+
+  const router = express.Router();
+
+  /**
+   * Begin sign-in: generate PKCE + state, stash them in the session, and
+   * redirect the browser to the Entra authorization endpoint.
+   */
+  router.get("/login", async (req, res) => {
+    try {
+      const { verifier, challenge } = await cryptoProvider.generatePkceCodes();
+      const state = cryptoProvider.createNewGuid();
+
+      // Persist PKCE verifier + state server-side to validate the callback.
+      req.session.pkceVerifier = verifier;
+      req.session.authState = state;
+
+      const authCodeUrl = await msalClient.getAuthCodeUrl({
+        scopes,
+        redirectUri,
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        state,
+      });
+
+      return res.redirect(authCodeUrl);
+    } catch (err) {
+      logger.error("/auth/login failed", err);
+      return res.status(500).json({ error: "Failed to start login" });
+    }
+  });
+
+  /**
+   * Handle the redirect back from Entra: validate state, exchange the code for
+   * tokens, upsert the user, and establish the session.
+   */
+  router.get("/callback", async (req, res) => {
+    try {
+      const { code, state } = req.query;
+
+      if (!code) {
+        return res.status(400).json({ error: "Missing authorization code" });
+      }
+      if (!state || state !== req.session.authState) {
+        logger.warn("/auth/callback: state mismatch");
+        return res.status(400).json({ error: "Invalid state" });
+      }
+
+      const tokenResponse = await msalClient.acquireTokenByCode({
+        code,
+        scopes,
+        redirectUri,
+        codeVerifier: req.session.pkceVerifier,
+      });
+
+      const claims = tokenResponse.idTokenClaims || {};
+      const externalId = claims.sub;
+      const email = claims.email || claims.preferred_username || null;
+      const displayName = claims.name || null;
+
+      if (!externalId) {
+        logger.error("/auth/callback: ID token missing sub claim");
+        return res.status(400).json({ error: "Invalid identity token" });
+      }
+
+      const user = await userRepository.upsertByExternalId({
+        externalId,
+        email,
+        displayName,
+      });
+
+      // Clear the one-time login artifacts, then bind the session to the user.
+      delete req.session.pkceVerifier;
+      delete req.session.authState;
+      req.session.userId = user.user_id;
+
+      return res.redirect(FRONTEND_URL);
+    } catch (err) {
+      logger.error("/auth/callback failed", err);
+      return res.status(500).json({ error: "Authentication failed" });
+    }
+  });
+
+  /**
+   * Return the currently authenticated user, or 401 if not signed in. Lets the
+   * SPA determine login state on load.
+   */
+  router.get("/me", async (req, res) => {
+    if (!req.session || !req.session.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    try {
+      const user = await userRepository.getUserById(req.session.userId);
+      if (!user) {
+        // Session references a user that no longer exists — clear it.
+        req.session.destroy(() => {});
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+      return res.json({ user });
+    } catch (err) {
+      logger.error("/auth/me failed", err);
+      return res.status(500).json({ error: "Failed to load user" });
+    }
+  });
+
+  /**
+   * Sign out: destroy the local session and redirect to the Entra logout
+   * endpoint so the IdP SSO session is also ended (full logout).
+   */
+  router.post("/logout", (req, res) => {
+    const logoutUrl =
+      `${authority}/oauth2/v2.0/logout` +
+      `?post_logout_redirect_uri=${encodeURIComponent(FRONTEND_URL)}`;
+
+    if (!req.session) {
+      return res.json({ logoutUrl });
+    }
+    req.session.destroy((err) => {
+      if (err) {
+        logger.error("/auth/logout: session destroy failed", err);
+      }
+      res.clearCookie("connect.sid");
+      return res.json({ logoutUrl });
+    });
+  });
+
+  return router;
+}
+
+module.exports = createAuthRouter;

--- a/backend/app/routes/auth.test.js
+++ b/backend/app/routes/auth.test.js
@@ -1,0 +1,200 @@
+// Mock the MSAL/Entra config so the router can be imported without real env vars
+// or network access. Each function is a jest mock we can program per test.
+jest.mock("../../config/auth", () => ({
+  msalClient: {
+    getAuthCodeUrl: jest.fn(),
+    acquireTokenByCode: jest.fn(),
+  },
+  authority: "https://testtenant.ciamlogin.com/tenant-guid",
+  redirectUri: "http://localhost:3000/auth/callback",
+  scopes: ["openid", "profile", "email"],
+  cryptoProvider: {
+    generatePkceCodes: jest.fn(),
+    createNewGuid: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const { msalClient, cryptoProvider } = require("../../config/auth");
+const createAuthRouter = require("./auth");
+
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+
+describe("auth routes", () => {
+  let app;
+  let session;
+  let userRepository;
+
+  // Minimal fake session middleware: a plain object with a destroy() method,
+  // seeded per test so we can assert what the routes read and write.
+  function buildApp(initialSession = {}) {
+    session = { ...initialSession };
+    const application = express();
+    application.use((req, res, next) => {
+      req.session = session;
+      req.session.destroy = (cb) => {
+        session = {};
+        req.session = {};
+        if (cb) cb();
+      };
+      next();
+    });
+    application.use("/auth", createAuthRouter({ userRepository }));
+    return application;
+  }
+
+  beforeEach(() => {
+    userRepository = {
+      upsertByExternalId: jest.fn(),
+      getUserById: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("factory", () => {
+    it("throws when no userRepository is provided", () => {
+      expect(() => createAuthRouter({})).toThrow(
+        "createAuthRouter requires a userRepository"
+      );
+    });
+  });
+
+  describe("GET /auth/login", () => {
+    it("stores PKCE + state in the session and redirects to the auth URL", async () => {
+      cryptoProvider.generatePkceCodes.mockResolvedValue({
+        verifier: "verifier-1",
+        challenge: "challenge-1",
+      });
+      cryptoProvider.createNewGuid.mockReturnValue("state-1");
+      msalClient.getAuthCodeUrl.mockResolvedValue(
+        "https://testtenant.ciamlogin.com/authorize?x=1"
+      );
+
+      app = buildApp();
+      const res = await request(app).get("/auth/login");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(
+        "https://testtenant.ciamlogin.com/authorize?x=1"
+      );
+      expect(session.pkceVerifier).toBe("verifier-1");
+      expect(session.authState).toBe("state-1");
+
+      const [args] = msalClient.getAuthCodeUrl.mock.calls[0];
+      expect(args).toMatchObject({
+        codeChallenge: "challenge-1",
+        codeChallengeMethod: "S256",
+        state: "state-1",
+      });
+    });
+
+    it("returns 500 when building the auth URL fails", async () => {
+      cryptoProvider.generatePkceCodes.mockRejectedValue(new Error("boom"));
+
+      app = buildApp();
+      const res = await request(app).get("/auth/login");
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("GET /auth/callback", () => {
+    it("exchanges the code, upserts the user, sets the session, and redirects", async () => {
+      msalClient.acquireTokenByCode.mockResolvedValue({
+        idTokenClaims: {
+          sub: "entra-sub-1",
+          email: "alice@example.com",
+          name: "Alice",
+        },
+      });
+      userRepository.upsertByExternalId.mockResolvedValue({
+        user_id: "user-1",
+      });
+
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "state-1" });
+
+      expect(msalClient.acquireTokenByCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "auth-code",
+          codeVerifier: "verifier-1",
+        })
+      );
+      expect(userRepository.upsertByExternalId).toHaveBeenCalledWith({
+        externalId: "entra-sub-1",
+        email: "alice@example.com",
+        displayName: "Alice",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(FRONTEND_URL);
+      expect(session.userId).toBe("user-1");
+      expect(session.pkceVerifier).toBeUndefined();
+      expect(session.authState).toBeUndefined();
+    });
+
+    it("rejects a state mismatch with 400 and does not exchange the code", async () => {
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "wrong-state" });
+
+      expect(res.status).toBe(400);
+      expect(msalClient.acquireTokenByCode).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the authorization code is missing", async () => {
+      app = buildApp({ authState: "state-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ state: "state-1" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /auth/me", () => {
+    it("returns the current user when authenticated", async () => {
+      const user = { user_id: "user-1", email: "alice@example.com" };
+      userRepository.getUserById.mockResolvedValue(user);
+
+      app = buildApp({ userId: "user-1" });
+      const res = await request(app).get("/auth/me");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ user });
+    });
+
+    it("returns 401 when there is no session user", async () => {
+      app = buildApp();
+      const res = await request(app).get("/auth/me");
+
+      expect(res.status).toBe(401);
+      expect(userRepository.getUserById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /auth/logout", () => {
+    it("destroys the session and returns the Entra logout URL", async () => {
+      app = buildApp({ userId: "user-1" });
+      const res = await request(app).post("/auth/logout");
+
+      expect(res.status).toBe(200);
+      expect(res.body.logoutUrl).toContain(
+        "https://testtenant.ciamlogin.com/tenant-guid/oauth2/v2.0/logout"
+      );
+      expect(res.body.logoutUrl).toContain(encodeURIComponent(FRONTEND_URL));
+    });
+  });
+});

--- a/backend/app/routes/auth.test.js
+++ b/backend/app/routes/auth.test.js
@@ -162,6 +162,20 @@ describe("auth routes", () => {
 
       expect(res.status).toBe(400);
     });
+
+    it("returns 400 and does not upsert when the ID token has no email claim", async () => {
+      msalClient.acquireTokenByCode.mockResolvedValue({
+        idTokenClaims: { sub: "entra-sub-1", name: "Alice" },
+      });
+
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "state-1" });
+
+      expect(res.status).toBe(400);
+      expect(userRepository.upsertByExternalId).not.toHaveBeenCalled();
+    });
   });
 
   describe("GET /auth/me", () => {

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -1,0 +1,42 @@
+/**
+ * Trip routes — the proof-of-chain protected resource.
+ *
+ * Every route is behind `requireAuth`, so `req.userId` is always the signed-in
+ * user. All data access is scoped by that id via the TripRepository, which is
+ * the authorization boundary: a user can only ever see their own trips.
+ *
+ * Exported as a factory so the TripRepository can be injected (keeps the routes
+ * unit-testable with a mock repository).
+ */
+
+const express = require("express");
+const requireAuth = require("../middleware/requireAuth");
+const logger = require("../utils/logger");
+
+/**
+ * @param {object} deps
+ * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @returns {import('express').Router}
+ */
+function createTripsRouter({ tripRepository }) {
+  if (!tripRepository) {
+    throw new Error("createTripsRouter requires a tripRepository");
+  }
+
+  const router = express.Router();
+
+  // List the signed-in user's trips, newest first.
+  router.get("/", requireAuth, async (req, res) => {
+    try {
+      const trips = await tripRepository.getTripsByUserId(req.userId);
+      return res.json({ trips });
+    } catch (err) {
+      logger.error("GET /api/trips failed", err);
+      return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createTripsRouter;

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -1,0 +1,66 @@
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const createTripsRouter = require("./trips");
+
+describe("trips routes", () => {
+  let tripRepository;
+
+  // Fake session middleware so we can toggle authentication per test.
+  function buildApp(userId) {
+    tripRepository = {
+      getTripsByUserId: jest.fn(),
+    };
+    const app = express();
+    app.use((req, res, next) => {
+      req.session = userId ? { userId } : {};
+      next();
+    });
+    app.use("/api/trips", createTripsRouter({ tripRepository }));
+    return app;
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws when no tripRepository is provided", () => {
+    expect(() => createTripsRouter({})).toThrow(
+      "createTripsRouter requires a tripRepository"
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const app = buildApp(null);
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(401);
+    expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+  });
+
+  it("returns the authenticated user's trips scoped by user id", async () => {
+    const trips = [{ trip_id: "t1", user_id: "user-1" }];
+    const app = buildApp("user-1");
+    tripRepository.getTripsByUserId.mockResolvedValue(trips);
+
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ trips });
+    expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
+  });
+
+  it("returns 500 when the repository throws", async () => {
+    const app = buildApp("user-1");
+    tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/config/auth.js
+++ b/backend/config/auth.js
@@ -1,0 +1,101 @@
+/**
+ * Microsoft Entra External ID (CIAM) authentication configuration.
+ *
+ * Builds a single shared MSAL confidential-client application used by the auth
+ * routes to run the OAuth 2.0 authorization-code + PKCE flow. The app registration
+ * platform is "Web" and authenticates with a client secret. Configuration comes
+ * from the ENTRA_* environment variables (see .devcontainer/devcontainer.env.example).
+ *
+ * Exposes:
+ *   - msalClient:  ConfidentialClientApplication for getAuthCodeUrl / acquireTokenByCode.
+ *   - authority:   the tenant authority base URL.
+ *   - redirectUri: the registered callback URL.
+ *   - scopes:      the default OIDC scopes requested at login.
+ *   - cryptoProvider: MSAL CryptoProvider for generating PKCE codes and state.
+ *   - getJwks:     lazily-created remote JWKS for future bearer-token verification.
+ */
+
+const {
+  ConfidentialClientApplication,
+  CryptoProvider,
+} = require("@azure/msal-node");
+const { createRemoteJWKSet } = require("jose");
+const logger = require("../app/utils/logger");
+
+const {
+  ENTRA_TENANT_SUBDOMAIN,
+  ENTRA_TENANT_ID,
+  ENTRA_CLIENT_ID,
+  ENTRA_CLIENT_SECRET,
+  ENTRA_REDIRECT_URI,
+} = process.env;
+
+// Fail fast at startup if the auth environment is not configured. Without these,
+// every login attempt would fail with a less obvious error deep inside MSAL.
+const missing = [
+  ["ENTRA_TENANT_SUBDOMAIN", ENTRA_TENANT_SUBDOMAIN],
+  ["ENTRA_TENANT_ID", ENTRA_TENANT_ID],
+  ["ENTRA_CLIENT_ID", ENTRA_CLIENT_ID],
+  ["ENTRA_CLIENT_SECRET", ENTRA_CLIENT_SECRET],
+  ["ENTRA_REDIRECT_URI", ENTRA_REDIRECT_URI],
+]
+  .filter(([, value]) => !value)
+  .map(([name]) => name);
+
+if (missing.length > 0) {
+  throw new Error(
+    `Missing required Entra environment variables: ${missing.join(", ")}`
+  );
+}
+
+// CIAM (Entra External ID) authority. Accept either the bare subdomain
+// ("jauntdetour") or the full domain ("jauntdetour.onmicrosoft.com") and derive
+// the ciamlogin host from the first label. The tenant ID must be in the
+// authority path: the CIAM discovery document's `issuer` uses the tenant-GUID
+// host, so MSAL's authority-alias validation rejects a tenant-less authority.
+const subdomain = ENTRA_TENANT_SUBDOMAIN.split(".")[0];
+const authorityHost = `${subdomain}.ciamlogin.com`;
+const authority = `https://${authorityHost}/${ENTRA_TENANT_ID}`;
+
+// OIDC scopes: openid for authentication, profile + email to populate the ID
+// token claims (name, email) we persist to the users table.
+const scopes = ["openid", "profile", "email"];
+
+const msalClient = new ConfidentialClientApplication({
+  auth: {
+    clientId: ENTRA_CLIENT_ID,
+    clientSecret: ENTRA_CLIENT_SECRET,
+    authority,
+    knownAuthorities: [authorityHost],
+  },
+  system: {
+    loggerOptions: {
+      loggerCallback(level, message) {
+        logger.info(`MSAL: ${message}`);
+      },
+      piiLoggingEnabled: false,
+      logLevel: 3, // Warning
+    },
+  },
+});
+
+const cryptoProvider = new CryptoProvider();
+
+// Remote JWKS for verifying bearer tokens (e.g. a future API-to-API path).
+// Created lazily so importing this module never triggers a network call.
+let jwks;
+function getJwks() {
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(`${authority}/discovery/v2.0/keys`));
+  }
+  return jwks;
+}
+
+module.exports = {
+  msalClient,
+  authority,
+  redirectUri: ENTRA_REDIRECT_URI,
+  scopes,
+  cryptoProvider,
+  getJwks,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,23 +6,59 @@ var bodyParser = require("body-parser");
 const routeAPI = require("./app/modules/routeAPI");
 const placesAPI = require("./app/modules/placesAPI");
 
+const db = require("./app/db/pool");
+const UserRepository = require("./app/repositories/UserRepository");
+const TripRepository = require("./app/repositories/TripRepository");
+const createAuthRouter = require("./app/routes/auth");
+const createTripsRouter = require("./app/routes/trips");
+
+const IS_PROD = process.env.NODE_ENV === "production";
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+const SESSION_SECRET = process.env.SESSION_SECRET;
+
+if (!SESSION_SECRET) {
+  throw new Error("SESSION_SECRET environment variable is required");
+}
+
 var app = express();
+
+// Behind a reverse proxy in production (e.g. Azure), trust the first proxy so
+// secure cookies work over the terminated TLS connection.
+if (IS_PROD) {
+  app.set("trust proxy", 1);
+}
+
 app.use(cookieParser());
 
 // This body parser is needed to access the body of a request cleanly
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 
-app.use(cors());
+// Explicit origin + credentials so the browser sends/accepts the session cookie
+// on cross-origin XHR from the frontend dev server. A wildcard origin cannot be
+// combined with credentials.
+app.use(cors({ origin: FRONTEND_URL, credentials: true }));
 
 app.use(
   session({
-    secret: "temporarySecretKey",
+    secret: SESSION_SECRET,
     resave: false,
-    saveUninitialized: true,
-    cookie: { maxAge: 100000000 },
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: IS_PROD,
+      maxAge: 1000 * 60 * 60 * 24, // 24 hours
+    },
   })
 );
+
+// Compose the data-access layer once and inject it into the routers.
+const userRepository = new UserRepository(db);
+const tripRepository = new TripRepository(db);
+
+app.use("/auth", createAuthRouter({ userRepository }));
+app.use("/api/trips", createTripsRouter({ tripRepository }));
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/backend/index.js
+++ b/backend/index.js
@@ -46,7 +46,12 @@ app.use(
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      sameSite: "lax",
+      // Frontend and backend are cross-site in production (separate
+      // *.azurewebsites.net hosts, which the Public Suffix List treats as
+      // distinct sites), so the cookie must be SameSite=None to be sent on
+      // cross-site XHR. SameSite=None requires Secure. Locally both run on
+      // localhost (same site), where Lax works and avoids needing HTTPS.
+      sameSite: IS_PROD ? "none" : "lax",
       secure: IS_PROD,
       maxAge: 1000 * 60 * 60 * 24, // 24 hours
     },

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
+        "@azure/msal-node": "^5.3.1",
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cookie-parser": "1.4.7",
@@ -17,6 +18,7 @@
         "express": "5.1.0",
         "express-session": "1.18.2",
         "https": "1.0.0",
+        "jose": "^6.2.3",
         "pg": "8.13.1",
         "polyline-encoded": "0.0.9"
       },
@@ -28,7 +30,30 @@
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.2.0",
         "nodemon": "3.1.10",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1251,6 +1276,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1287,6 +1325,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2006,6 +2054,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2267,6 +2322,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2602,6 +2663,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2663,6 +2734,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2865,6 +2943,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2910,6 +2999,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3871,6 +3969,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4028,16 +4133,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4062,6 +4167,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4473,9 +4596,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5878,6 +6001,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5952,6 +6084,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6009,11 +6184,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6089,6 +6306,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6101,6 +6328,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -6990,12 +7230,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7390,7 +7631,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7518,14 +7758,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7537,13 +7777,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7913,6 +8153,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@azure/msal-node": "^5.3.1",
     "axios": "1.10.0",
     "body-parser": "2.2.0",
     "cookie-parser": "1.4.7",
@@ -29,6 +30,7 @@
     "express": "5.1.0",
     "express-session": "1.18.2",
     "https": "1.0.0",
+    "jose": "^6.2.3",
     "pg": "8.13.1",
     "polyline-encoded": "0.0.9"
   },
@@ -40,6 +42,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.2.0",
     "nodemon": "3.1.10",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "supertest": "^7.2.2"
   }
 }

--- a/docs/authentication/implementation-guide.md
+++ b/docs/authentication/implementation-guide.md
@@ -27,13 +27,18 @@ We use **OpenID Connect / authorization-code + PKCE**. Most teams use **MSAL** (
 
 ```bash
 ENTRA_TENANT_SUBDOMAIN=jauntdetour           # <subdomain>.ciamlogin.com
+ENTRA_TENANT_ID=8edf3fc2-4cde-4c70-9cae-f95870994488  # tenant (directory) GUID
 ENTRA_CLIENT_ID=00001111-aaaa-2222-bbbb-3333cccc4444
 ENTRA_CLIENT_SECRET=                          # from Key Vault in production
 ENTRA_REDIRECT_URI=https://app.jauntdetour.com/auth/callback
 ```
 
 Authority URL format for external tenants:
-`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/`
+`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/<ENTRA_TENANT_ID>`
+
+The tenant ID must be in the authority path. The CIAM discovery document's
+`issuer` uses the tenant-GUID host, so a tenant-less authority fails MSAL's
+authority-alias validation with `endpoints_resolution_error`.
 
 ---
 
@@ -43,7 +48,7 @@ Authority URL format for external tenants:
 const { ConfidentialClientApplication } = require("@azure/msal-node");
 require("dotenv").config();
 
-const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/`;
+const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/${process.env.ENTRA_TENANT_ID}`;
 
 const msalClient = new ConfidentialClientApplication({
   auth: {
@@ -118,7 +123,7 @@ For APIs called with a bearer access token, validate it against the tenant's JWK
 const { createRemoteJWKSet, jwtVerify } = require("jose");
 const { authority } = require("../config/auth");
 
-const JWKS = createRemoteJWKSet(new URL(`${authority}discovery/v2.0/keys`));
+const JWKS = createRemoteJWKSet(new URL(`${authority}/discovery/v2.0/keys`));
 
 async function requireAuth(req, res, next) {
   try {

--- a/docs/authentication/implementation-guide.md
+++ b/docs/authentication/implementation-guide.md
@@ -24,6 +24,7 @@ We use **OpenID Connect / authorization-code + PKCE**. Most teams use **MSAL** (
 ## 1. Configuration
 
 `backend/.env.example`:
+
 ```bash
 ENTRA_TENANT_SUBDOMAIN=jauntdetour           # <subdomain>.ciamlogin.com
 ENTRA_CLIENT_ID=00001111-aaaa-2222-bbbb-3333cccc4444
@@ -39,15 +40,15 @@ Authority URL format for external tenants:
 ## 2. MSAL client — `backend/config/auth.js`
 
 ```javascript
-const { ConfidentialClientApplication } = require('@azure/msal-node');
-require('dotenv').config();
+const { ConfidentialClientApplication } = require("@azure/msal-node");
+require("dotenv").config();
 
 const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/`;
 
 const msalClient = new ConfidentialClientApplication({
   auth: {
     clientId: process.env.ENTRA_CLIENT_ID,
-    clientSecret: process.env.ENTRA_CLIENT_SECRET,  // from Key Vault in prod
+    clientSecret: process.env.ENTRA_CLIENT_SECRET, // from Key Vault in prod
     authority,
     knownAuthorities: [`${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com`],
   },
@@ -61,15 +62,17 @@ module.exports = { msalClient, authority };
 ## 3. Login + callback routes
 
 ```javascript
-const express = require('express');
-const { msalClient } = require('../config/auth');
-const User = require('../app/models/User');
+const express = require("express");
+const { msalClient } = require("../config/auth");
+const UserRepository = require("../app/repositories/UserRepository");
+const db = require("../app/db/pool");
 
+const userRepository = new UserRepository(db);
 const router = express.Router();
-const SCOPES = ['openid', 'profile', 'email'];
+const SCOPES = ["openid", "profile", "email"];
 
 // (1) Redirect the browser to the hosted Entra login flow.
-router.get('/auth/login', async (req, res) => {
+router.get("/auth/login", async (req, res) => {
   const url = await msalClient.getAuthCodeUrl({
     scopes: SCOPES,
     redirectUri: process.env.ENTRA_REDIRECT_URI,
@@ -78,7 +81,7 @@ router.get('/auth/login', async (req, res) => {
 });
 
 // (3-5) Exchange the code, verify the token, upsert the user.
-router.get('/auth/callback', async (req, res, next) => {
+router.get("/auth/callback", async (req, res, next) => {
   try {
     const result = await msalClient.acquireTokenByCode({
       code: req.query.code,
@@ -89,14 +92,14 @@ router.get('/auth/callback', async (req, res, next) => {
     // MSAL validates the token signature/issuer/audience for us.
     const { sub, email, name } = result.idTokenClaims;
 
-    const user = await User.upsertByExternalId({
-      externalId: sub,       // stable subject claim → users.external_id
+    const user = await userRepository.upsertByExternalId({
+      externalId: sub, // stable subject claim → users.external_id
       email,
       displayName: name,
     });
 
-    req.session.userId = user.user_id;  // or issue your own signed JWT
-    res.redirect('/');
+    req.session.userId = user.user_id; // or issue your own signed JWT
+    res.redirect("/");
   } catch (err) {
     next(err);
   }
@@ -112,30 +115,28 @@ module.exports = router;
 For APIs called with a bearer access token, validate it against the tenant's JWKS. `jose` keeps this small:
 
 ```javascript
-const { createRemoteJWKSet, jwtVerify } = require('jose');
-const { authority } = require('../config/auth');
+const { createRemoteJWKSet, jwtVerify } = require("jose");
+const { authority } = require("../config/auth");
 
-const JWKS = createRemoteJWKSet(
-  new URL(`${authority}discovery/v2.0/keys`)
-);
+const JWKS = createRemoteJWKSet(new URL(`${authority}discovery/v2.0/keys`));
 
 async function requireAuth(req, res, next) {
   try {
-    const token = (req.headers.authorization || '').replace('Bearer ', '');
+    const token = (req.headers.authorization || "").replace("Bearer ", "");
     const { payload } = await jwtVerify(token, JWKS, {
       audience: process.env.ENTRA_CLIENT_ID,
     });
 
-    const user = await User.upsertByExternalId({
+    const user = await userRepository.upsertByExternalId({
       externalId: payload.sub,
       email: payload.email,
       displayName: payload.name,
     });
 
-    req.userId = user.user_id;  // the authorization boundary
+    req.userId = user.user_id; // the authorization boundary
     next();
   } catch {
-    res.status(401).json({ error: 'Unauthorized' });
+    res.status(401).json({ error: "Unauthorized" });
   }
 }
 
@@ -145,8 +146,8 @@ module.exports = requireAuth;
 Usage — every data route is scoped to `req.userId`:
 
 ```javascript
-router.get('/api/trips', requireAuth, async (req, res) => {
-  const trips = await Trip.findByUserId(req.userId);  // WHERE user_id = $1
+router.get("/api/trips", requireAuth, async (req, res) => {
+  const trips = await tripRepository.getTripsByUserId(req.userId); // WHERE user_id = $1
   res.json(trips);
 });
 ```

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Header from "./header/Header";
+import AuthButton from "./header/AuthButton";
 import FooterMenu from "./footer-menu/FooterMenu";
 import MapContainer from "./MapContainer";
 import Sidebar from "./sidebar/Sidebar";
@@ -9,6 +10,11 @@ class Main extends React.Component {
   render() {
     return (
       <div className="app-container">
+        <AuthButton
+          user={this.props.user}
+          setUser={this.props.setUser}
+          clearUser={this.props.clearUser}
+        ></AuthButton>
         <Header
           origin={this.props.origin}
           destination={this.props.destination}
@@ -17,6 +23,9 @@ class Main extends React.Component {
           setRoute={this.props.setRoute}
           setTripSummary={this.props.setTripSummary}
           clearAll={this.props.clearAll}
+          user={this.props.user}
+          setUser={this.props.setUser}
+          clearUser={this.props.clearUser}
         ></Header>
         <Sidebar
           origin={this.props.origin}
@@ -124,6 +133,9 @@ Main.propTypes = {
   getDetourForm: PropTypes.func,
   clearAll: PropTypes.func,
   clearDetourOptions: PropTypes.func,
+  user: PropTypes.object,
+  setUser: PropTypes.func,
+  clearUser: PropTypes.func,
 };
 
 export default Main;

--- a/frontend/src/components/header/AuthButton.jsx
+++ b/frontend/src/components/header/AuthButton.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import PropTypes from "prop-types";
+import AuthRequester from "../../scripts/AuthRequester";
+
+/**
+ * AuthButton — sign-in / sign-out control.
+ *
+ * On mount it asks the backend who the current user is (via the session cookie)
+ * and stores the result in Redux. When signed out it shows "Sign in"; when
+ * signed in it shows the display name and "Sign out".
+ */
+class AuthButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.auth = new AuthRequester();
+    this.handleLogin = this.handleLogin.bind(this);
+    this.handleLogout = this.handleLogout.bind(this);
+  }
+
+  componentDidMount() {
+    // Resolve login state from the backend session on first render.
+    this.auth.getCurrentUser().then((user) => {
+      if (user) {
+        this.props.setUser(user);
+      }
+    });
+  }
+
+  handleLogin() {
+    this.auth.login();
+  }
+
+  handleLogout() {
+    this.props.clearUser();
+    this.auth.logout();
+  }
+
+  render() {
+    const user = this.props.user;
+
+    if (user) {
+      const name = user.display_name || user.email;
+      return (
+        <div className="auth-button auth-button--signed-in">
+          <span className="auth-button__name">{name}</span>
+          <button type="button" onClick={this.handleLogout}>
+            Sign out
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="auth-button auth-button--signed-out">
+        <button type="button" onClick={this.handleLogin}>
+          Sign in
+        </button>
+      </div>
+    );
+  }
+}
+
+AuthButton.propTypes = {
+  user: PropTypes.object,
+  setUser: PropTypes.func.isRequired,
+  clearUser: PropTypes.func.isRequired,
+};
+
+export default AuthButton;

--- a/frontend/src/components/header/AuthButton.jsx
+++ b/frontend/src/components/header/AuthButton.jsx
@@ -18,10 +18,14 @@ class AuthButton extends React.Component {
   }
 
   componentDidMount() {
-    // Resolve login state from the backend session on first render.
+    // Resolve login state from the backend session on first render, syncing
+    // Redux to the backend's truth: set the user when signed in, clear it
+    // otherwise (getCurrentUser resolves to null on a 401 or any error).
     this.auth.getCurrentUser().then((user) => {
       if (user) {
         this.props.setUser(user);
+      } else {
+        this.props.clearUser();
       }
     });
   }

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,6 +1,11 @@
 var config = {
   NODE_ENV: process.env.NODE_ENV,
   GOOGLE_API_KEY: process.env.REACT_APP_GOOGLE_API_KEY,
+  BACKEND_URL:
+    process.env.REACT_APP_BACKEND_URL ||
+    (process.env.NODE_ENV === "development"
+      ? "http://localhost:3000"
+      : "https://jauntdetour-backend.azurewebsites.net"),
 };
 
 module.exports = config;

--- a/frontend/src/containers/MainContainer.js
+++ b/frontend/src/containers/MainContainer.js
@@ -103,6 +103,17 @@ let matchDispatchToProps = (dispatch) => {
       dispatch({
         type: "CLEAR_ALL",
       }),
+    setUser: (user) =>
+      dispatch({
+        type: "SET_USER",
+        data: {
+          user: user,
+        },
+      }),
+    clearUser: () =>
+      dispatch({
+        type: "CLEAR_USER",
+      }),
   };
 };
 

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -1,4 +1,5 @@
 let initialState = {
+  user: null,
   origin: "",
   destination: "",
   detourType: "Hike",
@@ -19,6 +20,16 @@ let initialState = {
 
 const mainReducer = (state = initialState, action) => {
   switch (action.type) {
+    case "SET_USER":
+      return {
+        ...state,
+        user: action.data.user,
+      };
+    case "CLEAR_USER":
+      return {
+        ...state,
+        user: null,
+      };
     case "SET_ORIGIN":
       return {
         ...state,
@@ -103,6 +114,7 @@ const mainReducer = (state = initialState, action) => {
       };
     case "CLEAR_ALL":
       return {
+        user: state.user,
         origin: "",
         destination: "",
         detourType: "Hike",

--- a/frontend/src/scripts/AuthRequester.js
+++ b/frontend/src/scripts/AuthRequester.js
@@ -1,0 +1,65 @@
+import axios from "axios";
+import config from "../config/config.js";
+import log from "../utils/logger";
+
+/**
+ * AuthRequester — talks to the backend auth endpoints.
+ *
+ * The backend owns the OAuth flow and issues an http-only session cookie, so
+ * every call must send credentials. Login is a full-page redirect (not XHR)
+ * because it navigates to the Entra hosted pages.
+ */
+export default class AuthRequester {
+  getUrlBase() {
+    return config.BACKEND_URL;
+  }
+
+  /**
+   * Start sign-in by navigating the browser to the backend login endpoint,
+   * which redirects on to Entra.
+   */
+  login() {
+    window.location.assign(this.getUrlBase() + "/auth/login");
+  }
+
+  /**
+   * Fetch the currently authenticated user. Resolves to the user object, or
+   * null when not signed in (the backend returns 401).
+   *
+   * @returns {Promise<object|null>}
+   */
+  getCurrentUser() {
+    return axios
+      .get(this.getUrlBase() + "/auth/me", { withCredentials: true })
+      .then((response) => response.data.user)
+      .catch((error) => {
+        if (error.response && error.response.status === 401) {
+          return null;
+        }
+        log.error("Unable to fetch current user:", error);
+        return null;
+      });
+  }
+
+  /**
+   * Sign out: clear the backend session, then navigate to the Entra logout URL
+   * returned by the server to end the IdP SSO session.
+   *
+   * @returns {Promise<void>}
+   */
+  logout() {
+    return axios
+      .post(this.getUrlBase() + "/auth/logout", {}, { withCredentials: true })
+      .then((response) => {
+        const logoutUrl = response.data && response.data.logoutUrl;
+        if (logoutUrl) {
+          window.location.assign(logoutUrl);
+        } else {
+          window.location.reload();
+        }
+      })
+      .catch((error) => {
+        log.error("Logout failed:", error);
+      });
+  }
+}

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -28,6 +28,42 @@
   flex-direction: column;
 }
 
+/* Sign in / sign out control, pinned top-right above all layouts. */
+.auth-button {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-button button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #1a73e8;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.auth-button button:hover {
+  background-color: #1666c9;
+}
+
+.auth-button__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  background: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+}
+
 /* Desktop: sidebar is visible, so add left margin to avoid overlap */
 @media only screen and (min-width: 1025px) {
   .app-container {


### PR DESCRIPTION
# Add user account creation and login via Microsoft Entra External ID

## Summary

Implements end-to-end user authentication using the provisioned Microsoft Entra
External ID (CIAM) tenant. Uses a backend-driven confidential-client flow
(MSAL Node, OAuth 2.0 authorization-code + PKCE) with a server-side session,
proves the chain with one `user_id`-scoped protected route, and adds a minimal
sign-in / sign-out UI. Email/password only this pass; social login is deferred
and additive later.

## Motivation

The app had no concept of a user — the session used a hardcoded secret and CORS
was wide open. This change establishes real identity: users sign up/in through
the Entra hosted pages, the backend exchanges the auth code for tokens, upserts
the user into Postgres keyed by the Entra `sub` claim, and issues an http-only
session cookie. Every data route can now be scoped to its owner via `req.userId`.

## Changes

### Backend — auth foundation
- `config/auth.js`: MSAL `ConfidentialClientApplication`, PKCE `CryptoProvider`,
  and a lazy JWKS. Builds the CIAM authority as
  `https://<subdomain>.ciamlogin.com/<tenantId>` and validates required env at
  startup.
- `app/routes/auth.js`: `GET /auth/login`, `GET /auth/callback`, `GET /auth/me`,
  `POST /auth/logout` (full Entra logout). Injectable factory for testability.
- `app/middleware/requireAuth.js`: promotes `req.session.userId` to `req.userId`
  or returns `401`.
- `app/repositories/UserRepository.js`: new `upsertByExternalId` (create on first
  login, refresh email/display name + `last_login` on subsequent logins).
- `index.js`: `SESSION_SECRET` from env, `saveUninitialized: false`,
  `httpOnly` / `sameSite` / `secure` cookie, CORS locked to `FRONTEND_URL` with
  `credentials: true`, repositories composed and routes mounted.

### Backend — protected route (proof of chain)
- `app/routes/trips.js`: `GET /api/trips` behind `requireAuth`, scoped to the
  signed-in user via `TripRepository.getTripsByUserId`.

### Frontend — sign-in / sign-out UI
- `components/header/AuthButton.jsx`: resolves login state on load via
  `GET /auth/me`, shows **Sign in** when logged out and the display name +
  **Sign out** when logged in. Pinned top-right so it renders on all viewports.
- `scripts/AuthRequester.js`: `withCredentials` calls to the auth endpoints.
- Redux `user` state + `setUser` / `clearUser` actions; `config.js` gains
  `BACKEND_URL`.

### Config, docs, tooling
- `.devcontainer/devcontainer.env.example`: `ENTRA_*` (incl. `ENTRA_TENANT_ID`),
  `SESSION_SECRET`, `FRONTEND_URL`.
- `docs/authentication/implementation-guide.md`: reconciled to the repository API.
- `.gitattributes`: force LF on `*.sh` and `.husky/*` (fixes a CRLF pre-commit
  hook failure).

## Testing

- Backend: **93 tests passing** (74 existing + 19 new — `upsertByExternalId`,
  `requireAuth`, auth routes, trips route). Lint clean.
- Frontend: **45 tests passing**.
- Manual E2E verified: created an Entra account, logged in, logged out, logged
  back in; the account appears in the Entra admin center and a `users` row is
  persisted locally with a refreshed `last_login`; `GET /api/trips` returns `401`
  unauthenticated and the user's trips when signed in.

## Implementation notes

- **CIAM authority requires the tenant ID in the path.** The External ID
  discovery document's `issuer` uses the tenant-GUID host, so MSAL rejects a
  bare `https://<subdomain>.ciamlogin.com/` authority with
  `endpoints_resolution_error`. `ENTRA_TENANT_ID` is now required.
- `localhost:3000` and `localhost:3001` are the same site, so a `sameSite=lax`
  cookie is sent on XHR; CORS still needs an explicit origin + `credentials`, and
  axios uses `withCredentials`.

## Out of scope / follow-ups

- Gate trip/detour writes behind `requireAuth` so saved trips belong to the user.
- Full trip/detour CRUD and frontend persistence.
- Google/social login (enable in the Entra user flow — additive).
- Production hardening: separate prod tenant, secrets in Azure Key Vault, prod
  redirect URIs / CORS origins.

## Reviewer setup

Add to `.devcontainer/devcontainer.env`, then rebuild the container:

```
ENTRA_TENANT_SUBDOMAIN=<subdomain>
ENTRA_TENANT_ID=<tenant directory GUID>
ENTRA_CLIENT_ID=<app registration client id>
ENTRA_CLIENT_SECRET=<app registration client secret>
ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
SESSION_SECRET=<openssl rand -base64 32>
FRONTEND_URL=http://localhost:3001
```