### PR TITLE
51 user save trip + 52 view saved trips

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,14 @@ trips.
 - Frontend: `cd frontend && CI=true npm test`.
 - Keep the suite green and add tests for new backend routes/repos.
 
+## Pull Requests
+
+- When asked for a PR description, provide a summary of the change, what files were modified, how to test the
+  changes, and any other relevant information or assumtpions. Provide all of this in markdown to be copy and pasted.
+- Once a PR is active, the user will review the changes with you based on feedback from a Github Copilot agent.
+  For each comment, do not assume the comment is correct, but investigate if the feedback is accurate and within
+  scope of this PR. If it is, work with the user to make changes based on the feedback.
+
 ## Known constraints / follow-ups
 
 - `@azure/msal-node` requires **Node >= 20** (dev container is 20). CI still uses

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,73 @@
+# JauntDetour — Copilot Instructions
+
+Road-trip planner: React frontend + Node/Express backend + PostgreSQL, using
+Google Maps APIs to build routes and find detours, with user accounts and saved
+trips.
+
+## Architecture at a glance
+
+- **Frontend**: React 19 (CRA) + Redux, runs on `:3001`. Entry: `frontend/src/index.js`.
+- **Backend**: Node/Express (CommonJS), runs on `:3000`. Entry: `backend/index.js`.
+- **Database**: PostgreSQL (`users → trips → detours`). Local DB via the dev
+  container; Azure Database for PostgreSQL in production. Schema:
+  `docs/database/schema.sql`.
+- **Dev**: runs inside a dev container; env comes from `.devcontainer/devcontainer.env`
+  (see `.env.example` / `.devcontainer/devcontainer.env.example`). `npm run dev`
+  starts both apps.
+
+## High-level tech decisions
+
+- **UI library: Fluent 2 (`@fluentui/react-components`).** Build NEW frontend UI
+  (dialogs, drawers, toasts, buttons, inputs) with Fluent. The app root is wrapped
+  in `<FluentProvider theme={webLightTheme}>` (`frontend/src/index.js`). The
+  original planning UI is legacy custom CSS/Bootstrap-ish markup — don't expand it;
+  prefer Fluent for new work.
+- **Auth: Microsoft Entra External ID (CIAM)**, backend-driven confidential-client
+  OAuth (MSAL Node, authorization-code + PKCE) with a server-side session cookie.
+  - `requireAuth` middleware sets `req.userId` — the **authorization boundary**.
+    Never trust a `userId` from the client; always use `req.userId`.
+  - The MSAL authority **must include the tenant ID in the path**
+    (`https://<subdomain>.ciamlogin.com/<tenantId>`) or CIAM discovery fails with
+    `endpoints_resolution_error`. Config: `backend/config/auth.js`.
+  - Env: `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_TENANT_ID`, `ENTRA_CLIENT_ID`,
+    `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI`, `SESSION_SECRET`, `FRONTEND_URL`.
+- **Cookies/CORS**: session cookie is `httpOnly`; `sameSite="none"` + `secure` in
+  prod (frontend/backend are cross-site on `*.azurewebsites.net`), `lax` in dev.
+  CORS uses an explicit origin (`FRONTEND_URL`) + `credentials: true`; frontend
+  axios calls that need auth use `withCredentials: true`.
+- **Data access: repository pattern** (`backend/app/repositories/*Repository.js`).
+  A `pg` pool (or a transaction client) is injected via the constructor. All SQL
+  is parameterized. Every query is scoped by `user_id`.
+- **Transactions**: use `db.getClient()` and construct client-scoped repositories
+  (`new TripRepository(client)`) inside `BEGIN`/`COMMIT`/`ROLLBACK` (see the
+  `POST /api/trips` handler in `backend/app/routes/trips.js`).
+- **Routes are injectable factories** (`createXRouter({ ...deps })`) so they can be
+  unit-tested with mock repositories.
+- **Redux state persists to `sessionStorage`** (`frontend/src/index.js`) so an
+  in-progress trip survives the full-page login redirect. `user` is NOT persisted —
+  auth state is always re-resolved from `GET /auth/me`.
+- **Frontend requesters** (`frontend/src/scripts/*Requester.js`) wrap axios, build
+  URLs from `config.BACKEND_URL`, and pass `withCredentials: true` for authed calls.
+
+## Conventions
+
+- Backend is CommonJS (`require`/`module.exports`), `var`/`const` mixed in older
+  files — match the file you're editing.
+- Prettier + ESLint enforced via husky `pre-commit` + lint-staged. **Git hooks and
+  shell scripts must be LF** (see `.gitattributes`) or the hook breaks on CRLF.
+- Don't commit secrets; real values live in the gitignored `devcontainer.env`.
+
+## Testing
+
+- Backend: Jest. Repos tested with a mock pool (`{ query: jest.fn() }`, assert SQL
+  substrings + params); routes tested with `supertest` + mocked repos/db. Run
+  `cd backend && npm test`.
+- Frontend: `cd frontend && CI=true npm test`.
+- Keep the suite green and add tests for new backend routes/repos.
+
+## Known constraints / follow-ups
+
+- `@azure/msal-node` requires **Node >= 20** (dev container is 20). CI still uses
+  Node 18 — bump tracked separately.
+- Sessions use the default in-memory `MemoryStore` — fine for a single instance;
+  needs a persistent store (e.g. `connect-pg-simple`) before scaling out.

--- a/backend/app/repositories/TripRepository.js
+++ b/backend/app/repositories/TripRepository.js
@@ -135,17 +135,62 @@ class TripRepository {
   }
 
   /**
-   * List a user's trips, newest first. Optionally filter by status.
+   * List a user's trips, newest first. Optionally filter by status and
+   * paginate with limit/offset.
    *
    * @param {string} userId - Owning user's UUID (authorization scope).
    * @param {object} [options]
    * @param {string} [options.status] - Filter to a single status value.
+   * @param {number} [options.limit] - Max rows to return (pagination).
+   * @param {number} [options.offset] - Rows to skip (pagination).
    * @returns {Promise<object[]>} Array of trip rows (empty if none).
    */
