### PR TITLE
Load saved trips

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,55 @@ trips.
 - Frontend: `cd frontend && CI=true npm test`.
 - Keep the suite green and add tests for new backend routes/repos.
 
+## Reviewing code
+
+When reviewing code, focus on:
+
+### Security Critical Issues
+
+- Check for hardcoded secrets, API keys, or credentials
+- Look for SQL injection and XSS vulnerabilities
+- Verify proper input validation and sanitization
+- Review authentication and authorization logic
+
+### Performance Red Flags
+
+- Identify N+1 database query problems
+- Spot inefficient loops and algorithmic issues
+- Check for memory leaks and resource cleanup
+- Review caching opportunities for expensive operations
+
+### Code Quality Essentials
+
+- Functions should be focused and appropriately sized
+- Use clear, descriptive naming conventions
+- Ensure proper error handling throughout
+
+### Review Style
+
+- Be specific and actionable in feedback
+- Explain the "why" behind recommendations
+- Acknowledge good patterns when you see them
+- Ask clarifying questions when code intent is unclear
+
+Always prioritize security vulnerabilities and performance issues that could impact users.
+
+Always suggest changes to improve readability. For example, this suggestion seeks to make the code more readable and also makes the validation logic reusable and testable.
+
+// Instead of:
+if (user.email && user.email.includes('@') && user.email.length > 5) {
+submitButton.enabled = true;
+} else {
+submitButton.enabled = false;
+}
+
+// Consider:
+function isValidEmail(email) {
+return email && email.includes('@') && email.length > 5;
+}
+
+submitButton.enabled = isValidEmail(user.email);
+
 ## Pull Requests
 
 - When asked for a PR description, provide a summary of the change, what files were modified, how to test the

--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -25,9 +25,11 @@ function buildSummary(distanceMeters, durationSeconds) {
   const min = Math.floor((seconds / 3600 - hours) * 60);
 
   let distance = (distanceMeters || 0) / METERS_PER_MILE;
-  // At least 3 significant digits under 100 mi; whole miles at or above 100.
-  distance =
-    distance < 100 ? Number(distance.toPrecision(3)) : Math.round(distance);
+  // Match routeAPI.createSummaryData exactly: under 100 mi the distance is a
+  // toPrecision(3) STRING (preserving trailing zeros like "2.00"), at/above 100
+  // it is a rounded number. Keeping the string means a loaded trip displays
+  // identically to a freshly planned one.
+  distance = distance < 100 ? distance.toPrecision(3) : Math.round(distance);
 
   return { time: { hours, min }, distance };
 }