-  async getTripsByUserId(userId, { status } = {}) {
+  async getTripsByUserId(userId, { status, limit, offset } = {}) {
     const params = [userId];
+    let position = 1;
     let text = `
       SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE user_id = $1
+    `;
+    if (status !== undefined) {
+      position += 1;
+      params.push(status);
+      text += ` AND status = $${position}`;
+    }
+    text += ` ORDER BY created_at DESC`;
+    if (limit !== undefined) {
+      position += 1;
+      params.push(limit);
+      text += ` LIMIT $${position}`;
+    }
+    if (offset !== undefined) {
+      position += 1;
+      params.push(offset);
+      text += ` OFFSET $${position}`;
+    }
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows;
+    } catch (err) {
+      logger.error("getTripsByUserId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Count a user's trips (for pagination). Optionally filter by status.
+   *
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} [options]
+   * @param {string} [options.status] - Filter to a single status value.
+   * @returns {Promise<number>} Total matching trips.
+   */
+  async countTripsByUserId(userId, { status } = {}) {
+    const params = [userId];
+    let text = `
+      SELECT COUNT(*)::int AS total
       FROM trips
       WHERE user_id = $1
     `;
@@ -153,13 +198,12 @@ class TripRepository {
       params.push(status);
       text += ` AND status = $2`;
     }
-    text += ` ORDER BY created_at DESC`;
 
     try {
       const result = await this.pool.query(text, params);
-      return result.rows;
+      return result.rows[0].total;
     } catch (err) {
-      logger.error("getTripsByUserId failed", err);
+      logger.error("countTripsByUserId failed", err);
       throw err;
     }
   }

--- a/backend/app/repositories/TripRepository.test.js
+++ b/backend/app/repositories/TripRepository.test.js
@@ -182,9 +182,69 @@ describe("TripRepository", () => {
       expect(params).toEqual([USER_ID, "completed"]);
     });
 
+    it("appends LIMIT and OFFSET when paginating", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, { limit: 10, offset: 20 });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("LIMIT $2");
+      expect(sql).toContain("OFFSET $3");
+      expect(params).toEqual([USER_ID, 10, 20]);
+    });
+
+    it("numbers pagination placeholders after a status filter", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, {
+        status: "planned",
+        limit: 5,
+        offset: 5,
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(sql).toContain("LIMIT $3");
+      expect(sql).toContain("OFFSET $4");
+      expect(params).toEqual([USER_ID, "planned", 5, 5]);
+    });
+
     it("rethrows database errors", async () => {
       pool.query.mockRejectedValue(new Error("DB down"));
       await expect(repo.getTripsByUserId(USER_ID)).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("countTripsByUserId", () => {
+    it("counts a user's trips scoped by user id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ total: 7 }] });
+
+      const result = await repo.countTripsByUserId(USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("SELECT COUNT(*)::int AS total");
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(sql).not.toContain("status = $2");
+      expect(params).toEqual([USER_ID]);
+      expect(result).toBe(7);
+    });
+
+    it("adds a status filter when provided", async () => {
+      pool.query.mockResolvedValue({ rows: [{ total: 2 }] });
+
+      const result = await repo.countTripsByUserId(USER_ID, {
+        status: "completed",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(params).toEqual([USER_ID, "completed"]);
+      expect(result).toBe(2);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.countTripsByUserId(USER_ID)).rejects.toThrow("DB down");
     });
   });
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -113,8 +113,8 @@ function createTripsRouter({ tripRepository, db }) {
         origin,
         destination,
         routePolyline: routePolyline || null,
-        distanceMeters: distanceMeters || null,
-        durationSeconds: durationSeconds || null,
+        distanceMeters: distanceMeters ?? null,
+        durationSeconds: durationSeconds ?? null,
       });
 
       const savedDetours = [];

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -12,15 +12,21 @@
 const express = require("express");
 const requireAuth = require("../middleware/requireAuth");
 const logger = require("../utils/logger");
+const TripRepository = require("../repositories/TripRepository");
+const DetourRepository = require("../repositories/DetourRepository");
 
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @param {{ getClient: Function }} deps.db - Pool with getClient() for transactions.
  * @returns {import('express').Router}
  */
-function createTripsRouter({ tripRepository }) {
+function createTripsRouter({ tripRepository, db }) {
   if (!tripRepository) {
     throw new Error("createTripsRouter requires a tripRepository");
+  }
+  if (!db || typeof db.getClient !== "function") {
+    throw new Error("createTripsRouter requires a db with a getClient method");
   }
 
   const router = express.Router();
@@ -33,6 +39,93 @@ function createTripsRouter({ tripRepository }) {
     } catch (err) {
       logger.error("GET /api/trips failed", err);
       return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  // Save a new trip (with its detours) for the signed-in user. The trip and all
+  // its detours are written in a single transaction so a partial failure never
+  // leaves an orphan trip. The owner is always req.userId — never trusted from
+  // the request body.
+  router.post("/", requireAuth, async (req, res) => {
+    const {
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      detours,
+    } = req.body || {};
+
+    if (!tripName || typeof tripName !== "string" || !tripName.trim()) {
+      return res.status(400).json({ error: "tripName is required" });
+    }
+    if (!origin || !destination) {
+      return res
+        .status(400)
+        .json({ error: "origin and destination are required" });
+    }
+
+    const detourList = Array.isArray(detours) ? detours : [];
+    for (const d of detourList) {
+      if (
+        !d ||
+        !d.placeName ||
+        typeof d.latitude !== "number" ||
+        typeof d.longitude !== "number"
+      ) {
+        return res.status(400).json({
+          error: "Each detour requires placeName, latitude, and longitude",
+        });
+      }
+    }
+
+    const client = await db.getClient();
+    try {
+      await client.query("BEGIN");
+
+      // Client-scoped repositories so every write runs on the same transaction.
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const trip = await txTripRepo.createTrip({
+        userId: req.userId,
+        tripName: tripName.trim(),
+        origin,
+        destination,
+        routePolyline: routePolyline || null,
+        distanceMeters: distanceMeters || null,
+        durationSeconds: durationSeconds || null,
+      });
+
+      const savedDetours = [];
+      for (const d of detourList) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: trip.trip_id,
+          userId: req.userId,
+          placeName: d.placeName,
+          latitude: d.latitude,
+          longitude: d.longitude,
+          placeId: d.placeId || null,
+          placeType: d.placeType || null,
+          address: d.address || null,
+          rating: d.rating || null,
+          metadata: d.metadata || {},
+        });
+        savedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.status(201).json({ trip, detours: savedDetours });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("POST /api/trips failed", err);
+      if (err.code === "INVALID_USER") {
+        return res.status(400).json({ error: "Invalid user" });
+      }
+      return res.status(500).json({ error: "Failed to save trip" });
+    } finally {
+      client.release();
     }
   });
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -92,7 +92,14 @@ function createTripsRouter({ tripRepository, db }) {
       }
     }
 
-    const client = await db.getClient();
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error("POST /api/trips failed to acquire DB client", err);
+      return res.status(500).json({ error: "Failed to save trip" });
+    }
+
     try {
       await client.query("BEGIN");
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -15,6 +15,10 @@ const logger = require("../utils/logger");
 const TripRepository = require("../repositories/TripRepository");
 const DetourRepository = require("../repositories/DetourRepository");
 
+// Pagination defaults for GET /api/trips.
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
@@ -31,11 +35,19 @@ function createTripsRouter({ tripRepository, db }) {
 
   const router = express.Router();
 
-  // List the signed-in user's trips, newest first.
+  // List the signed-in user's trips, newest first, paginated.
   router.get("/", requireAuth, async (req, res) => {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const requestedLimit = parseInt(req.query.limit, 10) || DEFAULT_LIMIT;
+    const limit = Math.min(MAX_LIMIT, Math.max(1, requestedLimit));
+    const offset = (page - 1) * limit;
+
     try {
-      const trips = await tripRepository.getTripsByUserId(req.userId);
-      return res.json({ trips });
+      const [trips, total] = await Promise.all([
+        tripRepository.getTripsByUserId(req.userId, { limit, offset }),
+        tripRepository.countTripsByUserId(req.userId),
+      ]);
+      return res.json({ trips, total, page, limit });
     } catch (err) {
       logger.error("GET /api/trips failed", err);
       return res.status(500).json({ error: "Failed to load trips" });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -243,5 +243,18 @@ describe("trips routes", () => {
       // No transaction was started and no create was attempted.
       expect(mockCreateTrip).not.toHaveBeenCalled();
     });
+
+    it("preserves a numeric 0 for distance/duration (does not coerce to null)", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+
+      await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, distanceMeters: 0, durationSeconds: 0 });
+
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({ distanceMeters: 0, durationSeconds: 0 })
+      );
+    });
   });
 });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -4,24 +4,44 @@ jest.mock("../utils/logger", () => ({
   error: jest.fn(),
 }));
 
+// Shared mocks for the transaction-scoped repositories. The POST handler does
+// `new TripRepository(client)` / `new DetourRepository(client)`, so we replace
+// the classes with constructors that return these controllable instances.
+const mockCreateTrip = jest.fn();
+const mockCreateDetour = jest.fn();
+
+jest.mock("../repositories/TripRepository", () =>
+  jest.fn().mockImplementation(() => ({ createTrip: mockCreateTrip }))
+);
+jest.mock("../repositories/DetourRepository", () =>
+  jest.fn().mockImplementation(() => ({ createDetour: mockCreateDetour }))
+);
+
 const express = require("express");
 const request = require("supertest");
 const createTripsRouter = require("./trips");
 
 describe("trips routes", () => {
   let tripRepository;
+  let db;
+  let client;
 
   // Fake session middleware so we can toggle authentication per test.
   function buildApp(userId) {
-    tripRepository = {
-      getTripsByUserId: jest.fn(),
+    tripRepository = { getTripsByUserId: jest.fn() };
+    client = {
+      query: jest.fn().mockResolvedValue({}),
+      release: jest.fn(),
     };
+    db = { getClient: jest.fn().mockResolvedValue(client) };
+
     const app = express();
+    app.use(express.json());
     app.use((req, res, next) => {
       req.session = userId ? { userId } : {};
       next();
     });
-    app.use("/api/trips", createTripsRouter({ tripRepository }));
+    app.use("/api/trips", createTripsRouter({ tripRepository, db }));
     return app;
   }
 
@@ -29,38 +49,149 @@ describe("trips routes", () => {
     jest.clearAllMocks();
   });
 
-  it("throws when no tripRepository is provided", () => {
-    expect(() => createTripsRouter({})).toThrow(
-      "createTripsRouter requires a tripRepository"
-    );
+  describe("factory", () => {
+    it("throws when no tripRepository is provided", () => {
+      expect(() => createTripsRouter({ db: { getClient: jest.fn() } })).toThrow(
+        "createTripsRouter requires a tripRepository"
+      );
+    });
+
+    it("throws when no db with getClient is provided", () => {
+      expect(() => createTripsRouter({ tripRepository: {} })).toThrow(
+        "createTripsRouter requires a db with a getClient method"
+      );
+    });
   });
 
-  it("returns 401 when unauthenticated", async () => {
-    const app = buildApp(null);
-    const res = await request(app).get("/api/trips");
+  describe("GET /api/trips", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).get("/api/trips");
 
-    expect(res.status).toBe(401);
-    expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+      expect(res.status).toBe(401);
+      expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+    });
+
+    it("returns the authenticated user's trips scoped by user id", async () => {
+      const trips = [{ trip_id: "t1", user_id: "user-1" }];
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue(trips);
+
+      const res = await request(app).get("/api/trips");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ trips });
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+
+      const res = await request(app).get("/api/trips");
+
+      expect(res.status).toBe(500);
+    });
   });
 
-  it("returns the authenticated user's trips scoped by user id", async () => {
-    const trips = [{ trip_id: "t1", user_id: "user-1" }];
-    const app = buildApp("user-1");
-    tripRepository.getTripsByUserId.mockResolvedValue(trips);
+  describe("POST /api/trips", () => {
+    const validBody = {
+      tripName: "Road trip",
+      origin: { address: "A", lat: 1, lng: 2 },
+      destination: { address: "B", lat: 3, lng: 4 },
+      routePolyline: "abc",
+      distanceMeters: 1000,
+      durationSeconds: 600,
+      detours: [
+        { placeName: "Park", latitude: 1.5, longitude: 2.5, placeType: "park" },
+      ],
+    };
 
-    const res = await request(app).get("/api/trips");
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app).post("/api/trips").send(validBody);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ trips });
-    expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
-  });
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
 
-  it("returns 500 when the repository throws", async () => {
-    const app = buildApp("user-1");
-    tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+    it("returns 400 when tripName is missing", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, tripName: "  " });
 
-    const res = await request(app).get("/api/trips");
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
 
-    expect(res.status).toBe(500);
+    it("returns 400 when a detour is missing coordinates", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, detours: [{ placeName: "No coords" }] });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("creates the trip and its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({
+        trip_id: "t1",
+        trip_name: "Road trip",
+      });
+      mockCreateDetour.mockResolvedValue({ detour_id: "d1" });
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(res.body.trip).toEqual({ trip_id: "t1", trip_name: "Road trip" });
+      expect(res.body.detours).toEqual([{ detour_id: "d1" }]);
+
+      // Owner comes from the session, not the body.
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user-1", tripName: "Road trip" })
+      );
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: "t1",
+          userId: "user-1",
+          placeName: "Park",
+          latitude: 1.5,
+          longitude: 2.5,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("BEGIN");
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a detour insert fails", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+      mockCreateDetour.mockRejectedValue(new Error("detour insert failed"));
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("saves a trip with no detours", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, detours: [] });
+
+      expect(res.status).toBe(201);
+      expect(res.body.detours).toEqual([]);
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
   });
 });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -232,5 +232,16 @@ describe("trips routes", () => {
       expect(mockCreateDetour).not.toHaveBeenCalled();
       expect(client.query).toHaveBeenCalledWith("COMMIT");
     });
+
+    it("returns 500 when acquiring a DB client fails", async () => {
+      const app = buildApp("user-1");
+      db.getClient.mockRejectedValue(new Error("pool exhausted"));
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(500);
+      // No transaction was started and no create was attempted.
+      expect(mockCreateTrip).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -28,7 +28,10 @@ describe("trips routes", () => {
 
   // Fake session middleware so we can toggle authentication per test.
   function buildApp(userId) {
-    tripRepository = { getTripsByUserId: jest.fn() };
+    tripRepository = {
+      getTripsByUserId: jest.fn(),
+      countTripsByUserId: jest.fn(),
+    };
     client = {
       query: jest.fn().mockResolvedValue({}),
       release: jest.fn(),
@@ -72,21 +75,57 @@ describe("trips routes", () => {
       expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
     });
 
-    it("returns the authenticated user's trips scoped by user id", async () => {
+    it("returns a paginated, user-scoped page of trips (defaults)", async () => {
       const trips = [{ trip_id: "t1", user_id: "user-1" }];
       const app = buildApp("user-1");
       tripRepository.getTripsByUserId.mockResolvedValue(trips);
+      tripRepository.countTripsByUserId.mockResolvedValue(1);
 
       const res = await request(app).get("/api/trips");
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ trips });
-      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
+      expect(res.body).toEqual({ trips, total: 1, page: 1, limit: 10 });
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 10,
+        offset: 0,
+      });
+      expect(tripRepository.countTripsByUserId).toHaveBeenCalledWith("user-1");
+    });
+
+    it("honors page and limit query params (offset computed)", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue([]);
+      tripRepository.countTripsByUserId.mockResolvedValue(25);
+
+      const res = await request(app).get("/api/trips?page=3&limit=5");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ total: 25, page: 3, limit: 5 });
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 5,
+        offset: 10,
+      });
+    });
+
+    it("clamps limit to the maximum and page to at least 1", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue([]);
+      tripRepository.countTripsByUserId.mockResolvedValue(0);
+
+      const res = await request(app).get("/api/trips?page=0&limit=999");
+
+      expect(res.body.page).toBe(1);
+      expect(res.body.limit).toBe(50);
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 50,
+        offset: 0,
+      });
     });
 
     it("returns 500 when the repository throws", async () => {
       const app = buildApp("user-1");
       tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+      tripRepository.countTripsByUserId.mockResolvedValue(0);
 
       const res = await request(app).get("/api/trips");
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -63,7 +63,7 @@ const userRepository = new UserRepository(db);
 const tripRepository = new TripRepository(db);
 
 app.use("/auth", createAuthRouter({ userRepository }));
-app.use("/api/trips", createTripsRouter({ tripRepository }));
+app.use("/api/trips", createTripsRouter({ tripRepository, db }));
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ JauntDetour uses the Google Maps APIs to build routes and find detours along the
 |------|----------|
 | **Database** | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS |
 | **Authentication** | Microsoft Entra External ID (email/password + social login) |
+| **Frontend UI** | Fluent 2 (`@fluentui/react-components`) for new UI (dialogs, drawers, toasts) |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,11 @@ JauntDetour uses the Google Maps APIs to build routes and find detours along the
 
 ## Architecture Decisions
 
-| Area | Decision |
-|------|----------|
-| **Database** | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS |
-| **Authentication** | Microsoft Entra External ID (email/password + social login) |
-| **Frontend UI** | Fluent 2 (`@fluentui/react-components`) for new UI (dialogs, drawers, toasts) |
+| Area               | Decision                                                                      |
+| ------------------ | ----------------------------------------------------------------------------- |
+| **Database**       | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS      |
+| **Authentication** | Microsoft Entra External ID (email/password + social login)                   |
+| **Frontend UI**    | Fluent 2 (`@fluentui/react-components`) for new UI (dialogs, drawers, toasts) |
 
 ---
 
@@ -40,11 +40,13 @@ Managed identity for end users.
 ## Key Findings
 
 ### Database — Azure Database for PostgreSQL
+
 - **Right fit:** Google APIs handle all geospatial work, so the data model is plainly relational (`users → trips → detours`) with JSONB for API responses — no spatial extension needed.
 - **Cost-effective:** lowest 3-year TCO of all options (~$5,484 vs ~$21,624 for Cosmos DB). Free for the first 12 months (B1ms, 32 GB).
 - **Future-ready:** `pgvector` + the `azure_ai` extension add semantic search in-place if the AI agent needs it later — no second datastore.
 
 ### Authentication — Microsoft Entra External ID
+
 - **Managed and secure:** Microsoft hosts sign-up/sign-in and handles password storage, MFA, lockout, and reset. We never store credentials.
 - **Flexible login:** email/password **and** Google (plus Apple/Facebook/Microsoft) in one hosted, brandable flow.
 - **Clean DB tie-in:** the token's `sub` claim is stored as `users.external_id` — no `password_hash`. The resolved `user_id` is the authorization boundary for both the API and a future Foundry agent tool.
@@ -84,17 +86,17 @@ Managed identity for end users.
 
 ## Document Status
 
-| Document | Status | Last Updated |
-|----------|--------|--------------|
-| database/selection.md | ✅ | Jun 2, 2026 |
-| database/schema.sql | ✅ | Jun 2, 2026 |
-| database/cost-comparison.md | ✅ | Jun 2, 2026 |
-| database/implementation-guide.md | ✅ | Jun 2, 2026 |
-| authentication/authentication.md | ✅ | Jun 2, 2026 |
-| authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
-| authentication/security.md | ✅ | Jun 2, 2026 |
-| authentication/session-management.md | ✅ | Jun 2, 2026 |
-| authentication/compliance.md | ✅ | Jun 2, 2026 |
+| Document                               | Status | Last Updated |
+| -------------------------------------- | ------ | ------------ |
+| database/selection.md                  | ✅     | Jun 2, 2026  |
+| database/schema.sql                    | ✅     | Jun 2, 2026  |
+| database/cost-comparison.md            | ✅     | Jun 2, 2026  |
+| database/implementation-guide.md       | ✅     | Jun 2, 2026  |
+| authentication/authentication.md       | ✅     | Jun 2, 2026  |
+| authentication/implementation-guide.md | ✅     | Jun 2, 2026  |
+| authentication/security.md             | ✅     | Jun 2, 2026  |
+| authentication/session-management.md   | ✅     | Jun 2, 2026  |
+| authentication/compliance.md           | ✅     | Jun 2, 2026  |
 
 ---
 

--- a/docs/authentication/session-management.md
+++ b/docs/authentication/session-management.md
@@ -68,6 +68,13 @@ Short access-token lifetimes (15 min) mean a revoked or expired session is rejec
 
 ## Optional: server-side session store
 
+> **Current build:** sessions use `express-session`'s default in-memory
+> `MemoryStore`. That's fine for local dev and a single instance, but it loses
+> sessions on restart and does not scale across instances. Before running more
+> than one backend instance, switch to a persistent store — `connect-pg-simple`
+> (reuses the existing Postgres pool) is the low-friction option; Redis (below)
+> is the alternative when you also need global revocation.
+
 Adopt this only if you need **immediate, global revocation** or **concurrent-session limits** — e.g. an admin "sign out all devices" feature. It adds a Redis dependency and rotation code.
 
 ```javascript

--- a/docs/authentication/session-management.md
+++ b/docs/authentication/session-management.md
@@ -27,11 +27,11 @@ This needs **no Redis** and no hand-rolled refresh logic.
 
 ## Token lifetimes
 
-| Token | Lifetime | Storage |
-|-------|----------|---------|
-| Access token | 15–60 min | Browser memory |
-| Refresh token | 7–30 days (rotated by Entra) | MSAL cache / `httpOnly` cookie |
-| App session | Match refresh window; absolute cap 90 days | `httpOnly` cookie |
+| Token         | Lifetime                                   | Storage                        |
+| ------------- | ------------------------------------------ | ------------------------------ |
+| Access token  | 15–60 min                                  | Browser memory                 |
+| Refresh token | 7–30 days (rotated by Entra)               | MSAL cache / `httpOnly` cookie |
+| App session   | Match refresh window; absolute cap 90 days | `httpOnly` cookie              |
 
 The frontend refreshes the access token shortly before expiry (MSAL `acquireTokenSilent` handles this transparently).
 
@@ -44,9 +44,9 @@ The frontend refreshes the access token shortly before expiry (MSAL `acquireToke
 - **Force sign-out everywhere** — see the optional server-side store below; without it, revocation is bounded by access-token lifetime (keep it short, 15 min).
 
 ```javascript
-router.post('/auth/logout', (req, res) => {
+router.post("/auth/logout", (req, res) => {
   req.session.destroy(() => {
-    res.clearCookie('connect.sid');
+    res.clearCookie("connect.sid");
     const logoutUrl =
       `${authority}oauth2/v2.0/logout` +
       `?post_logout_redirect_uri=${encodeURIComponent(process.env.FRONTEND_URL)}`;
@@ -79,8 +79,16 @@ Adopt this only if you need **immediate, global revocation** or **concurrent-ses
 
 ```javascript
 // Store session metadata for revocation
-await redis.setex(`session:${userId}:${sessionId}`, 7 * 24 * 60 * 60,
-  JSON.stringify({ userId, createdAt: Date.now(), lastActivity: Date.now(), ip: req.ip }));
+await redis.setex(
+  `session:${userId}:${sessionId}`,
+  7 * 24 * 60 * 60,
+  JSON.stringify({
+    userId,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    ip: req.ip,
+  })
+);
 
 // Revoke a single session or all of a user's sessions
 async function revokeAllUserSessions(userId) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "1.1.5",
       "dependencies": {
+        "@fluentui/react-components": "^9.74.3",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@vis.gl/react-google-maps": "1.5.4",
@@ -2077,6 +2078,21 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "license": "MIT",
@@ -2142,6 +2158,1586 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.4.0.tgz",
+      "integrity": "sha512-NwhNNwCTbXYdLYwa6Ha484qCLHgRFo5vOv7BGaq0REcY2rkgwcDHVlbchwsGV7D3XgTZCjzDu54SSPmk5NOxXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
+      "integrity": "sha512-F7xVaP0OR7JMCxrBwI3ryNhKof9Yi2c6RhYPsQy7rh2+KMGLGgYLsrDJyHmSejjxp4Bs11plXGdU38SN5j1hgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.142",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.142.tgz",
+      "integrity": "sha512-YrbMX1wF7huOByxP2J+2aUWatpODd1MXhqam95oeLUnoJUViBK6ZZuBYba7m0OTsRMUA4pB1WfjvuIGsnSQKtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.17.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
+      "integrity": "sha512-f5qSP5aD2ZbYgQn4hCjQzqh8mHJNeN/vsC9Nwth5uJlGNdIAPbPO+dXVC18DkYqNU8O9A5Ae/uJPRbxoH23zbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.11.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.3.tgz",
+      "integrity": "sha512-O8PoDUf1OUXDviECFvxdxo88kCEJLlP4TtCXyE58PKuAywrVeqmOA7eNy6/xhaGVuyDO8l9YJh05sYkyLiNLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
+      "integrity": "sha512-jxS6H6+KCk62MeueCf7cT2fRbdnN6h/lCOIyXWJLpPf9Mx+LWWP3KAfKik3BuDY28oy1pDYIuvFucDL+OMAb/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.4.tgz",
+      "integrity": "sha512-KcxyQAC+xTO/n2BMBj2lLKgQL2/eyTlkUhElHv9SKqP29Ks8EPYSovYpDtSfbtx8Dle+8NSUnhAvnO1kE/+fMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.10.1.tgz",
+      "integrity": "sha512-8Ow/ck9a/RLh3cJ6ZPF4asmGnNfqXr/Kengk+zTkMuppk+pFL3X6WEMrJLSOUKKZtx0Tp1UBuUPA6RL6Ive5WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.1.tgz",
+      "integrity": "sha512-4t65Y9pRW9W7kf/Yyc7S796le2WFKfXFTCuzfkFS+AHUM7JlrmMUOnQLA0i24WDNS6ArA0vo6EbMDnUcjgV9Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.9.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.10.tgz",
+      "integrity": "sha512-Ml3Vqi9KNA+mRG1FUiIjk/HCYqEjRZKSE8jQviMSQDLe4Rb6EO16FhtuFuIOz/ls47y/Sx6zTnb1t+HiFatpJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
+      "integrity": "sha512-VzePhN5Nz3D69Fu7SnPUCrMfkrbhfqGpNJDis85+W7dvOo9cyUou6yRreHsSzxVkRyE9swcA1LnsKJS6oVn9ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.18.tgz",
+      "integrity": "sha512-zbsQ+hVJeGwXVTjneA42i4UuHRACfcTnBs3BUcDT22lBDQjJxhYYZzmj5ksM92M2ZU0fMHV8K5OfSyCnZU5mqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.17.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.3.tgz",
+      "integrity": "sha512-QuWcM6fvqnfUzpkJApQbXfbIQ6iQkMGgrsdwmJHkB4Q/E6zT0aLZoEjEx2P5QkMz9m5D7LzeZWmFIOEFq8SzFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.74.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.3.tgz",
+      "integrity": "sha512-HdcLR4V9KZnduui0v4UfBIyJrO4G8eZf3W4iu8hssykl0hN1uneNNJmsVZExT8G8ybFen85ucqMOxCXQ3L7raw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.12.1",
+        "@fluentui/react-alert": "9.0.0-beta.142",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-breadcrumb": "^9.4.4",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-card": "^9.7.1",
+        "@fluentui/react-carousel": "^9.9.10",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-color-picker": "^9.2.18",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-image": "^9.4.3",
+        "@fluentui/react-infobutton": "9.0.0-beta.117",
+        "@fluentui/react-infolabel": "^9.4.22",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-list": "^9.6.16",
+        "@fluentui/react-menu": "^9.25.1",
+        "@fluentui/react-message-bar": "^9.7.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-nav": "^9.4.2",
+        "@fluentui/react-overflow": "^9.9.0",
+        "@fluentui/react-persona": "^9.7.5",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-progress": "^9.5.3",
+        "@fluentui/react-provider": "^9.22.18",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-rating": "^9.4.3",
+        "@fluentui/react-search": "^9.4.4",
+        "@fluentui/react-select": "^9.5.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-skeleton": "^9.7.4",
+        "@fluentui/react-slider": "^9.6.4",
+        "@fluentui/react-spinbutton": "^9.6.4",
+        "@fluentui/react-spinner": "^9.8.4",
+        "@fluentui/react-swatch-picker": "^9.5.4",
+        "@fluentui/react-switch": "^9.7.4",
+        "@fluentui/react-table": "^9.19.17",
+        "@fluentui/react-tabs": "^9.12.3",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tag-picker": "^9.9.0",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-teaching-popover": "^9.7.2",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-textarea": "^9.7.4",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-toast": "^9.8.1",
+        "@fluentui/react-toolbar": "^9.8.3",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-tree": "^9.16.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.114",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
+      "integrity": "sha512-A9YdkKonDlNSTnD8SCcSMhj0O6mAyMtXMERWH5mA1UqdtVxzJ4Y/muNd3Nk5rwAaLPUZ5HWMabtt2Ewa/BxARA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0",
+        "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.18.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
+      "integrity": "sha512-acW70/CxibJC19bQVbrJyxYiuIP9nX593O/Tya4x9wMEEcnTHZ6RW8liS6kbYYEL/AERYRuOYkLJ++TNniTxSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
+      "integrity": "sha512-uhqpu+JfSaLEqFNtDQFYFo/gM1QoRV2I1iUYTMsO2iqEis4zZmMsQETti7lTv29SITWIky3e8pkRoC6xyQBLsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
+      "integrity": "sha512-nZBWG0290IcCshpt2wjORDD8fLOsccSPdp0EW45CxK09/JR+4hkGbbIj8x14GW7GYu4RsGzk18OYga0kY+4j2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.3.tgz",
+      "integrity": "sha512-5PJXFTGS9W4CBJW6Nh2Tqe5p8RxMMCPbsIyIcYUXIxCZTXDGrx1jZ+af8lWKJFlcfWOlFxyK+QE14UXl+lqzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.331",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.331.tgz",
+      "integrity": "sha512-SY3Js+SW20T0qqt8uo1pWwi1njWisOzblIFqVoACql+ZrcSkXeifI+CQMCVdf5BZTAk0NnsUGb0pV9048SKpZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.3.tgz",
+      "integrity": "sha512-BQSsT3kVdpR3s02Zq9zpqj0NjaijWOVKPLBchp9XqWlygO15dkykNt2LRoHAkZRgpnlh2D8zBCw9qQ4ubzYNaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.117",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.117.tgz",
+      "integrity": "sha512-h01PQzH736I/7mhjNcYi8cFjspCqgSmQukXbzCsESzB1VnAkx8djqy5A8f/mV1HmHw7vBAIX8VdH+ddtx8WyXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.22.tgz",
+      "integrity": "sha512-K5W+g+HfGu5ltl5BGekZJB2z0ACLidIW7KFQ5Qj+UG1kpoB3G4q10HTm5gY74VjXP/GrM5RVx8IcnHRqyAfR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.4.tgz",
+      "integrity": "sha512-Lpdu0TBBSbv3VasaCz3blNeEgQS7XhtLTmiYXZj5g8Hrk7gNDJORDPYRrXcRjOUPGkV/InB4JY+GeXy2cYfOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
+      "integrity": "sha512-npqPWSJ2qciCRB4B/cyWyrTbf8V8Z2Kfr9HnZqrUBDgEvq72rRGb+gml6naxGNzhaT4NBLQLZmdPZqt+1wZ4ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.3.tgz",
+      "integrity": "sha512-/tYFciaorFym7Q2yDCdRYeP3JzLtw5eYt2yCvRlmBsugtKmn2f/kOu+b2cB37kWizbXjSdOGhCrTL8J1EUlIZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.3.tgz",
+      "integrity": "sha512-3Cd+UWgLpP6E6/NZaomCqZd965gruWXz2+gqUDfP7nBTLaCgOIuFQe0HAgSYi0ys4xli3cDtKeytqZJ7ReA6gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.6.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.16.tgz",
+      "integrity": "sha512-ZWsLxr1ZDe6hmvGLGlHQIPt1E70xsWHaHn+QGxB0XUxjq64SnxCDm4HCSPZ40MS3Hqgd4eQdnmPUS9d6odcYUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.1.tgz",
+      "integrity": "sha512-nP2bUB0Blrz5cqG6JnaHKznD2zGv134vuiCStk0op1/IErIPoU6wJj6H+unYVhFwyHCReyPZcp/pQZWkSWErJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.3.tgz",
+      "integrity": "sha512-LxcoTatsPPYj8Y5fx9QeJYOlXs6C4HIgmXTUaqNTCnFquNrcBHU4RtzUEq/6ssJ8jP/dy8Z03Bk4dE31RCV5MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
+      "integrity": "sha512-sbrNuauwI5uw20XOAqPjXBfgBqPreHc5AxU7bJ6yoLUHL2gDKo7KGAIvLEd216GX37mgPkb3dx9rarIVGx3uvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
+      "integrity": "sha512-9aNzHAHNdfbH/8/mYGy5YVrUOGnpiru3YrqQ7KhCRWXvlce7yV3WF5CzN1g/uNh3MFmKGwQeW4ui6xJOfEaI4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@fluentui/react-utilities": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.2.tgz",
+      "integrity": "sha512-1nZgZwZHgJ1P73E0Aw4UrTqri9BMSShI7otuktdATB5iHolDHE+9JtQjr3OQJ0QR+YyXgD8bMWiKvSa6p/Pdlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.9.0.tgz",
+      "integrity": "sha512-u8M7yqlzmvdYezlvVjGJUH38ik5fb59aSSGOsJyepnXM5HwnyFb9ecBwqAFAGi23lw+wz07V0aeYMEzK7q+slw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.4.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.5.tgz",
+      "integrity": "sha512-5MlVpl3+l+UW7vTf/d1qKP6EANBkxoXjmxmbNZpiuXjIE2QJFcVRBplWXwEPgt3GAOGnix1wPVkUgHElUJOCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.4.tgz",
+      "integrity": "sha512-Ofn4kh+WfC647n9ap0mtoN47eP0FsP/ZIjoZf1GfW6Co+A3zAZN+V7z6AayCPvbvdv8vKFQ0diHeUBrIu9Pz3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.8.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
+      "integrity": "sha512-od8RN6dny6N/qGFm2uv5UV+ugGOKupFeCIF+R0rU5SimSvix6o+wv5rPrH9JHRHFqjDIi5kRh9hk/rZfgsnuaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.3.tgz",
+      "integrity": "sha512-2j2k87k7yVX8LYd9q3SniXYVGqED6JFRdTNeyamDf4DTk9/ECxTl2nKTmKedkDodddR5RRXpAtJXv874Mi9eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "^0.2.3",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
+      "integrity": "sha512-GVrZzo9QCBOyMZC/K8Q4VTbD76hgG/Xuvhr8gyqOxnuHS9lTfnPJyEZ+T+F36LmpDb6d/XmDcwKjIcyg359ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.18.tgz",
+      "integrity": "sha512-kLtBaw6WIzyJJCmzeublw1ifidVPnpzGS39lYjzWdO6vHwuizs5ARCgwlGXxkB+kAlG2Mma/cPFUdYOa0J2f2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.4.tgz",
+      "integrity": "sha512-punC09igeQT+3Fc67lteh4ibzi8kIAQyKJSh8gdYj9mA4WlAIAcdUIQ4cnqT57hRoz0zuUtZGXpP1y2Kbr8M+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
+      "integrity": "sha512-kolMzzTl9/fg54jY1iy8w54BktkKFKGLaEeiESXAbtSZiUyNIj1BADMbIG3kysbVnhkYK8Q5h0kxZPsblrL/ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.4.tgz",
+      "integrity": "sha512-mLDqzL00XkSfJrtIZN34tQO2eBrjlPr33HuD9m3zUUQTq5g7wvA0LomT7m3RQPCJfV6FcOcMDmVfotqDUmttzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.3.tgz",
+      "integrity": "sha512-Qt4ovfXQRx11ou7OaoD0O1CNawfIzTS+Q39fX+wwLwL2yfn15oWnQGGVuQD3hWh0dh7k9cmOErRIrOKeI2wmXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
+      "integrity": "sha512-lIDvfFDldqOkmiwQU0ZEdnKnj/xxnNOGeuciuPz7ao+RyvDYf87Uo1RvTpMTveRCmpPC9z5rOX0EZZK+PhX7Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
+      "integrity": "sha512-hPpbAe6pT00FG717A7wV6QCx4+WizhvT9AI/IbEifjKTQ9uxKhodDQNk8WqEXA1ziFoSifDHGAKbcOn/kdr4Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
+      "integrity": "sha512-+t4B6anAWSXFJgmnNXOvC7S/ZWU23MOCDWrvRXKz3fki9fENN85HiRmlnx4fR8akYItVDscqQacRQRxAL8F0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
+      "integrity": "sha512-vgfsJosM6hMixFCR7mP856xKx0xXa5Vz4Y95t37Xne2yzJ47bTfqQ62kof7U1AyvaSEeDIp76cwKMyv3lQUD3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.4.tgz",
+      "integrity": "sha512-UwrtK3vP2Ruo2nAI+bbu56XhtpEIwi1XvHFXpVyRWGNQI9362lMS3F4CjwDlyPR24GeF+kEgZeF7QaruTVmagQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.4.tgz",
+      "integrity": "sha512-P4Xh+zrEOXO7mUmHDPo2G/yfQYwXWArrBOBKCLKOw6qI7KjuzBJxmy1Zqm94/drRr1EKVpBaZckSiT8X8N0TNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.19.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.17.tgz",
+      "integrity": "sha512-SPhAlS6yQ/53GB/1XUzCum63ktzmNaZVWswshr6SCo7oUERxdszr6xHJ5bSvgNczlApuLzZVz6Vnxe2s7+bsCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
+      "integrity": "sha512-CkQmrErImxvGDgrNIh+v0GbXzTKx1YSiBXYuFIhjdFaTnTk5CE79xwZp3mIkZK4SUns0HcH5wchjuO1L5LfcRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
+      "integrity": "sha512-napGx7dGdLoKoUpKlzc2Til43UMUTtr9J1GWrOFvCT6aZLTox5GjtoxQM/IPhcZ09jJOOUMbVF8ScA5u3/uyTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.14.1",
+        "tabster": "^8.8.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.9.0.tgz",
+      "integrity": "sha512-DYe0p4eFkCTi0HbKFWgr+MmaVhvggGnnUG4vTsgZ9zGADXPAkcVebjSGoF3LeYvRwp73t+qQRe8dT0lvBofTpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.2.tgz",
+      "integrity": "sha512-yJmUrx3b1m4OYoXGt1+hUgZzghoTuHGGHkXyTwmCUCKX7BKAXQBbOu0VHyxmG+VDkPhpO3773ObQCFXCdTavrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.2.tgz",
+      "integrity": "sha512-984lSUplfBiLTKpNSGvzPaBMmQ8pSM0u/Ucv4QoB2QB9U771pu8NtuNvtiuhQe5f6yC3wblIFHnTVrlZW66TWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.18.tgz",
+      "integrity": "sha512-iED0KJPtU44M5kByfg93n/Zwwky0BhyRHaWFcIeB6jsCVAeCf8kUSS2Nr+7zQocf60DFHgMF7y4XEl0rRe+PHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.4.tgz",
+      "integrity": "sha512-Zq2D8u2ssneLVY4OuvMWYT5Er3yAo3OKmTWmPNsJ6F9dISIc7UullDwuBoKYES943EBzSfNyKZQwCY7Bo1BGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.23",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
+      "integrity": "sha512-J9nKVwbwmBxDNrArgJ9GHypWH43WW0XJhNWvC6ED4dGrvgc8Rnw7bKxI7swG46OTMJNCkwrOnGNEu5YGkMigfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
+      "integrity": "sha512-/R12jBM1cllfvim9x+NxL4/5ObDdih42yHsswecVGhwK/rituz37UEWWr1MkapMCDnr/gVRVb4QEsbFXX3lpNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.3.tgz",
+      "integrity": "sha512-QDc5XQyODm0BIQ5VCbM59n0pEXNCMk2a9OQ7B5eDWoqnvTxj++ul1XQb6EF0libbkjFl7zTsaaHnhIOzsVEq0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.16.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.3.tgz",
+      "integrity": "sha512-Uf4ero9GhHoe8B6ZONKTIriPnd8cuyPFGXbPo+AG4t4vB5QO8qSZmwrR89btd2Xbr1zWQoMmJJFDn83S+3Te8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.26.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
+      "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.114",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
+      "integrity": "sha512-hD44CrZh84P1Rsd+ACPdmre3j20OevkoMKxMRzMXWlSIYKbT+m5I5yM3XxxSvKb1Qr77LeBPTTJs6apvMcfRiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.7.2",
       "license": "MIT",
@@ -2179,6 +3775,42 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.3.tgz",
+      "integrity": "sha512-FMnlwhtmCRWvXEg2j/6W90wzvW+PFqdrsWFslfmxwS6l9X73gO0dnndKphht9ZOsJODvmLdqlnU1Lh8igg2mKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.4.2",
+        "csstype": "^3.2.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.5.tgz",
+      "integrity": "sha512-7otiHiIqhdOdoSgNJdZenUR8hRljS5e2CecBVPrA3U9hLgRQzRjEMo3pPF/HJoHHo6cvdpHdqQH1HaFTJWgKeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/core": "^1.21.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "integrity": "sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3025,6 +4657,15 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3241,6 +4882,26 @@
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -5403,6 +7064,12 @@
       "version": "0.3.8",
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "license": "BSD-2-Clause"
@@ -5779,6 +7446,30 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.187",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -9414,6 +11105,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keyborg": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
+      "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "license": "MIT",
@@ -12328,6 +14025,15 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "funding": [
@@ -13281,6 +14987,12 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "license": "MIT",
@@ -13528,6 +15240,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tabster": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
+      "integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "^2.14.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.5",
   "private": true,
   "dependencies": {
+    "@fluentui/react-components": "^9.74.3",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@vis.gl/react-google-maps": "1.5.4",

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Header from "./header/Header";
 import AuthButton from "./header/AuthButton";
+import MyTrips from "./sidebar/MyTrips";
 import FooterMenu from "./footer-menu/FooterMenu";
 import MapContainer from "./MapContainer";
 import Sidebar from "./sidebar/Sidebar";
@@ -10,11 +11,14 @@ class Main extends React.Component {
   render() {
     return (
       <div className="app-container">
-        <AuthButton
-          user={this.props.user}
-          setUser={this.props.setUser}
-          clearUser={this.props.clearUser}
-        ></AuthButton>
+        <div className="app-toolbar">
+          <MyTrips></MyTrips>
+          <AuthButton
+            user={this.props.user}
+            setUser={this.props.setUser}
+            clearUser={this.props.clearUser}
+          ></AuthButton>
+        </div>
         <Header
           origin={this.props.origin}
           destination={this.props.destination}

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,0 +1,150 @@
+import React, { useState, useCallback } from "react";
+import { useSelector } from "react-redux";
+import {
+  Button,
+  OverlayDrawer,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  DrawerBody,
+  Card,
+  Text,
+  Spinner,
+} from "@fluentui/react-components";
+import TripRequester from "../../scripts/TripRequester";
+
+const PAGE_SIZE = 10;
+
+// origin/destination are stored as JSONB { address, lat, lng }; show the address.
+function formatEndpoint(point) {
+  if (!point) {
+    return "Unknown";
+  }
+  if (point.address) {
+    return point.address;
+  }
+  if (point.lat != null && point.lng != null) {
+    return `${point.lat}, ${point.lng}`;
+  }
+  return "Unknown";
+}
+
+/**
+ * MyTrips — a "My Trips" button (shown only when signed in) that opens a
+ * non-modal Fluent drawer listing the user's saved trips. The drawer overlays
+ * the map without a backdrop, so the map stays visible behind it. List-only for
+ * now; loading a trip onto the map is a later story.
+ */
+export default function MyTrips() {
+  const user = useSelector((state) => state.user);
+
+  const [open, setOpen] = useState(false);
+  const [trips, setTrips] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const load = useCallback((nextPage) => {
+    setLoading(true);
+    setError(false);
+    new TripRequester()
+      .listTrips(nextPage, PAGE_SIZE)
+      .then((data) => {
+        setTrips(data.trips || []);
+        setTotal(data.total || 0);
+        setPage(data.page || nextPage);
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleOpen = () => {
+    setOpen(true);
+    load(1);
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <>
+      <Button appearance="secondary" id="my-trips-button" onClick={handleOpen}>
+        My Trips
+      </Button>
+
+      <OverlayDrawer
+        as="aside"
+        position="end"
+        modalType="non-modal"
+        open={open}
+        onOpenChange={(event, data) => setOpen(data.open)}
+      >
+        <DrawerHeader>
+          <DrawerHeaderTitle
+            action={
+              <Button
+                appearance="subtle"
+                aria-label="Close"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </Button>
+            }
+          >
+            My Trips
+          </DrawerHeaderTitle>
+        </DrawerHeader>
+
+        <DrawerBody>
+          {loading ? (
+            <Spinner label="Loading trips..." />
+          ) : error ? (
+            <Text>Could not load your trips. Please try again.</Text>
+          ) : total === 0 ? (
+            <Text>You haven&apos;t saved any trips yet.</Text>
+          ) : (
+            <>
+              <div className="my-trips-list">
+                {trips.map((trip) => (
+                  <Card key={trip.trip_id} className="my-trips-card">
+                    <Text weight="semibold">{trip.trip_name}</Text>
+                    <Text size={200}>
+                      {formatEndpoint(trip.origin)} &rarr;{" "}
+                      {formatEndpoint(trip.destination)}
+                    </Text>
+                    <Text size={200}>
+                      Saved {new Date(trip.created_at).toLocaleDateString()}
+                    </Text>
+                  </Card>
+                ))}
+              </div>
+
+              <div className="my-trips-pager">
+                <Button
+                  appearance="secondary"
+                  disabled={page <= 1}
+                  onClick={() => load(page - 1)}
+                >
+                  Previous
+                </Button>
+                <Text>
+                  Page {page} of {totalPages}
+                </Text>
+                <Button
+                  appearance="secondary"
+                  disabled={page >= totalPages}
+                  onClick={() => load(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </>
+          )}
+        </DrawerBody>
+      </OverlayDrawer>
+    </>
+  );
+}

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import {
+  Button,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Field,
+  Input,
+  Toaster,
+  Toast,
+  ToastTitle,
+  useToastController,
+  useId,
+} from "@fluentui/react-components";
+import TripRequester, { buildTripPayload } from "../../scripts/TripRequester";
+import AuthRequester from "../../scripts/AuthRequester";
+
+// sessionStorage flag: set when a signed-out user opts to sign in from the save
+// prompt, so the name dialog reopens automatically after the login redirect.
+const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
+
+/**
+ * SaveTrip — "Save Trip" button plus its Fluent dialogs and toast.
+ *
+ * Reads the current trip straight from Redux, so it can drop into TripSummary
+ * with no prop threading. Signed-out users get a prompt to sign in; signed-in
+ * users get a name dialog, and the result is reported via a Fluent toast.
+ */
+export default function SaveTrip() {
+  const { user, origin, destination, route, detourList } = useSelector(
+    (state) => ({
+      user: state.user,
+      origin: state.origin,
+      destination: state.destination,
+      route: state.route,
+      detourList: state.detourList,
+    })
+  );
+
+  const [nameDialogOpen, setNameDialogOpen] = useState(false);
+  const [signInDialogOpen, setSignInDialogOpen] = useState(false);
+  const [tripName, setTripName] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const toasterId = useId("save-trip-toaster");
+  const { dispatchToast } = useToastController(toasterId);
+  const auth = new AuthRequester();
+
+  // Clicking "Sign in" from the save prompt is an intent to save. We stash a
+  // one-shot flag before the login redirect; once the user is authenticated on
+  // return, reopen the name dialog automatically.
+  useEffect(() => {
+    if (user && sessionStorage.getItem(RESUME_SAVE_KEY)) {
+      sessionStorage.removeItem(RESUME_SAVE_KEY);
+      setTripName("");
+      setNameDialogOpen(true);
+    }
+  }, [user]);
+
+  const handleClick = () => {
+    if (!user) {
+      setSignInDialogOpen(true);
+    } else {
+      setTripName("");
+      setNameDialogOpen(true);
+    }
+  };
+
+  const handleSignIn = () => {
+    // Survive the full-page login redirect so we can resume on return.
+    sessionStorage.setItem(RESUME_SAVE_KEY, "1");
+    auth.login();
+  };
+
+  const handleSave = () => {
+    const name = tripName.trim();
+    if (!name) {
+      return;
+    }
+    setSaving(true);
+    const payload = buildTripPayload(
+      { origin, destination, route, detourList },
+      name
+    );
+    new TripRequester()
+      .saveTrip(payload)
+      .then(() => {
+        setNameDialogOpen(false);
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Trip saved</ToastTitle>
+          </Toast>,
+          { intent: "success" }
+        );
+      })
+      .catch(() => {
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Could not save trip. Please try again.</ToastTitle>
+          </Toast>,
+          { intent: "error" }
+        );
+      })
+      .finally(() => {
+        setSaving(false);
+      });
+  };
+
+  return (
+    <>
+      <Toaster toasterId={toasterId} />
+
+      <Button
+        appearance="primary"
+        className="save-trip-btn mt-2"
+        id="save-trip-button"
+        onClick={handleClick}
+      >
+        Save Trip
+      </Button>
+
+      {/* Signed-in: prompt for a trip name. */}
+      <Dialog
+        open={nameDialogOpen}
+        onOpenChange={(event, data) => setNameDialogOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Save your trip</DialogTitle>
+            <DialogContent>
+              <Field label="Trip name" required>
+                <Input
+                  value={tripName}
+                  placeholder="e.g. Coastal weekend"
+                  onChange={(event) => setTripName(event.target.value)}
+                />
+              </Field>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                disabled={saving}
+                onClick={() => setNameDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="primary"
+                disabled={saving || !tripName.trim()}
+                onClick={handleSave}
+              >
+                {saving ? "Saving..." : "Save"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* Signed-out: prompt to sign in. */}
+      <Dialog
+        open={signInDialogOpen}
+        onOpenChange={(event, data) => setSignInDialogOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Sign in to save your trip</DialogTitle>
+            <DialogContent>
+              Create an account or sign in to save this trip and access it
+              later.
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                onClick={() => setSignInDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button appearance="primary" onClick={handleSignIn}>
+                Sign in
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/sidebar/TripSummary.jsx
+++ b/frontend/src/components/sidebar/TripSummary.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import TripTimeline from "./TripTimeline";
+import SaveTrip from "./SaveTrip";
 import { exportToGoogleMaps } from "../../utils/googleMapsExport";
 
 class TripSummary extends React.Component {
@@ -51,6 +52,7 @@ class TripSummary extends React.Component {
                     id="export-route-button"
                     text="Open in Google Maps"
                   ></Button>
+                  <SaveTrip></SaveTrip>
                 </div>
               </div>
             </div>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,15 +6,45 @@ import * as serviceWorker from "./serviceWorker";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
 import mainReducer from "./reducers/main-reducer";
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 
-let store = createStore(mainReducer);
+// Persist the planning state to sessionStorage so an in-progress trip survives
+// full-page navigations — most importantly the sign-in redirect (backend →
+// Entra → back), which would otherwise wipe the in-memory Redux state. Scoped
+// to sessionStorage so it's per-tab and cleared when the tab closes. `user` is
+// deliberately not persisted: auth state is always re-resolved from /auth/me.
+const PERSIST_KEY = "jaunt.tripState";
+
+function loadState() {
+  try {
+    const saved = sessionStorage.getItem(PERSIST_KEY);
+    return saved ? JSON.parse(saved) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function saveState(state) {
+  try {
+    // eslint-disable-next-line no-unused-vars
+    const { user, ...planning } = state;
+    sessionStorage.setItem(PERSIST_KEY, JSON.stringify(planning));
+  } catch {
+    // Ignore write failures (e.g. storage disabled or full).
+  }
+}
+
+let store = createStore(mainReducer, loadState());
+store.subscribe(() => saveState(store.getState()));
 
 const container = document.getElementById("root");
 const root = createRoot(container);
 
 root.render(
   <Provider store={store}>
-    <App />
+    <FluentProvider theme={webLightTheme}>
+      <App />
+    </FluentProvider>
   </Provider>
 );
 

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -89,4 +89,24 @@ export default class TripRequester {
         throw error;
       });
   }
+
+  /**
+   * List the signed-in user's saved trips, newest first, paginated.
+   *
+   * @param {number} [page=1] - 1-based page number.
+   * @param {number} [limit=10] - Page size.
+   * @returns {Promise<object>} { trips, total, page, limit }
+   */
+  listTrips(page = 1, limit = 10) {
+    return axios
+      .get(this.getUrlBase() + "/api/trips", {
+        params: { page, limit },
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to load trips:", error);
+        throw error;
+      });
+  }
 }

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -1,0 +1,92 @@
+import axios from "axios";
+import config from "../config/config.js";
+import log from "../utils/logger";
+
+/**
+ * Build the POST /api/trips payload from the current Redux state.
+ *
+ * The full Google route object is kept in `state.route`, so we can pull exact
+ * coordinates, distance, duration, and the encoded polyline straight from it —
+ * no extra API calls. `origin`/`destination` in state are the address strings
+ * the user typed; we pair them with the resolved leg coordinates.
+ *
+ * @param {object} state - Redux state ({ origin, destination, route, detourList }).
+ * @param {string} tripName - The name the user entered for the trip.
+ * @returns {object} The request body for POST /api/trips.
+ */
+export function buildTripPayload(state, tripName) {
+  const { origin, destination, route, detourList } = state;
+  const legs = (route && route.legs) || [];
+  const firstLeg = legs[0] || {};
+  const lastLeg = legs[legs.length - 1] || {};
+  const startLocation = firstLeg.start_location || {};
+  const endLocation = lastLeg.end_location || {};
+
+  const distanceMeters = legs.reduce(
+    (sum, leg) => sum + ((leg.distance && leg.distance.value) || 0),
+    0
+  );
+  const durationSeconds = legs.reduce(
+    (sum, leg) => sum + ((leg.duration && leg.duration.value) || 0),
+    0
+  );
+  const routePolyline =
+    (route && route.overview_polyline && route.overview_polyline.points) ||
+    null;
+
+  return {
+    tripName,
+    origin: {
+      address: origin || "",
+      lat: startLocation.lat ?? null,
+      lng: startLocation.lng ?? null,
+    },
+    destination: {
+      address: destination || "",
+      lat: endLocation.lat ?? null,
+      lng: endLocation.lng ?? null,
+    },
+    routePolyline,
+    distanceMeters: distanceMeters || null,
+    durationSeconds: durationSeconds || null,
+    detours: (detourList || []).map((detour) => ({
+      placeName: detour.name,
+      placeType: detour.type || null,
+      latitude: detour.lat,
+      longitude: detour.lng,
+      placeId: detour.placeId || detour.id || null,
+      rating: detour.rating || null,
+      metadata: { addedTime: detour.addedTime },
+    })),
+  };
+}
+
+/**
+ * TripRequester — persists a trip to the backend.
+ *
+ * The backend scopes the trip to the signed-in user via the session cookie, so
+ * every call must send credentials.
+ */
+export default class TripRequester {
+  getUrlBase() {
+    return config.BACKEND_URL;
+  }
+
+  /**
+   * Save a trip (with its detours). Resolves to the created trip on success.
+   *
+   * @param {object} payload - Body from buildTripPayload.
+   * @returns {Promise<object>} { trip, detours }
+   */
+  saveTrip(payload) {
+    return axios
+      .post(this.getUrlBase() + "/api/trips", payload, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to save trip:", error);
+        throw error;
+      });
+  }
+}

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -30,6 +30,8 @@ export function buildTripPayload(state, tripName) {
     (sum, leg) => sum + ((leg.duration && leg.duration.value) || 0),
     0
   );
+  // Only report distance/duration when there is a route; preserve a genuine 0.
+  const hasLegs = legs.length > 0;
   const routePolyline =
     (route && route.overview_polyline && route.overview_polyline.points) ||
     null;
@@ -47,8 +49,8 @@ export function buildTripPayload(state, tripName) {
       lng: endLocation.lng ?? null,
     },
     routePolyline,
-    distanceMeters: distanceMeters || null,
-    durationSeconds: durationSeconds || null,
+    distanceMeters: hasLegs ? distanceMeters : null,
+    durationSeconds: hasLegs ? durationSeconds : null,
     detours: (detourList || []).map((detour) => ({
       placeName: detour.name,
       placeType: detour.type || null,

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -97,6 +97,30 @@ describe("buildTripPayload", () => {
     expect(payload.routePolyline).toBeNull();
     expect(payload.detours).toEqual([]);
   });
+
+  it("preserves a computed 0 distance/duration when a route (legs) exists", () => {
+    const payload = buildTripPayload(
+      {
+        origin: "A",
+        destination: "A",
+        route: {
+          legs: [
+            {
+              start_location: { lat: 1, lng: 2 },
+              end_location: { lat: 1, lng: 2 },
+              distance: { value: 0 },
+              duration: { value: 0 },
+            },
+          ],
+        },
+        detourList: [],
+      },
+      "Zero"
+    );
+
+    expect(payload.distanceMeters).toBe(0);
+    expect(payload.durationSeconds).toBe(0);
+  });
 });
 
 describe("TripRequester.listTrips", () => {

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -1,0 +1,91 @@
+import { buildTripPayload } from "./TripRequester";
+
+describe("buildTripPayload", () => {
+  const state = {
+    origin: "San Francisco, CA",
+    destination: "Los Angeles, CA",
+    route: {
+      overview_polyline: { points: "encoded_polyline_string" },
+      legs: [
+        {
+          start_location: { lat: 37.77, lng: -122.42 },
+          end_location: { lat: 36.0, lng: -120.0 },
+          distance: { value: 300000 },
+          duration: { value: 18000 },
+        },
+        {
+          start_location: { lat: 36.0, lng: -120.0 },
+          end_location: { lat: 34.05, lng: -118.24 },
+          distance: { value: 316000 },
+          duration: { value: 14400 },
+        },
+      ],
+    },
+    detourList: [
+      {
+        name: "Big Sur",
+        type: "Landmark",
+        lat: 36.27,
+        lng: -121.8,
+        id: "place-1",
+        placeId: "gplace-1",
+        rating: 4.8,
+        addedTime: 45,
+      },
+    ],
+  };
+
+  it("pairs the typed addresses with the resolved leg coordinates", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.tripName).toBe("Coastal drive");
+    expect(payload.origin).toEqual({
+      address: "San Francisco, CA",
+      lat: 37.77,
+      lng: -122.42,
+    });
+    expect(payload.destination).toEqual({
+      address: "Los Angeles, CA",
+      lat: 34.05,
+      lng: -118.24,
+    });
+  });
+
+  it("sums distance and duration across all legs and takes the encoded polyline", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.distanceMeters).toBe(616000);
+    expect(payload.durationSeconds).toBe(32400);
+    expect(payload.routePolyline).toBe("encoded_polyline_string");
+  });
+
+  it("maps detours to the backend shape", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.detours).toEqual([
+      {
+        placeName: "Big Sur",
+        placeType: "Landmark",
+        latitude: 36.27,
+        longitude: -121.8,
+        placeId: "gplace-1",
+        rating: 4.8,
+        metadata: { addedTime: 45 },
+      },
+    ]);
+  });
+
+  it("degrades gracefully when route data is missing", () => {
+    const payload = buildTripPayload(
+      { origin: "A", destination: "B", route: {}, detourList: [] },
+      "Empty"
+    );
+
+    expect(payload.origin).toEqual({ address: "A", lat: null, lng: null });
+    expect(payload.destination).toEqual({ address: "B", lat: null, lng: null });
+    expect(payload.distanceMeters).toBeNull();
+    expect(payload.durationSeconds).toBeNull();
+    expect(payload.routePolyline).toBeNull();
+    expect(payload.detours).toEqual([]);
+  });
+});

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -1,4 +1,13 @@
-import { buildTripPayload } from "./TripRequester";
+import axios from "axios";
+import TripRequester, { buildTripPayload } from "./TripRequester";
+
+jest.mock("axios");
+
+jest.mock("../utils/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
 
 describe("buildTripPayload", () => {
   const state = {
@@ -87,5 +96,41 @@ describe("buildTripPayload", () => {
     expect(payload.durationSeconds).toBeNull();
     expect(payload.routePolyline).toBeNull();
     expect(payload.detours).toEqual([]);
+  });
+});
+
+describe("TripRequester.listTrips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests the given page/limit with credentials and returns the data", async () => {
+    const data = { trips: [{ trip_id: "t1" }], total: 1, page: 2, limit: 5 };
+    axios.get.mockResolvedValue({ data });
+
+    const result = await new TripRequester().listTrips(2, 5);
+
+    const [url, options] = axios.get.mock.calls[0];
+    expect(url).toContain("/api/trips");
+    expect(options).toMatchObject({
+      params: { page: 2, limit: 5 },
+      withCredentials: true,
+    });
+    expect(result).toBe(data);
+  });
+
+  it("defaults to page 1 and limit 10", async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    await new TripRequester().listTrips();
+
+    const [, options] = axios.get.mock.calls[0];
+    expect(options.params).toEqual({ page: 1, limit: 10 });
+  });
+
+  it("propagates errors", async () => {
+    axios.get.mockRejectedValue(new Error("network"));
+
+    await expect(new TripRequester().listTrips()).rejects.toThrow("network");
   });
 });

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -260,6 +260,23 @@
   color: #6c757d;
 }
 
+/* Save Trip — pill shape to match the detour/route buttons; green to signal a
+   positive "save/commit" action, distinct from the blue Add Detour button. */
+.save-trip-btn {
+  width: 100%;
+  border-radius: 1.5rem !important;
+  background-color: #188038 !important;
+  color: #ffffff !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.save-trip-btn:hover,
+.save-trip-btn:active {
+  background-color: #146c2e !important;
+  color: #ffffff !important;
+}
+
 /* Apply rounded pill-like styling to all buttons */
 .btn {
   border-radius: 1.5rem !important;

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -28,12 +28,19 @@
   flex-direction: column;
 }
 
-/* Sign in / sign out control, pinned top-right above all layouts. */
-.auth-button {
+/* Top-right toolbar holding the My Trips + sign-in/out controls. */
+.app-toolbar {
   position: fixed;
   top: 12px;
   right: 12px;
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Sign in / sign out control. */
+.auth-button {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -62,6 +69,27 @@
   padding: 6px 10px;
   border-radius: 4px;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* My Trips drawer list. */
+.my-trips-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.my-trips-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.my-trips-pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
 }
 
 /* Desktop: sidebar is visible, so add left margin to avoid overlap */

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,9 @@ Jauntdetour consists of a lightweight frontend that is built in React that inter
 
 ### Prerequisites
 
-This project was built with NodeJS (v10.15.3). You can obtain the latest version from the URL below.
+This project requires **Node.js >= 20** (`@azure/msal-node`, used for
+authentication, requires Node 20+). The dev container already provides Node 20.
+For a local install, get the latest LTS from the URL below.
 
 ```
 https://nodejs.org/en/download/
@@ -43,10 +45,29 @@ DB_USER=<user>
 DB_PASSWORD=<password>
 DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
 ```
+
+Authentication & session (backend) — Microsoft Entra External ID
+```
+ENTRA_TENANT_SUBDOMAIN=<subdomain>        # the <sub> in <sub>.ciamlogin.com
+ENTRA_TENANT_ID=<tenant directory GUID>   # required in the CIAM authority path
+ENTRA_CLIENT_ID=<app registration client id>
+ENTRA_CLIENT_SECRET=<app registration client secret>
+ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
+SESSION_SECRET=<long random string>       # e.g. openssl rand -base64 32
+FRONTEND_URL=http://localhost:3001        # CORS origin + post-login redirect
+```
+
+Frontend
+```
+REACT_APP_GOOGLE_API_KEY=<key>
+REACT_APP_BACKEND_URL=<backend base URL>   # optional; defaults by NODE_ENV
+```
 When using the DevContainer, the `DB_*` values are provided automatically from
 `.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
 For the schema, data-access layer, and Azure/production setup, see
 [docs/database/implementation-guide.md](docs/database/implementation-guide.md).
+For authentication setup, see
+[docs/authentication/implementation-guide.md](docs/authentication/implementation-guide.md).
 
 ### Installing
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Often during a road trip, you want to stop at a nice place for lunch an hour dow
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
-Jauntdetour consists of a lightweight frontend that is built in React that interfaces with a NodeJS backend deployed on an Ubuntu server. 
+Jauntdetour consists of a lightweight frontend that is built in React that interfaces with a NodeJS backend deployed on an Ubuntu server.
 
 ### Prerequisites
 
@@ -23,11 +23,13 @@ https://nodejs.org/en/download/
 Both the frontend and backend use environment variables in their configuration. These are used to set the Google API key and to determine if this is a development or production environment
 
 Google API key
+
 ```
 export GOOGLE_API_KEY=<key>
 ```
 
 Node environment
+
 ```
 // If this is going on a development environment such as a laptop
 export NODE_ENV="development"
@@ -37,6 +39,7 @@ export NODE_ENV="production"
 ```
 
 Database connection (backend)
+
 ```
 DB_HOST=<host>
 DB_PORT=5432
@@ -47,6 +50,7 @@ DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
 ```
 
 Authentication & session (backend) — Microsoft Entra External ID
+
 ```
 ENTRA_TENANT_SUBDOMAIN=<subdomain>        # the <sub> in <sub>.ciamlogin.com
 ENTRA_TENANT_ID=<tenant directory GUID>   # required in the CIAM authority path
@@ -58,10 +62,12 @@ FRONTEND_URL=http://localhost:3001        # CORS origin + post-login redirect
 ```
 
 Frontend
+
 ```
 REACT_APP_GOOGLE_API_KEY=<key>
 REACT_APP_BACKEND_URL=<backend base URL>   # optional; defaults by NODE_ENV
 ```
+
 When using the DevContainer, the `DB_*` values are provided automatically from
 `.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
 For the schema, data-access layer, and Azure/production setup, see
@@ -94,6 +100,7 @@ npm install
 For the best development experience, use the provided DevContainer or the convenience scripts:
 
 ### Option 1: DevContainer (VS Code)
+
 1. Copy the environment template and add your Google Maps API key:
    ```bash
    cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
@@ -109,30 +116,36 @@ database with no cloud setup required. See [DEV-SETUP.md](DEV-SETUP.md) for deta
 connection info, and how to reset the database.
 
 ### Option 2: Local Development with Scripts
+
 Install root-level dependencies first:
+
 ```bash
 npm install
 ```
 
 Then start both services:
+
 ```bash
 npm run dev
 ```
 
 This will start:
+
 - Backend on http://localhost:3000
 - Frontend on http://localhost:3001
 
 ### Individual Services
+
 ```bash
 # Backend only (with auto-restart)
 npm run backend:dev
 
-# Frontend only  
+# Frontend only
 npm run frontend:dev
 ```
 
 ### Database
+
 Local development uses a PostgreSQL database that runs automatically inside the
 DevContainer (see Option 1 above) — no manual database install needed. The backend
 connects through the `DB_*` environment variables. For the schema, the data-access
@@ -164,12 +177,14 @@ npm install
 To run in a development environment, follow the following steps
 
 Start the backend
+
 ```
 cd /<repo-root-dir>/backend
 node index.js
 ```
 
 Start the frontend
+
 ```
 cd ../frontend
 npm start
@@ -184,6 +199,7 @@ This project includes comprehensive unit tests and linting to ensure code qualit
 ### Running Tests Locally
 
 #### Frontend Tests
+
 ```bash
 cd frontend
 
@@ -198,6 +214,7 @@ npm run test:coverage
 ```
 
 #### Backend Tests
+
 ```bash
 cd backend
 
@@ -214,6 +231,7 @@ npm run test:coverage
 ### Running Linters
 
 #### Frontend Linting
+
 ```bash
 cd frontend
 
@@ -231,6 +249,7 @@ npm run format
 ```
 
 #### Backend Linting
+
 ```bash
 cd backend
 
@@ -250,6 +269,7 @@ npm run format
 ### Continuous Integration
 
 All pushes and pull requests automatically trigger the CI pipeline which:
+
 - Runs ESLint on both frontend and backend
 - Runs Prettier to check code formatting
 - Executes all unit tests
@@ -259,12 +279,12 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 ## Built With
 
-* [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
-* [Express](https://expressjs.com/) - Web framework used for backend
-* [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
-* [React](https://reactjs.org/) - Library used to build the frontend
-* [Redux](https://redux.js.org/) - State management library
-* [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API
+- [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
+- [Express](https://expressjs.com/) - Web framework used for backend
+- [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
+- [React](https://reactjs.org/) - Library used to build the frontend
+- [Redux](https://redux.js.org/) - State management library
+- [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API
 
 ## Versioning
 
@@ -272,17 +292,21 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## CI/CD
 
-This project uses GitHub Actions for continuous integration and deployment. 
+This project uses GitHub Actions for continuous integration and deployment.
 
 ### Continuous Integration (CI)
+
 Every push and pull request triggers automated checks:
+
 - **Linting**: ESLint validates code quality for both frontend (React best practices) and backend (Node.js best practices)
 - **Formatting**: Prettier ensures consistent code formatting
 - **Unit Tests**: All tests must pass before merging
 - **Build**: Verifies the application builds successfully
 
 ### Continuous Deployment (CD)
+
 The deployment pipeline automatically:
+
 - Detects changes in backend and frontend directories
 - Builds Docker containers (`jauntdetour-backend` and `jauntdetour-frontend`)
 - Automatically bumps versions (patch by default, configurable via commit messages)
@@ -295,8 +319,8 @@ For detailed information about the CI/CD pipeline, version management, and deplo
 
 ## Authors
 
-* **Anthony Gray** - *Initial work* - [Portfolio](https://anthonyrgray.com)
+- **Anthony Gray** - _Initial work_ - [Portfolio](https://anthonyrgray.com)
 
 ## Acknowledgments
 
-* Thank you to the Digital Crafts instructors that helped me get this project off the ground
+- Thank you to the Digital Crafts instructors that helped me get this project off the ground


### PR DESCRIPTION
# Save trips and view saved trips

## Summary

Adds two related features on top of the existing Entra authentication:

1. **Save Trip** — a signed-in user can name and save their planned trip (origin,
   destination, route, and detours) to the database.
2. **View Saved Trips** — a "My Trips" drawer lists the user's saved trips,
   newest-first, with pagination and an empty state.

Both are scoped to the authenticated user via the existing session, and the
frontend uses Fluent 2 (`@fluentui/react-components`) for the dialog, drawer, and
toasts.

## Save Trip

- **`POST /api/trips`** ([backend/app/routes/trips.js](backend/app/routes/trips.js)) — behind `requireAuth`. Validates
  `tripName`/`origin`/`destination` and each detour's `placeName` + coordinates,
  then writes the trip and all its detours in a **single transaction**
  (`db.getClient()` → `BEGIN` → client-scoped repositories → `COMMIT`/`ROLLBACK`
  → `release`), so a partial failure never leaves an orphan trip. The owner is
  always `req.userId` — never trusted from the request body.
- **Full-fidelity persistence with no extra API calls.** `buildTripPayload`
  ([frontend/src/scripts/TripRequester.js](frontend/src/scripts/TripRequester.js)) reads exact coordinates, distance
  (meters), duration (seconds), and the encoded polyline straight from the Google
  route object already in Redux, and maps detours to the DB shape.
- **UI** — a green, pill-styled **Save Trip** button in the trip summary
  ([SaveTrip.jsx](frontend/src/components/sidebar/SaveTrip.jsx)): a Fluent name dialog for signed-in users, a Fluent
  "sign in to save" dialog for anonymous users (which routes into the Entra login
  flow), and a Fluent toast on success/error.
- **Survives the login redirect.** The planning state is persisted to
  `sessionStorage` ([frontend/src/index.js](frontend/src/index.js)) so an in-progress trip is not lost when
  an anonymous user is sent through the full-page sign-in flow; on return, the
  name dialog reopens automatically to resume the save.

## View Saved Trips

- **Pagination on the backend** — `TripRepository.getTripsByUserId` gained
  optional `{ limit, offset }` (backward-compatible) and a new
  `countTripsByUserId`; `GET /api/trips` now accepts `page`/`limit` (default 10,
  clamped 1–50) and returns `{ trips, total, page, limit }`, newest-first.
- **My Trips drawer** ([MyTrips.jsx](frontend/src/components/sidebar/MyTrips.jsx)) — a "My Trips" button (shown only when
  signed in) opens a **non-modal** Fluent `OverlayDrawer` so the map stays
  visible. Each trip shows name, origin → destination (address), and saved date,
  with Prev/Next paging ("Page X of N"), a loading spinner, an error state, and an
  empty state. Rows are display-only for now.
- **Header toolbar** — `MyTrips` and the existing `AuthButton` are grouped in a
  fixed top-right toolbar ([Main.jsx](frontend/src/components/Main.jsx), [App.css](frontend/src/styles/App.css)).

## Testing

- Backend: **109 tests pass**, including new repository tests (pagination +
  count) and route tests (transactional create, validation, rollback on detour
  failure, zero-detour save, paginated listing, defaults, and clamping).
- Frontend: **52 tests pass**, including `buildTripPayload` extraction and
  `TripRequester.listTrips`.
- Lint clean across changed files.

## Manual verification

- Plan a route + detours → **Save Trip** → name it → success toast → rows appear
  in `trips`/`detours` (with `distance_meters`, `duration_seconds`,
  `route_polyline`).
- Signed-out **Save Trip** → sign-in prompt → after login the trip is intact and
  the name dialog reopens.
- **My Trips** lists trips newest-first, paginates, and shows the empty state for
  a new account; the map remains visible behind the drawer.
- Unauthenticated `GET /api/trips` and `POST /api/trips` return `401`.

## Known follow-ups (out of scope)

- Clicking a saved trip to preview/load it back onto the map.
- Unifying the custom planning sidebar and the trips drawer into one Fluent
  tabbed drawer (and resolving the drawer overlapping the top-right toolbar).
- Duplicate trip-name handling (currently allowed by design).

## Notes for reviewers

- New frontend dependency: `@fluentui/react-components` (React 19 compatible;
  peer range `>=16.14.0 <20.0.0`). The app root is wrapped in `FluentProvider`.
- No schema changes — uses the existing `trips`/`detours` tables.