--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -1,0 +1,118 @@
+/**
+ * tripView — reconstructs a render-ready view of a saved trip.
+ *
+ * A saved trip persists only the *encoded* route polyline plus distance/duration
+ * (see POST /api/trips). The frontend map, however, renders from a decoded
+ * points array and needs map bounds and a formatted summary. The frontend has
+ * no polyline decoder, so we rebuild all of that here (the backend already
+ * depends on `polyline-encoded`) and hand the client a route object shaped like
+ * the one it gets during normal planning.
+ */
+
+const polylineEncoder = require("polyline-encoded");
+
+// Meters per mile (matches routeAPI's conversion).
+const METERS_PER_MILE = 1609.34;
+
+/**
+ * Format distance (meters) + duration (seconds) into the summary shape the
+ * sidebar renders: { time: { hours, min }, distance }. Mirrors
+ * routeAPI.createSummaryData so a loaded trip reads identically to a fresh one.
+ */
+function buildSummary(distanceMeters, durationSeconds) {
+  const seconds = durationSeconds || 0;
+  const hours = Math.floor(seconds / 3600);
+  const min = Math.floor((seconds / 3600 - hours) * 60);
+
+  let distance = (distanceMeters || 0) / METERS_PER_MILE;
+  // At least 3 significant digits under 100 mi; whole miles at or above 100.
+  distance =
+    distance < 100 ? Number(distance.toPrecision(3)) : Math.round(distance);
+
+  return { time: { hours, min }, distance };
+}
+
+/**
+ * Compute Google-style bounds from an array of [lat, lng] points.
+ *
+ * @param {Array<[number, number]>} points
+ * @returns {{northeast:{lat:number,lng:number}, southwest:{lat:number,lng:number}}|null}
+ */
+function computeBounds(points) {
+  if (!points || points.length === 0) {
+    return null;
+  }
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+  for (const [lat, lng] of points) {
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+  }
+  return {
+    northeast: { lat: maxLat, lng: maxLng },
+    southwest: { lat: minLat, lng: minLng },
+  };
+}
+
+/**
+ * Map a stored detour row to the frontend detour shape. DECIMAL columns come
+ * back from pg as strings, so coerce the numerics.
+ */
+function mapDetour(row) {
+  return {
+    name: row.place_name,
+    type: row.place_type,
+    lat: Number(row.latitude),
+    lng: Number(row.longitude),
+    id: row.place_id,
+    placeId: row.place_id,
+    rating: row.rating != null ? Number(row.rating) : null,
+    addedTime: row.metadata ? row.metadata.addedTime : undefined,
+  };
+}
+
+/**
+ * Build the client-facing view of a saved trip.
+ *
+ * @param {object} trip - A row from TripRepository.getTripById.
+ * @param {object[]} [detours] - Rows from DetourRepository.getDetoursByTripId.
+ * @returns {{trip: object, route: object|null, detours: object[]}}
+ */
+function buildTripView(trip, detours = []) {
+  const points = trip.route_polyline
+    ? polylineEncoder.decode(trip.route_polyline)
+    : [];
+
+  const route =
+    points.length > 0
+      ? {
+          overview_polyline: {
+            points: trip.route_polyline,
+            // MapContainer reads complete_overview; DetourForm reads
+            // decodedPoints — provide both so loaded trips render and can still
+            // be extended with new detours.
+            complete_overview: points,
+            decodedPoints: points,
+          },
+          bounds: computeBounds(points),
+          summary: buildSummary(trip.distance_meters, trip.duration_seconds),
+        }
+      : null;
+
+  return {
+    trip: {
+      tripId: trip.trip_id,
+      tripName: trip.trip_name,
+      origin: trip.origin,
+      destination: trip.destination,
+    },
+    route,
+    detours: (detours || []).map(mapDetour),
+  };
+}
+
+module.exports = { buildTripView, buildSummary, computeBounds };

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -10,15 +10,16 @@ const SAMPLE_POINTS = [
 
 describe("buildSummary", () => {
   it("converts meters to miles and seconds to hours/min", () => {
-    // 3218.68 m = 2 mi; 5400 s = 1 h 30 m.
+    // 3218.68 m = 2 mi; 5400 s = 1 h 30 m. Under 100 mi is a toPrecision(3)
+    // string (matches routeAPI), so "2.00" not 2.
     const summary = buildSummary(3218.68, 5400);
-    expect(summary.distance).toBe(2);
+    expect(summary.distance).toBe("2.00");
     expect(summary.time).toEqual({ hours: 1, min: 30 });
   });
 
   it("keeps 3 significant digits under 100 miles", () => {
     const summary = buildSummary(16093.4, 0); // ~10 mi
-    expect(summary.distance).toBe(10);
+    expect(summary.distance).toBe("10.0");
     expect(summary.time).toEqual({ hours: 0, min: 0 });
   });
 
@@ -29,7 +30,7 @@ describe("buildSummary", () => {
 
   it("treats null distance/duration as zero", () => {
     expect(buildSummary(null, null)).toEqual({
-      distance: 0,
+      distance: "0.00",
       time: { hours: 0, min: 0 },
     });
   });
@@ -79,7 +80,7 @@ describe("buildTripView", () => {
     expect(view.route.bounds.northeast.lat).toBeCloseTo(43.252, 3);
     expect(view.route.bounds.southwest.lng).toBeCloseTo(-126.453, 3);
     expect(view.route.summary).toEqual({
-      distance: 2,
+      distance: "2.00",
       time: { hours: 1, min: 30 },
     });
   });

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -1,0 +1,129 @@
+const { buildTripView, buildSummary, computeBounds } = require("./tripView");
+
+// The canonical Google-documented polyline; decodes to three points.
+const SAMPLE_POLYLINE = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+const SAMPLE_POINTS = [
+  [38.5, -120.2],
+  [40.7, -120.95],
+  [43.252, -126.453],
+];
+
+describe("buildSummary", () => {
+  it("converts meters to miles and seconds to hours/min", () => {
+    // 3218.68 m = 2 mi; 5400 s = 1 h 30 m.
+    const summary = buildSummary(3218.68, 5400);
+    expect(summary.distance).toBe(2);
+    expect(summary.time).toEqual({ hours: 1, min: 30 });
+  });
+
+  it("keeps 3 significant digits under 100 miles", () => {
+    const summary = buildSummary(16093.4, 0); // ~10 mi
+    expect(summary.distance).toBe(10);
+    expect(summary.time).toEqual({ hours: 0, min: 0 });
+  });
+
+  it("rounds to whole miles at or above 100", () => {
+    const summary = buildSummary(200000, 0); // ~124.3 mi
+    expect(summary.distance).toBe(124);
+  });
+
+  it("treats null distance/duration as zero", () => {
+    expect(buildSummary(null, null)).toEqual({
+      distance: 0,
+      time: { hours: 0, min: 0 },
+    });
+  });
+});
+
+describe("computeBounds", () => {
+  it("returns north-east / south-west corners", () => {
+    expect(computeBounds(SAMPLE_POINTS)).toEqual({
+      northeast: { lat: 43.252, lng: -120.2 },
+      southwest: { lat: 38.5, lng: -126.453 },
+    });
+  });
+
+  it("returns null for empty points", () => {
+    expect(computeBounds([])).toBeNull();
+  });
+});
+
+describe("buildTripView", () => {
+  const trip = {
+    trip_id: "t1",
+    trip_name: "Coastal drive",
+    origin: { address: "SF", lat: 37.77, lng: -122.42 },
+    destination: { address: "LA", lat: 34.05, lng: -118.24 },
+    route_polyline: SAMPLE_POLYLINE,
+    distance_meters: 3218.68,
+    duration_seconds: 5400,
+  };
+
+  it("decodes the polyline into complete_overview and decodedPoints", () => {
+    const view = buildTripView(trip, []);
+
+    expect(view.route.overview_polyline.points).toBe(SAMPLE_POLYLINE);
+    expect(view.route.overview_polyline.complete_overview).toHaveLength(3);
+    // Same array is exposed under both keys the frontend reads.
+    expect(view.route.overview_polyline.decodedPoints).toBe(
+      view.route.overview_polyline.complete_overview
+    );
+    view.route.overview_polyline.complete_overview.forEach((point, i) => {
+      expect(point[0]).toBeCloseTo(SAMPLE_POINTS[i][0], 3);
+      expect(point[1]).toBeCloseTo(SAMPLE_POINTS[i][1], 3);
+    });
+  });
+
+  it("includes bounds and a formatted summary", () => {
+    const view = buildTripView(trip, []);
+    expect(view.route.bounds.northeast.lat).toBeCloseTo(43.252, 3);
+    expect(view.route.bounds.southwest.lng).toBeCloseTo(-126.453, 3);
+    expect(view.route.summary).toEqual({
+      distance: 2,
+      time: { hours: 1, min: 30 },
+    });
+  });
+
+  it("returns the trip identity and endpoints", () => {
+    const view = buildTripView(trip, []);
+    expect(view.trip).toEqual({
+      tripId: "t1",
+      tripName: "Coastal drive",
+      origin: { address: "SF", lat: 37.77, lng: -122.42 },
+      destination: { address: "LA", lat: 34.05, lng: -118.24 },
+    });
+  });
+
+  it("maps detours and coerces DECIMAL string columns to numbers", () => {
+    const view = buildTripView(trip, [
+      {
+        place_name: "Big Sur",
+        place_type: "Landmark",
+        latitude: "36.27000000",
+        longitude: "-121.80000000",
+        place_id: "gp-1",
+        rating: "4.8",
+        metadata: { addedTime: 45 },
+      },
+    ]);
+
+    expect(view.detours).toEqual([
+      {
+        name: "Big Sur",
+        type: "Landmark",
+        lat: 36.27,
+        lng: -121.8,
+        id: "gp-1",
+        placeId: "gp-1",
+        rating: 4.8,
+        addedTime: 45,
+      },
+    ]);
+  });
+
+  it("returns a null route when the trip has no polyline", () => {
+    const view = buildTripView({ ...trip, route_polyline: null }, []);
+    expect(view.route).toBeNull();
+    expect(view.trip.tripId).toBe("t1");
+  });
+});

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -14,20 +14,30 @@ const requireAuth = require("../middleware/requireAuth");
 const logger = require("../utils/logger");
 const TripRepository = require("../repositories/TripRepository");
 const DetourRepository = require("../repositories/DetourRepository");
+const { buildTripView } = require("../modules/tripView");
 
 // Pagination defaults for GET /api/trips.
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 
+// trip_id is a uuid column, so reject malformed ids up front (otherwise
+// Postgres throws 22P02 and the request surfaces as a 500).
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @param {import('../repositories/DetourRepository')} deps.detourRepository
  * @param {{ getClient: Function }} deps.db - Pool with getClient() for transactions.
  * @returns {import('express').Router}
  */
-function createTripsRouter({ tripRepository, db }) {
+function createTripsRouter({ tripRepository, detourRepository, db }) {
   if (!tripRepository) {
     throw new Error("createTripsRouter requires a tripRepository");
+  }
+  if (!detourRepository) {
+    throw new Error("createTripsRouter requires a detourRepository");
   }
   if (!db || typeof db.getClient !== "function") {
     throw new Error("createTripsRouter requires a db with a getClient method");
@@ -51,6 +61,32 @@ function createTripsRouter({ tripRepository, db }) {
     } catch (err) {
       logger.error("GET /api/trips failed", err);
       return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  // Load a single trip (with its detours) for the signed-in user, reconstructed
+  // into a render-ready view (decoded route + bounds + summary). Scoped by
+  // req.userId — getTripById returns null for a trip the user does not own.
+  router.get("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+    try {
+      const trip = await tripRepository.getTripById(
+        req.params.tripId,
+        req.userId
+      );
+      if (!trip) {
+        return res.status(404).json({ error: "Trip not found" });
+      }
+      const detours = await detourRepository.getDetoursByTripId(
+        req.params.tripId,
+        req.userId
+      );
+      return res.json(buildTripView(trip, detours));
+    } catch (err) {
+      logger.error("GET /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to load trip" });
     }
   });
 

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -23,6 +23,7 @@ const createTripsRouter = require("./trips");
 
 describe("trips routes", () => {
   let tripRepository;
+  let detourRepository;
   let db;
   let client;
 
@@ -31,6 +32,10 @@ describe("trips routes", () => {
     tripRepository = {
       getTripsByUserId: jest.fn(),
       countTripsByUserId: jest.fn(),
+      getTripById: jest.fn(),
+    };
+    detourRepository = {
+      getDetoursByTripId: jest.fn(),
     };
     client = {
       query: jest.fn().mockResolvedValue({}),
@@ -44,7 +49,10 @@ describe("trips routes", () => {
       req.session = userId ? { userId } : {};
       next();
     });
-    app.use("/api/trips", createTripsRouter({ tripRepository, db }));
+    app.use(
+      "/api/trips",
+      createTripsRouter({ tripRepository, detourRepository, db })
+    );
     return app;
   }
 
@@ -59,10 +67,16 @@ describe("trips routes", () => {
       );
     });
 
+    it("throws when no detourRepository is provided", () => {
+      expect(() =>
+        createTripsRouter({ tripRepository: {}, db: { getClient: jest.fn() } })
+      ).toThrow("createTripsRouter requires a detourRepository");
+    });
+
     it("throws when no db with getClient is provided", () => {
-      expect(() => createTripsRouter({ tripRepository: {} })).toThrow(
-        "createTripsRouter requires a db with a getClient method"
-      );
+      expect(() =>
+        createTripsRouter({ tripRepository: {}, detourRepository: {} })
+      ).toThrow("createTripsRouter requires a db with a getClient method");
     });
   });
 
@@ -255,6 +269,102 @@ describe("trips routes", () => {
       expect(mockCreateTrip).toHaveBeenCalledWith(
         expect.objectContaining({ distanceMeters: 0, durationSeconds: 0 })
       );
+    });
+  });
+
+  describe("GET /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const tripRow = {
+      trip_id: TRIP_ID,
+      trip_name: "Coastal drive",
+      origin: { address: "SF", lat: 37.77, lng: -122.42 },
+      destination: { address: "LA", lat: 34.05, lng: -118.24 },
+      route_polyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+      distance_meters: 3218.68,
+      duration_seconds: 5400,
+    };
+
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(tripRepository.getTripById).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+
+      const res = await request(app).get("/api/trips/not-a-uuid");
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.getTripById).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockResolvedValue(null);
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.getTripById).toHaveBeenCalledWith(
+        TRIP_ID,
+        "user-1"
+      );
+      expect(detourRepository.getDetoursByTripId).not.toHaveBeenCalled();
+    });
+
+    it("returns the reconstructed trip view (route + detours) for the owner", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockResolvedValue(tripRow);
+      detourRepository.getDetoursByTripId.mockResolvedValue([
+        {
+          place_name: "Big Sur",
+          place_type: "Landmark",
+          latitude: "36.27000000",
+          longitude: "-121.80000000",
+          place_id: "gp-1",
+          rating: "4.8",
+          metadata: { addedTime: 45 },
+        },
+      ]);
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trip).toMatchObject({
+        tripId: TRIP_ID,
+        tripName: "Coastal drive",
+      });
+      expect(res.body.route.overview_polyline.complete_overview).toHaveLength(
+        3
+      );
+      expect(res.body.route.summary).toEqual({
+        distance: 2,
+        time: { hours: 1, min: 30 },
+      });
+      expect(res.body.detours).toEqual([
+        {
+          name: "Big Sur",
+          type: "Landmark",
+          lat: 36.27,
+          lng: -121.8,
+          id: "gp-1",
+          placeId: "gp-1",
+          rating: 4.8,
+          addedTime: 45,
+        },
+      ]);
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockRejectedValue(new Error("DB down"));
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(500);
     });
   });
 });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -341,7 +341,7 @@ describe("trips routes", () => {
         3
       );
       expect(res.body.route.summary).toEqual({
-        distance: 2,
+        distance: "2.00",
         time: { hours: 1, min: 30 },
       });
       expect(res.body.detours).toEqual([

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,7 @@ const placesAPI = require("./app/modules/placesAPI");
 const db = require("./app/db/pool");
 const UserRepository = require("./app/repositories/UserRepository");
 const TripRepository = require("./app/repositories/TripRepository");
+const DetourRepository = require("./app/repositories/DetourRepository");
 const createAuthRouter = require("./app/routes/auth");
 const createTripsRouter = require("./app/routes/trips");
 
@@ -61,9 +62,13 @@ app.use(
 // Compose the data-access layer once and inject it into the routers.
 const userRepository = new UserRepository(db);
 const tripRepository = new TripRepository(db);
+const detourRepository = new DetourRepository(db);
 
 app.use("/auth", createAuthRouter({ userRepository }));
-app.use("/api/trips", createTripsRouter({ tripRepository, db }));
+app.use(
+  "/api/trips",
+  createTripsRouter({ tripRepository, detourRepository, db })
+);
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
@@ -34,6 +34,29 @@ function formatEndpoint(point) {
   return "Unknown";
 }
 
+// Rebuild the planning state from a loaded trip view. clearAll first so a loaded
+// trip never merges with an in-progress one; SET_ROUTE also flips showRoute /
+// showDetourButton so the map and sidebar render.
+function applyTripView(dispatch, { trip, route, detours }) {
+  dispatch({ type: "CLEAR_ALL" });
+  dispatch({
+    type: "SET_ORIGIN",
+    data: { origin: (trip.origin && trip.origin.address) || "" },
+  });
+  dispatch({
+    type: "SET_DESTINATION",
+    data: { destination: (trip.destination && trip.destination.address) || "" },
+  });
+  if (route) {
+    dispatch({ type: "SET_ROUTE", data: { route } });
+    dispatch({
+      type: "SET_TRIP_SUMMARY",
+      data: { tripSummary: route.summary },
+    });
+  }
+  dispatch({ type: "SET_DETOUR_LIST", data: { detourList: detours || [] } });
+}
+
 /**
  * MyTrips — a "My Trips" button (shown only when signed in) that opens a
  * non-modal Fluent drawer listing the user's saved trips. The drawer overlays
@@ -51,6 +74,11 @@ export default function MyTrips() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [loadingTripId, setLoadingTripId] = useState(null);
+
+  // Monotonic token for load requests. Only the most recent click's response is
+  // applied, so quick successive clicks can't resolve out of order and load the
+  // wrong trip (or let an earlier request clear the later one's loading state).
+  const latestRequestRef = useRef(0);
 
   const toasterId = useId("my-trips-toaster");
   const { dispatchToast } = useToastController(toasterId);
@@ -80,41 +108,29 @@ export default function MyTrips() {
   // instantly, so a momentary spinner would just be a distracting flash.
   const loadTrip = useCallback(
     (tripId) => {
+      const requestId = latestRequestRef.current + 1;
+      latestRequestRef.current = requestId;
+      const isLatest = () => latestRequestRef.current === requestId;
+
       let settled = false;
       const spinnerTimer = setTimeout(() => {
-        if (!settled) {
+        if (!settled && isLatest()) {
           setLoadingTripId(tripId);
         }
       }, 250);
       new TripRequester()
         .getTrip(tripId)
         .then((view) => {
-          const { trip, route, detours } = view;
-          dispatch({ type: "CLEAR_ALL" });
-          dispatch({
-            type: "SET_ORIGIN",
-            data: { origin: (trip.origin && trip.origin.address) || "" },
-          });
-          dispatch({
-            type: "SET_DESTINATION",
-            data: {
-              destination: (trip.destination && trip.destination.address) || "",
-            },
-          });
-          if (route) {
-            dispatch({ type: "SET_ROUTE", data: { route } });
-            dispatch({
-              type: "SET_TRIP_SUMMARY",
-              data: { tripSummary: route.summary },
-            });
+          // Ignore a stale response from a superseded click.
+          if (isLatest()) {
+            applyTripView(dispatch, view);
           }
-          dispatch({
-            type: "SET_DETOUR_LIST",
-            data: { detourList: detours || [] },
-          });
         })
         .catch((err) => {
           log.error("Failed to load trip:", err);
+          if (!isLatest()) {
+            return;
+          }
           dispatchToast(
             <Toast>
               <ToastTitle>
@@ -127,7 +143,10 @@ export default function MyTrips() {
         .finally(() => {
           settled = true;
           clearTimeout(spinnerTimer);
-          setLoadingTripId(null);
+          // Only the latest request owns the loading indicator.
+          if (isLatest()) {
+            setLoadingTripId(null);
+          }
         });
     },
     [dispatch, dispatchToast]

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
   OverlayDrawer,
@@ -9,8 +9,14 @@ import {
   Card,
   Text,
   Spinner,
+  Toaster,
+  Toast,
+  ToastTitle,
+  useToastController,
+  useId,
 } from "@fluentui/react-components";
 import TripRequester from "../../scripts/TripRequester";
+import log from "../../utils/logger";
 
 const PAGE_SIZE = 10;
 
@@ -31,11 +37,12 @@ function formatEndpoint(point) {
 /**
  * MyTrips — a "My Trips" button (shown only when signed in) that opens a
  * non-modal Fluent drawer listing the user's saved trips. The drawer overlays
- * the map without a backdrop, so the map stays visible behind it. List-only for
- * now; loading a trip onto the map is a later story.
+ * the map without a backdrop, so the map stays visible behind it. Clicking a
+ * trip loads it onto the map and into the sidebar; the drawer stays open.
  */
 export default function MyTrips() {
   const user = useSelector((state) => state.user);
+  const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
   const [trips, setTrips] = useState([]);
@@ -43,6 +50,10 @@ export default function MyTrips() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const [loadingTripId, setLoadingTripId] = useState(null);
+
+  const toasterId = useId("my-trips-toaster");
+  const { dispatchToast } = useToastController(toasterId);
 
   const load = useCallback((nextPage) => {
     setLoading(true);
@@ -63,6 +74,65 @@ export default function MyTrips() {
     load(1);
   };
 
+  // Fetch a saved trip and rebuild the planning state from it. clearAll first so
+  // a loaded trip never merges with an in-progress one. The drawer stays open.
+  // Only show the spinner if the load is slow (>250ms); fast loads render
+  // instantly, so a momentary spinner would just be a distracting flash.
+  const loadTrip = useCallback(
+    (tripId) => {
+      let settled = false;
+      const spinnerTimer = setTimeout(() => {
+        if (!settled) {
+          setLoadingTripId(tripId);
+        }
+      }, 250);
+      new TripRequester()
+        .getTrip(tripId)
+        .then((view) => {
+          const { trip, route, detours } = view;
+          dispatch({ type: "CLEAR_ALL" });
+          dispatch({
+            type: "SET_ORIGIN",
+            data: { origin: (trip.origin && trip.origin.address) || "" },
+          });
+          dispatch({
+            type: "SET_DESTINATION",
+            data: {
+              destination: (trip.destination && trip.destination.address) || "",
+            },
+          });
+          if (route) {
+            dispatch({ type: "SET_ROUTE", data: { route } });
+            dispatch({
+              type: "SET_TRIP_SUMMARY",
+              data: { tripSummary: route.summary },
+            });
+          }
+          dispatch({
+            type: "SET_DETOUR_LIST",
+            data: { detourList: detours || [] },
+          });
+        })
+        .catch((err) => {
+          log.error("Failed to load trip:", err);
+          dispatchToast(
+            <Toast>
+              <ToastTitle>
+                Could not load that trip. Please try again.
+              </ToastTitle>
+            </Toast>,
+            { intent: "error" }
+          );
+        })
+        .finally(() => {
+          settled = true;
+          clearTimeout(spinnerTimer);
+          setLoadingTripId(null);
+        });
+    },
+    [dispatch, dispatchToast]
+  );
+
   if (!user) {
     return null;
   }
@@ -71,6 +141,7 @@ export default function MyTrips() {
 
   return (
     <>
+      <Toaster toasterId={toasterId} />
       <Button appearance="secondary" id="my-trips-button" onClick={handleOpen}>
         My Trips
       </Button>
@@ -109,7 +180,30 @@ export default function MyTrips() {
             <>
               <div className="my-trips-list">
                 {trips.map((trip) => (
-                  <Card key={trip.trip_id} className="my-trips-card">
+                  <Card
+                    key={trip.trip_id}
+                    className="my-trips-card"
+                    style={{ position: "relative" }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Load trip ${trip.trip_name}`}
+                    aria-busy={loadingTripId === trip.trip_id}
+                    onClick={() => loadTrip(trip.trip_id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        loadTrip(trip.trip_id);
+                      }
+                    }}
+                  >
+                    {loadingTripId === trip.trip_id && (
+                      <div
+                        style={{ position: "absolute", top: 8, right: 8 }}
+                        aria-hidden="true"
+                      >
+                        <Spinner size="tiny" />
+                      </div>
+                    )}
                     <Text weight="semibold">{trip.trip_name}</Text>
                     <Text size={200}>
                       {formatEndpoint(trip.origin)} &rarr;{" "}

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -202,7 +202,6 @@ export default function MyTrips() {
                   <Card
                     key={trip.trip_id}
                     className="my-trips-card"
-                    style={{ position: "relative" }}
                     role="button"
                     tabIndex={0}
                     aria-label={`Load trip ${trip.trip_name}`}
@@ -217,7 +216,7 @@ export default function MyTrips() {
                   >
                     {loadingTripId === trip.trip_id && (
                       <div
-                        style={{ position: "absolute", top: 8, right: 8 }}
+                        className="my-trips-card__spinner"
                         aria-hidden="true"
                       >
                         <Spinner size="tiny" />

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -111,4 +111,22 @@ export default class TripRequester {
         throw error;
       });
   }
+
+  /**
+   * Load a single saved trip, reconstructed for rendering.
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @returns {Promise<object>} { trip, route, detours }
+   */
+  getTrip(tripId) {
+    return axios
+      .get(this.getUrlBase() + "/api/trips/" + tripId, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to load trip:", error);
+        throw error;
+      });
+  }
 }

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -158,3 +158,29 @@ describe("TripRequester.listTrips", () => {
     await expect(new TripRequester().listTrips()).rejects.toThrow("network");
   });
 });
+
+describe("TripRequester.getTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests the trip by id with credentials and returns the data", async () => {
+    const data = { trip: { tripId: "t1" }, route: {}, detours: [] };
+    axios.get.mockResolvedValue({ data });
+
+    const result = await new TripRequester().getTrip("t1");
+
+    const [url, options] = axios.get.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.get.mockRejectedValue(new Error("not found"));
+
+    await expect(new TripRequester().getTrip("bad")).rejects.toThrow(
+      "not found"
+    );
+  });
+});

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -82,6 +82,14 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  position: relative;
+}
+
+/* Overlay the load spinner in the corner so it never resizes the card. */
+.my-trips-card__spinner {
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .my-trips-pager {


### PR DESCRIPTION
# Load a saved trip onto the map

## Summary

Lets a signed-in user click a trip in the **My Trips** drawer to load it back
onto the map and into the sidebar, ready to keep planning. Because a saved trip
only persists an *encoded* polyline plus distance/duration, the backend
reconstructs a render-ready route (decoded points, map bounds, formatted
summary) so the frontend — which has no polyline decoder — can render it exactly
like a freshly planned trip.

## Changes

### Backend
- **New `backend/app/modules/tripView.js`** — `buildTripView(trip, detours)`
  decodes `route_polyline` into `overview_polyline.complete_overview` **and**
  `decodedPoints` (the map reads the former, the detour form the latter, so a
  loaded trip can still be extended), computes `bounds`, and rebuilds `summary`
  mirroring the existing `routeAPI` formatting. Detours are mapped to the
  frontend shape with the `DECIMAL` lat/lng/rating coerced from strings to
  numbers. A trip with no polyline yields `route: null`.
- **`backend/app/routes/trips.js`** — new `GET /api/trips/:tripId` (behind
  `requireAuth`): validates the id is a UUID (returns `404` on a malformed id
  instead of surfacing a Postgres `22P02` as a `500`), loads the user-scoped trip
  (`404` if not found/owned), fetches its detours, and returns
  `buildTripView(...)`. `DetourRepository` is now injected into the router.
- **`backend/index.js`** — instantiates and injects `DetourRepository`.

### Frontend
- **`frontend/src/scripts/TripRequester.js`** — adds `getTrip(tripId)`
  (credentialed `GET /api/trips/:tripId`).
- **`frontend/src/components/sidebar/MyTrips.jsx`** — trip cards are now
  clickable (mouse + keyboard, `role="button"`). Clicking dispatches
  `clearAll` → `setOrigin`/`setDestination` → `setRoute` + `setTripSummary`
  (when a route exists) → `setDetourList`, so the route line + detour pins render
  and the map fits the bounds. The drawer intentionally **stays open**. A load
  failure shows a Fluent error toast. The per-card load spinner only appears if
  the fetch exceeds 250ms and is absolutely positioned so it never resizes the
  card (avoids a flash on fast loads).
- **`frontend/src/styles/App.css`** — minor styles for the card spinner overlay.

## Testing

- Backend: **128 tests pass**, including new `tripView` unit tests (decode,
  bounds, summary formatting, detour numeric coercion, null-polyline) and new
  `GET /api/trips/:tripId` route tests (401, 404 not-owned, 404 malformed-UUID,
  200 reconstructed view, 500).
- Frontend: **55 tests pass**, including `TripRequester.getTrip`.
- Lint clean across changed files.

## How to test

1. Sign in, plan a route with a detour, and save it.
2. Open **My Trips** and click the trip: the route line and detour pins render,
   the map fits the trip's bounds, and the sidebar shows the distance/time +
   timeline. The drawer stays open.
3. Confirm **Add Detour** still works on the loaded route (the reconstructed
   route includes the decoded points the detour flow needs).
4. `GET /api/trips/<valid-uuid>` returns `{ trip, route, detours }`; a
   non-existent/other-user id returns `404`; a malformed id (e.g.
   `/api/trips/not-a-uuid`) returns `404`; unauthenticated returns `401`.

## Notes / assumptions

- **Route reconstruction on the backend** (rather than re-calling Google
  Directions) — deterministic replay of the saved trip and no extra API cost.
- The **drawer stays open** after loading (a deliberate deviation from the
  original AC's "close the drawer"); easy to flip if preferred.
- No schema changes — uses the existing `trips`/`detours` tables and repositories.

## Out of scope (follow-ups)

- Editing/renaming/deleting a loaded trip, or overwriting the saved copy
  (continued planning reuses the existing Add-Detour + Save-Trip = new trip).
- Unifying the custom planning sidebar and the trips drawer into one tabbed
  Fluent drawer (separate refactor).