### PR TITLE
Update delete saved trip

### DIFF
--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -112,6 +112,10 @@ function buildTripView(trip, detours = []) {
       origin: trip.origin,
       destination: trip.destination,
       updatedAt: trip.updated_at,
+      // Raw stored values so the client can persist them back on an update that
+      // hasn't re-routed (a rename), without recomputing from a route it lacks.
+      distanceMeters: trip.distance_meters ?? null,
+      durationSeconds: trip.duration_seconds ?? null,
     },
     route,
     detours: (detours || []).map(mapDetour),

--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -111,6 +111,7 @@ function buildTripView(trip, detours = []) {
       tripName: trip.trip_name,
       origin: trip.origin,
       destination: trip.destination,
+      updatedAt: trip.updated_at,
     },
     route,
     detours: (detours || []).map(mapDetour),

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -58,6 +58,7 @@ describe("buildTripView", () => {
     route_polyline: SAMPLE_POLYLINE,
     distance_meters: 3218.68,
     duration_seconds: 5400,
+    updated_at: "2026-07-07T12:00:00.000Z",
   };
 
   it("decodes the polyline into complete_overview and decodedPoints", () => {
@@ -92,6 +93,7 @@ describe("buildTripView", () => {
       tripName: "Coastal drive",
       origin: { address: "SF", lat: 37.77, lng: -122.42 },
       destination: { address: "LA", lat: 34.05, lng: -118.24 },
+      updatedAt: "2026-07-07T12:00:00.000Z",
     });
   });
 

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -94,6 +94,8 @@ describe("buildTripView", () => {
       origin: { address: "SF", lat: 37.77, lng: -122.42 },
       destination: { address: "LA", lat: 34.05, lng: -118.24 },
       updatedAt: "2026-07-07T12:00:00.000Z",
+      distanceMeters: 3218.68,
+      durationSeconds: 5400,
     });
   });
 

--- a/backend/app/repositories/DetourRepository.js
+++ b/backend/app/repositories/DetourRepository.js
@@ -265,6 +265,31 @@ class DetourRepository {
       throw err;
     }
   }
+
+  /**
+   * Delete every detour on a trip. Used by "update trip" to replace the trip's
+   * detours wholesale (delete-all then re-insert) inside a transaction. Scoped
+   * by user_id via the parent trip, so a user cannot clear detours on a trip
+   * they do not own (the subquery matches no trip and nothing is deleted).
+   *
+   * @param {string} tripId - Parent trip UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<number>} The number of detours deleted.
+   */
+  async deleteByTripId(tripId, userId) {
+    const text = `
+      DELETE FROM detours
+      WHERE trip_id = $1
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rowCount;
+    } catch (err) {
+      logger.error("deleteByTripId failed", err);
+      throw err;
+    }
+  }
 }
 
 module.exports = DetourRepository;

--- a/backend/app/repositories/DetourRepository.test.js
+++ b/backend/app/repositories/DetourRepository.test.js
@@ -292,4 +292,33 @@ describe("DetourRepository", () => {
       );
     });
   });
+
+  describe("deleteByTripId", () => {
+    it("deletes all detours on a trip, scoped via the parent trip", async () => {
+      pool.query.mockResolvedValue({ rowCount: 3 });
+
+      const result = await repo.deleteByTripId(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM detours");
+      expect(sql).toContain("WHERE trip_id = $1");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)"
+      );
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(3);
+    });
+
+    it("returns 0 when the trip has no detours or is not owned", async () => {
+      pool.query.mockResolvedValue({ rowCount: 0 });
+      expect(await repo.deleteByTripId(TRIP_ID, "not-the-owner")).toBe(0);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteByTripId(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
 });

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -25,6 +25,22 @@ const MAX_LIMIT = 50;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Validate an inbound detour list (shared by POST create and PUT update).
+// Returns an error message string, or null when every detour is well-formed.
+function validateDetours(detours) {
+  for (const d of detours) {
+    if (
+      !d ||
+      !d.placeName ||
+      typeof d.latitude !== "number" ||
+      typeof d.longitude !== "number"
+    ) {
+      return "Each detour requires placeName, latitude, and longitude";
+    }
+  }
+  return null;
+}
+
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
@@ -115,17 +131,9 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
     }
 
     const detourList = Array.isArray(detours) ? detours : [];
-    for (const d of detourList) {
-      if (
-        !d ||
-        !d.placeName ||
-        typeof d.latitude !== "number" ||
-        typeof d.longitude !== "number"
-      ) {
-        return res.status(400).json({
-          error: "Each detour requires placeName, latitude, and longitude",
-        });
-      }
+    const detourError = validateDetours(detourList);
+    if (detourError) {
+      return res.status(400).json({ error: detourError });
     }
 
     let client;
@@ -181,6 +189,215 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
       return res.status(500).json({ error: "Failed to save trip" });
     } finally {
       client.release();
+    }
+  });
+
+  // Update an existing trip (and replace its detours) for the signed-in user.
+  // The trip row and its detours are rewritten in a single transaction:
+  // update the trip, delete all its current detours, then re-insert the ones in
+  // the request. Replacing wholesale mirrors the create flow and keeps the
+  // persisted detours exactly in sync with the client's list. Scoped by
+  // req.userId — updateTrip returns null for a trip the user does not own, which
+  // rolls back and 404s. Last-write-wins (no optimistic concurrency check).
+  router.put("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+
+    const {
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      detours,
+    } = req.body || {};
+
+    if (!tripName || typeof tripName !== "string" || !tripName.trim()) {
+      return res.status(400).json({ error: "tripName is required" });
+    }
+    if (!origin || !destination) {
+      return res
+        .status(400)
+        .json({ error: "origin and destination are required" });
+    }
+
+    const detourList = Array.isArray(detours) ? detours : [];
+    const detourError = validateDetours(detourList);
+    if (detourError) {
+      return res.status(400).json({ error: detourError });
+    }
+
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error("PUT /api/trips/:tripId failed to acquire DB client", err);
+      return res.status(500).json({ error: "Failed to update trip" });
+    }
+
+    try {
+      await client.query("BEGIN");
+
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const trip = await txTripRepo.updateTrip(req.params.tripId, req.userId, {
+        tripName: tripName.trim(),
+        origin,
+        destination,
+        routePolyline: routePolyline || null,
+        distanceMeters: distanceMeters ?? null,
+        durationSeconds: durationSeconds ?? null,
+      });
+
+      // Not found / not owned — nothing was updated, so unwind and 404.
+      if (!trip) {
+        await client.query("ROLLBACK");
+        return res.status(404).json({ error: "Trip not found" });
+      }
+
+      // Replace the trip's detours wholesale.
+      await txDetourRepo.deleteByTripId(req.params.tripId, req.userId);
+      const savedDetours = [];
+      for (const d of detourList) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: trip.trip_id,
+          userId: req.userId,
+          placeName: d.placeName,
+          latitude: d.latitude,
+          longitude: d.longitude,
+          placeId: d.placeId || null,
+          placeType: d.placeType || null,
+          address: d.address || null,
+          rating: d.rating || null,
+          metadata: d.metadata || {},
+        });
+        savedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.json(buildTripView(trip, savedDetours));
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("PUT /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to update trip" });
+    } finally {
+      client.release();
+    }
+  });
+
+  // Duplicate a trip (and all of its detours) for the signed-in user. The copy
+  // is named "Copy of <name>" and is written in a single transaction so a
+  // partial failure never leaves a half-copied trip. Scoped by req.userId — the
+  // source read returns null for a trip the user does not own, which 404s.
+  router.post("/:tripId/duplicate", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error(
+        "POST /api/trips/:tripId/duplicate failed to acquire DB client",
+        err
+      );
+      return res.status(500).json({ error: "Failed to duplicate trip" });
+    }
+
+    try {
+      await client.query("BEGIN");
+
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const source = await txTripRepo.getTripById(
+        req.params.tripId,
+        req.userId
+      );
+      if (!source) {
+        await client.query("ROLLBACK");
+        return res.status(404).json({ error: "Trip not found" });
+      }
+
+      const sourceDetours = await txDetourRepo.getDetoursByTripId(
+        req.params.tripId,
+        req.userId
+      );
+
+      const copy = await txTripRepo.createTrip({
+        userId: req.userId,
+        tripName: `Copy of ${source.trip_name}`,
+        origin: source.origin,
+        destination: source.destination,
+        routePolyline: source.route_polyline || null,
+        distanceMeters: source.distance_meters ?? null,
+        durationSeconds: source.duration_seconds ?? null,
+        departureTime: source.departure_time || null,
+        status: source.status,
+        metadata: source.metadata || {},
+      });
+
+      const copiedDetours = [];
+      for (const d of sourceDetours) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: copy.trip_id,
+          userId: req.userId,
+          placeName: d.place_name,
+          // DECIMAL columns come back from pg as strings — coerce to numbers.
+          latitude: Number(d.latitude),
+          longitude: Number(d.longitude),
+          placeId: d.place_id || null,
+          placeType: d.place_type || null,
+          address: d.address || null,
+          positionOnRoute: d.position_on_route ?? null,
+          estimatedDetourDurationSeconds:
+            d.estimated_detour_duration_seconds ?? null,
+          estimatedDetourDistanceMeters:
+            d.estimated_detour_distance_meters ?? null,
+          rating: d.rating != null ? Number(d.rating) : null,
+          priceLevel: d.price_level ?? null,
+          stopDurationMinutes: d.stop_duration_minutes ?? 30,
+          visitTime: d.visit_time || null,
+          notes: d.notes || null,
+          metadata: d.metadata || {},
+        });
+        copiedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.status(201).json({ trip: copy, detours: copiedDetours });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("POST /api/trips/:tripId/duplicate failed", err);
+      return res.status(500).json({ error: "Failed to duplicate trip" });
+    } finally {
+      client.release();
+    }
+  });
+
+  // Delete a trip (and its detours, via ON DELETE CASCADE) for the signed-in
+  // user. Scoped by req.userId — deleteTrip returns null for a trip the user
+  // does not own, which 404s.
+  router.delete("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+    try {
+      const deleted = await tripRepository.deleteTrip(
+        req.params.tripId,
+        req.userId
+      );
+      if (!deleted) {
+        return res.status(404).json({ error: "Trip not found" });
+      }
+      return res.json({ message: "Trip deleted" });
+    } catch (err) {
+      logger.error("DELETE /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to delete trip" });
     }
   });
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -32,8 +32,8 @@ function validateDetours(detours) {
     if (
       !d ||
       !d.placeName ||
-      typeof d.latitude !== "number" ||
-      typeof d.longitude !== "number"
+      !Number.isFinite(d.latitude) ||
+      !Number.isFinite(d.longitude)
     ) {
       return "Each detour requires placeName, latitude, and longitude";
     }
@@ -172,7 +172,7 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
           placeId: d.placeId || null,
           placeType: d.placeType || null,
           address: d.address || null,
-          rating: d.rating || null,
+          rating: d.rating != null ? Number(d.rating) : null,
           metadata: d.metadata || {},
         });
         savedDetours.push(detour);
@@ -271,7 +271,7 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
           placeId: d.placeId || null,
           placeType: d.placeType || null,
           address: d.address || null,
-          rating: d.rating || null,
+          rating: d.rating != null ? Number(d.rating) : null,
           metadata: d.metadata || {},
         });
         savedDetours.push(detour);

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -4,17 +4,30 @@ jest.mock("../utils/logger", () => ({
   error: jest.fn(),
 }));
 
-// Shared mocks for the transaction-scoped repositories. The POST handler does
-// `new TripRepository(client)` / `new DetourRepository(client)`, so we replace
-// the classes with constructors that return these controllable instances.
+// Shared mocks for the transaction-scoped repositories. The POST/PUT/duplicate
+// handlers do `new TripRepository(client)` / `new DetourRepository(client)`, so
+// we replace the classes with constructors that return these controllable
+// instances.
 const mockCreateTrip = jest.fn();
 const mockCreateDetour = jest.fn();
+const mockUpdateTrip = jest.fn();
+const mockDeleteByTripId = jest.fn();
+const mockTxGetTripById = jest.fn();
+const mockTxGetDetoursByTripId = jest.fn();
 
 jest.mock("../repositories/TripRepository", () =>
-  jest.fn().mockImplementation(() => ({ createTrip: mockCreateTrip }))
+  jest.fn().mockImplementation(() => ({
+    createTrip: mockCreateTrip,
+    updateTrip: mockUpdateTrip,
+    getTripById: mockTxGetTripById,
+  }))
 );
 jest.mock("../repositories/DetourRepository", () =>
-  jest.fn().mockImplementation(() => ({ createDetour: mockCreateDetour }))
+  jest.fn().mockImplementation(() => ({
+    createDetour: mockCreateDetour,
+    deleteByTripId: mockDeleteByTripId,
+    getDetoursByTripId: mockTxGetDetoursByTripId,
+  }))
 );
 
 const express = require("express");
@@ -33,6 +46,7 @@ describe("trips routes", () => {
       getTripsByUserId: jest.fn(),
       countTripsByUserId: jest.fn(),
       getTripById: jest.fn(),
+      deleteTrip: jest.fn(),
     };
     detourRepository = {
       getDetoursByTripId: jest.fn(),
@@ -363,6 +377,314 @@ describe("trips routes", () => {
       tripRepository.getTripById.mockRejectedValue(new Error("DB down"));
 
       const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("PUT /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const validBody = {
+      tripName: "Updated trip",
+      origin: { address: "A", lat: 1, lng: 2 },
+      destination: { address: "B", lat: 3, lng: 4 },
+      routePolyline: "abc",
+      distanceMeters: 2000,
+      durationSeconds: 1200,
+      detours: [
+        { placeName: "Park", latitude: 1.5, longitude: 2.5, placeType: "park" },
+      ],
+    };
+
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put("/api/trips/not-a-uuid")
+        .send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when tripName is missing", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, tripName: "  " });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when a detour is missing coordinates", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, detours: [{ placeName: "No coords" }] });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("updates the trip and replaces its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({
+        trip_id: TRIP_ID,
+        trip_name: "Updated trip",
+        updated_at: "2026-07-07T12:00:00.000Z",
+      });
+      mockDeleteByTripId.mockResolvedValue(1);
+      mockCreateDetour.mockResolvedValue({
+        place_name: "Park",
+        place_type: "park",
+        latitude: "1.5",
+        longitude: "2.5",
+        place_id: null,
+        rating: null,
+      });
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(200);
+      // Response is the reconstructed trip view (includes updatedAt).
+      expect(res.body.trip).toMatchObject({
+        tripId: TRIP_ID,
+        tripName: "Updated trip",
+        updatedAt: "2026-07-07T12:00:00.000Z",
+      });
+
+      // Owner comes from the session, not the body.
+      expect(mockUpdateTrip).toHaveBeenCalledWith(
+        TRIP_ID,
+        "user-1",
+        expect.objectContaining({
+          tripName: "Updated trip",
+          routePolyline: "abc",
+          distanceMeters: 2000,
+          durationSeconds: 1200,
+        })
+      );
+      expect(mockDeleteByTripId).toHaveBeenCalledWith(TRIP_ID, "user-1");
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: TRIP_ID,
+          userId: "user-1",
+          placeName: "Park",
+          latitude: 1.5,
+          longitude: 2.5,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("BEGIN");
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue(null);
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(mockDeleteByTripId).not.toHaveBeenCalled();
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a detour insert fails", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({ trip_id: TRIP_ID });
+      mockDeleteByTripId.mockResolvedValue(1);
+      mockCreateDetour.mockRejectedValue(new Error("detour insert failed"));
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("updates a trip and clears its detours when none are supplied", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({ trip_id: TRIP_ID });
+      mockDeleteByTripId.mockResolvedValue(2);
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, detours: [] });
+
+      expect(res.status).toBe(200);
+      expect(mockDeleteByTripId).toHaveBeenCalledWith(TRIP_ID, "user-1");
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
+  });
+
+  describe("POST /api/trips/:tripId/duplicate", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const sourceTrip = {
+      trip_id: TRIP_ID,
+      trip_name: "Coastal drive",
+      origin: { address: "SF" },
+      destination: { address: "LA" },
+      route_polyline: "abc",
+      distance_meters: 3218,
+      duration_seconds: 5400,
+      status: "planned",
+      metadata: {},
+    };
+
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app).post("/api/trips/not-a-uuid/duplicate");
+
+      expect(res.status).toBe(404);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 404 when the source is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(null);
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(404);
+      expect(mockCreateTrip).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("copies the trip and its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(sourceTrip);
+      mockTxGetDetoursByTripId.mockResolvedValue([
+        {
+          place_name: "Big Sur",
+          place_type: "Landmark",
+          latitude: "36.27",
+          longitude: "-121.8",
+          place_id: "gp-1",
+          rating: "4.8",
+          metadata: {},
+        },
+      ]);
+      mockCreateTrip.mockResolvedValue({ trip_id: "copy-1" });
+      mockCreateDetour.mockResolvedValue({ detour_id: "d1" });
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(201);
+      expect(res.body.trip).toEqual({ trip_id: "copy-1" });
+      // The copy is named "Copy of <name>" and owned by the session user.
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-1",
+          tripName: "Copy of Coastal drive",
+          routePolyline: "abc",
+        })
+      );
+      // Detours are copied onto the new trip, with numerics coerced.
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: "copy-1",
+          userId: "user-1",
+          placeName: "Big Sur",
+          latitude: 36.27,
+          longitude: -121.8,
+          rating: 4.8,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a copy insert fails", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(sourceTrip);
+      mockTxGetDetoursByTripId.mockResolvedValue([]);
+      mockCreateTrip.mockRejectedValue(new Error("insert failed"));
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(tripRepository.deleteTrip).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app).delete("/api/trips/not-a-uuid");
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.deleteTrip).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockResolvedValue(null);
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.deleteTrip).toHaveBeenCalledWith(TRIP_ID, "user-1");
+    });
+
+    it("deletes a trip the user owns", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockResolvedValue({ trip_id: TRIP_ID });
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ message: "Trip deleted" });
+      expect(tripRepository.deleteTrip).toHaveBeenCalledWith(TRIP_ID, "user-1");
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockRejectedValue(new Error("DB down"));
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
 
       expect(res.status).toBe(500);
     });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.5",
       "dependencies": {
         "@fluentui/react-components": "^9.74.3",
+        "@fluentui/react-icons": "^2.0.331",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@vis.gl/react-google-maps": "1.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fluentui/react-components": "^9.74.3",
+    "@fluentui/react-icons": "^2.0.331",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@vis.gl/react-google-maps": "1.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
     "redux": "5.0.1"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "start": "GENERATE_SOURCEMAP=false PORT=3001 react-scripts --openssl-legacy-provider start",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --watchAll=false",

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
@@ -93,6 +93,9 @@ function applyTripView(dispatch, { trip, route, detours }) {
  */
 export default function MyTrips() {
   const user = useSelector((state) => state.user);
+  // Bumped whenever a trip is saved/updated elsewhere (e.g. the Save Trip
+  // button) so the open list can refresh instead of showing stale data.
+  const tripsRevision = useSelector((state) => state.tripsRevision);
   const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
@@ -112,6 +115,9 @@ export default function MyTrips() {
   // applied, so quick successive clicks can't resolve out of order and load the
   // wrong trip (or let an earlier request clear the later one's loading state).
   const latestRequestRef = useRef(0);
+  // Tracks the last trips-revision we reacted to, so we only reload when a trip
+  // actually changed (not on the initial render).
+  const prevRevisionRef = useRef(tripsRevision);
 
   const toasterId = useId("my-trips-toaster");
   const { dispatchToast } = useToastController(toasterId);
@@ -134,6 +140,18 @@ export default function MyTrips() {
     setOpen(true);
     load(1);
   };
+
+  // Refresh the open list when a trip is saved/updated elsewhere so it never
+  // shows stale data (previously required closing and reopening the drawer).
+  useEffect(() => {
+    if (tripsRevision === prevRevisionRef.current) {
+      return;
+    }
+    prevRevisionRef.current = tripsRevision;
+    if (open) {
+      load(page);
+    }
+  }, [tripsRevision, open, page, load]);
 
   // Fetch a saved trip and rebuild the planning state from it. clearAll first so
   // a loaded trip never merges with an in-progress one. The drawer stays open.

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -80,6 +80,18 @@ function applyTripView(dispatch, { trip, route, detours }) {
         tripId: trip.tripId,
         tripName: trip.tripName,
         updatedAt: trip.updatedAt,
+        // Snapshot of the saved values so a later update that hasn't re-routed
+        // (e.g. a rename) preserves distance/duration/coords/polyline instead
+        // of wiping them (the loaded route has no legs to recompute from).
+        origin: trip.origin,
+        destination: trip.destination,
+        routePolyline:
+          (route &&
+            route.overview_polyline &&
+            route.overview_polyline.points) ||
+          null,
+        distanceMeters: trip.distanceMeters,
+        durationSeconds: trip.durationSeconds,
       },
     },
   });

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -9,12 +9,28 @@ import {
   Card,
   Text,
   Spinner,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItem,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
   Toaster,
   Toast,
   ToastTitle,
   useToastController,
   useId,
 } from "@fluentui/react-components";
+import {
+  MoreHorizontalRegular,
+  CopyRegular,
+  DeleteRegular,
+} from "@fluentui/react-icons";
 import TripRequester from "../../scripts/TripRequester";
 import log from "../../utils/logger";
 
@@ -36,7 +52,8 @@ function formatEndpoint(point) {
 
 // Rebuild the planning state from a loaded trip view. clearAll first so a loaded
 // trip never merges with an in-progress one; SET_ROUTE also flips showRoute /
-// showDetourButton so the map and sidebar render.
+// showDetourButton so the map and sidebar render. Record which saved trip is
+// loaded (currentTrip) and its name so the sidebar can offer "Update Trip".
 function applyTripView(dispatch, { trip, route, detours }) {
   dispatch({ type: "CLEAR_ALL" });
   dispatch({
@@ -55,6 +72,17 @@ function applyTripView(dispatch, { trip, route, detours }) {
     });
   }
   dispatch({ type: "SET_DETOUR_LIST", data: { detourList: detours || [] } });
+  dispatch({ type: "SET_TRIP_NAME", data: { tripName: trip.tripName || "" } });
+  dispatch({
+    type: "SET_CURRENT_TRIP",
+    data: {
+      currentTrip: {
+        tripId: trip.tripId,
+        tripName: trip.tripName,
+        updatedAt: trip.updatedAt,
+      },
+    },
+  });
 }
 
 /**
@@ -74,6 +102,11 @@ export default function MyTrips() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [loadingTripId, setLoadingTripId] = useState(null);
+  // Trip pending delete confirmation (null when the dialog is closed).
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  // Trip currently being duplicated (drives the per-card spinner).
+  const [duplicatingTripId, setDuplicatingTripId] = useState(null);
 
   // Monotonic token for load requests. Only the most recent click's response is
   // applied, so quick successive clicks can't resolve out of order and load the
@@ -152,6 +185,79 @@ export default function MyTrips() {
     [dispatch, dispatchToast]
   );
 
+  // Duplicate a trip, then refresh the list so the new "Copy of ..." appears
+  // (it sorts to the top by created_at). The copy is created server-side.
+  const handleDuplicate = useCallback(
+    (trip) => {
+      setDuplicatingTripId(trip.trip_id);
+      new TripRequester()
+        .duplicateTrip(trip.trip_id)
+        .then(() => {
+          load(page);
+          dispatchToast(
+            <Toast>
+              <ToastTitle>Trip duplicated</ToastTitle>
+            </Toast>,
+            { intent: "success" }
+          );
+        })
+        .catch((err) => {
+          log.error("Failed to duplicate trip:", err);
+          dispatchToast(
+            <Toast>
+              <ToastTitle>
+                Could not duplicate that trip. Please try again.
+              </ToastTitle>
+            </Toast>,
+            { intent: "error" }
+          );
+        })
+        .finally(() => setDuplicatingTripId(null));
+    },
+    [load, page, dispatchToast]
+  );
+
+  // Delete the trip awaiting confirmation, then update the list in place. If the
+  // last trip on a page beyond the first is removed, step back a page so the
+  // user isn't left on an empty page.
+  const handleConfirmDelete = useCallback(() => {
+    const trip = deleteTarget;
+    if (!trip) {
+      return;
+    }
+    setDeleting(true);
+    new TripRequester()
+      .deleteTrip(trip.trip_id)
+      .then(() => {
+        setDeleteTarget(null);
+        const remaining = trips.filter((t) => t.trip_id !== trip.trip_id);
+        if (remaining.length === 0 && page > 1) {
+          load(page - 1);
+        } else {
+          setTrips(remaining);
+          setTotal((prev) => Math.max(0, prev - 1));
+        }
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Trip deleted</ToastTitle>
+          </Toast>,
+          { intent: "success" }
+        );
+      })
+      .catch((err) => {
+        log.error("Failed to delete trip:", err);
+        dispatchToast(
+          <Toast>
+            <ToastTitle>
+              Could not delete that trip. Please try again.
+            </ToastTitle>
+          </Toast>,
+          { intent: "error" }
+        );
+      })
+      .finally(() => setDeleting(false));
+  }, [deleteTarget, trips, page, load, dispatchToast]);
+
   if (!user) {
     return null;
   }
@@ -205,7 +311,10 @@ export default function MyTrips() {
                     role="button"
                     tabIndex={0}
                     aria-label={`Load trip ${trip.trip_name}`}
-                    aria-busy={loadingTripId === trip.trip_id}
+                    aria-busy={
+                      loadingTripId === trip.trip_id ||
+                      duplicatingTripId === trip.trip_id
+                    }
                     onClick={() => loadTrip(trip.trip_id)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
@@ -214,7 +323,8 @@ export default function MyTrips() {
                       }
                     }}
                   >
-                    {loadingTripId === trip.trip_id && (
+                    {(loadingTripId === trip.trip_id ||
+                      duplicatingTripId === trip.trip_id) && (
                       <div
                         className="my-trips-card__spinner"
                         aria-hidden="true"
@@ -222,6 +332,39 @@ export default function MyTrips() {
                         <Spinner size="tiny" />
                       </div>
                     )}
+                    {/* Options menu — stop propagation so opening it (or picking
+                        an item) never triggers the card's load-trip click. */}
+                    <div
+                      className="my-trips-card__menu"
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <Menu>
+                        <MenuTrigger disableButtonEnhancement>
+                          <Button
+                            appearance="subtle"
+                            icon={<MoreHorizontalRegular />}
+                            aria-label={`Options for ${trip.trip_name}`}
+                          />
+                        </MenuTrigger>
+                        <MenuPopover>
+                          <MenuList>
+                            <MenuItem
+                              icon={<CopyRegular />}
+                              onClick={() => handleDuplicate(trip)}
+                            >
+                              Duplicate
+                            </MenuItem>
+                            <MenuItem
+                              icon={<DeleteRegular />}
+                              onClick={() => setDeleteTarget(trip)}
+                            >
+                              Delete
+                            </MenuItem>
+                          </MenuList>
+                        </MenuPopover>
+                      </Menu>
+                    </div>
                     <Text weight="semibold">{trip.trip_name}</Text>
                     <Text size={200}>
                       {formatEndpoint(trip.origin)} &rarr;{" "}
@@ -257,6 +400,44 @@ export default function MyTrips() {
           )}
         </DrawerBody>
       </OverlayDrawer>
+
+      {/* Delete confirmation — driven by deleteTarget so a single dialog serves
+          every card. */}
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(event, data) => {
+          if (!data.open) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Delete trip?</DialogTitle>
+            <DialogContent>
+              This permanently deletes
+              {deleteTarget ? ` "${deleteTarget.trip_name}"` : " this trip"} and
+              its detours. This can&apos;t be undone.
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                disabled={deleting}
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="primary"
+                disabled={deleting}
+                onClick={handleConfirmDelete}
+              >
+                {deleting ? "Deleting..." : "Delete"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
     </>
   );
 }

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -24,15 +24,15 @@ import AuthRequester from "../../scripts/AuthRequester";
 const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
 
 /**
- * SaveTrip — the trip name field plus the "Save Trip" control and its dialogs.
+ * SaveTrip — the "Save Trip" control and its dialogs.
  *
- * Reads the current trip straight from Redux. The trip name is a first-class,
- * editable field (Redux `tripName`): when a saved trip is loaded its name
- * populates here. The button always reads "Save Trip"; under the hood it updates
- * the loaded trip in place when one is loaded (`currentTrip`), otherwise creates
- * a new trip. If the loaded trip no longer exists (e.g. deleted elsewhere), the
- * update falls back to creating a new trip. Signed-out users are prompted to
- * sign in.
+ * Reads the current trip straight from Redux. The trip name is edited in the
+ * separate TripNameField component (Redux `tripName`); SaveTrip only renders the
+ * Save button plus its dialogs. The button always reads "Save Trip"; under the
+ * hood it updates the loaded trip in place when one is loaded (`currentTrip`),
+ * otherwise creates a new trip. If the loaded trip no longer exists (e.g. deleted
+ * elsewhere), the update falls back to creating a new trip. Signed-out users are
+ * prompted to sign in.
  */
 export default function SaveTrip() {
   const {

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -198,17 +198,6 @@ export default function SaveTrip() {
       <Toaster toasterId={toasterId} />
 
       <div className="save-trip-section">
-        {/* Editable trip name — populated when a saved trip is loaded. */}
-        <Field className="trip-name-field" label="Trip name">
-          <Input
-            size="large"
-            className="trip-name-input"
-            value={tripName || ""}
-            placeholder="e.g. Coastal weekend"
-            onChange={(event) => setTripName(event.target.value)}
-          />
-        </Field>
-
         <Button
           appearance="primary"
           className="save-trip-btn"

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -89,7 +89,8 @@ export default function SaveTrip() {
       setSaving(true);
       const payload = buildTripPayload(
         { origin, destination, route, detourList },
-        name
+        name,
+        currentTrip
       );
       const requester = new TripRequester();
 
@@ -104,6 +105,11 @@ export default function SaveTrip() {
                 tripId: trip.trip_id,
                 tripName: name,
                 updatedAt: trip.updated_at,
+                origin: trip.origin,
+                destination: trip.destination,
+                routePolyline: trip.route_polyline,
+                distanceMeters: trip.distance_meters,
+                durationSeconds: trip.duration_seconds,
               },
             },
           });
@@ -114,6 +120,7 @@ export default function SaveTrip() {
             .updateTrip(currentTrip.tripId, payload)
             .then((data) => {
               const trip = data.trip || {};
+              const updatedRoute = data.route || {};
               setTripName(trip.tripName || name);
               dispatch({
                 type: "SET_CURRENT_TRIP",
@@ -122,6 +129,15 @@ export default function SaveTrip() {
                     tripId: trip.tripId || currentTrip.tripId,
                     tripName: trip.tripName || name,
                     updatedAt: trip.updatedAt,
+                    origin: trip.origin,
+                    destination: trip.destination,
+                    routePolyline:
+                      (updatedRoute.overview_polyline &&
+                        updatedRoute.overview_polyline.points) ||
+                      currentTrip.routePolyline ||
+                      null,
+                    distanceMeters: trip.distanceMeters,
+                    durationSeconds: trip.durationSeconds,
                   },
                 },
               });

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -10,7 +10,6 @@ import {
   DialogActions,
   Field,
   Input,
-  Text,
   Toaster,
   Toast,
   ToastTitle,
@@ -24,29 +23,16 @@ import AuthRequester from "../../scripts/AuthRequester";
 // prompt, so the save resumes automatically after the login redirect.
 const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
 
-// Format an ISO timestamp for the "Last saved" line. Returns "" when absent.
-function formatLastSaved(updatedAt) {
-  if (!updatedAt) {
-    return "";
-  }
-  const date = new Date(updatedAt);
-  if (Number.isNaN(date.getTime())) {
-    return "";
-  }
-  return date.toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
-}
-
 /**
- * SaveTrip — the trip name field plus the save/update control and its dialogs.
+ * SaveTrip — the trip name field plus the "Save Trip" control and its dialogs.
  *
  * Reads the current trip straight from Redux. The trip name is a first-class,
  * editable field (Redux `tripName`): when a saved trip is loaded its name
- * populates here and the primary button becomes "Update Trip"; for a brand-new
- * trip the button is "Save Trip" (saving directly when a name is present, or
- * prompting for one when it is blank). Signed-out users are prompted to sign in.
+ * populates here. The button always reads "Save Trip"; under the hood it updates
+ * the loaded trip in place when one is loaded (`currentTrip`), otherwise creates
+ * a new trip. If the loaded trip no longer exists (e.g. deleted elsewhere), the
+ * update falls back to creating a new trip. Signed-out users are prompted to
+ * sign in.
  */
 export default function SaveTrip() {
   const {
@@ -94,20 +80,22 @@ export default function SaveTrip() {
     [dispatchToast]
   );
 
-  // Create a brand-new trip, then remember it as the current trip so subsequent
-  // saves update it in place.
-  const createTrip = useCallback(
+  // Persist the current plan under `name`: update the loaded trip in place, or
+  // create a new one. A 404 on update means the loaded trip is gone (deleted),
+  // so fall back to creating it as a new trip. On success, bump the revision so
+  // an open "My Trips" list refreshes.
+  const persist = useCallback(
     (name) => {
       setSaving(true);
       const payload = buildTripPayload(
         { origin, destination, route, detourList },
         name
       );
-      return new TripRequester()
-        .saveTrip(payload)
-        .then((data) => {
+      const requester = new TripRequester();
+
+      const create = () =>
+        requester.saveTrip(payload).then((data) => {
           const trip = data.trip || {};
-          setNameDialogOpen(false);
           setTripName(name);
           dispatch({
             type: "SET_CURRENT_TRIP",
@@ -119,6 +107,38 @@ export default function SaveTrip() {
               },
             },
           });
+        });
+
+      const save = currentTrip
+        ? requester
+            .updateTrip(currentTrip.tripId, payload)
+            .then((data) => {
+              const trip = data.trip || {};
+              setTripName(trip.tripName || name);
+              dispatch({
+                type: "SET_CURRENT_TRIP",
+                data: {
+                  currentTrip: {
+                    tripId: trip.tripId || currentTrip.tripId,
+                    tripName: trip.tripName || name,
+                    updatedAt: trip.updatedAt,
+                  },
+                },
+              });
+            })
+            .catch((err) => {
+              // The loaded trip no longer exists — save it as a new trip.
+              if (err && err.response && err.response.status === 404) {
+                return create();
+              }
+              throw err;
+            })
+        : create();
+
+      return save
+        .then(() => {
+          setNameDialogOpen(false);
+          dispatch({ type: "BUMP_TRIPS_REVISION" });
           showToast("Trip saved", "success");
         })
         .catch(() => {
@@ -126,62 +146,28 @@ export default function SaveTrip() {
         })
         .finally(() => setSaving(false));
     },
-    [origin, destination, route, detourList, dispatch, setTripName, showToast]
+    [
+      origin,
+      destination,
+      route,
+      detourList,
+      currentTrip,
+      dispatch,
+      setTripName,
+      showToast,
+    ]
   );
 
-  // Update the currently loaded trip in place (persists any name edits too).
-  const updateTrip = useCallback(() => {
-    const name = (tripName || "").trim();
-    if (!name || !currentTrip) {
-      return;
-    }
-    setSaving(true);
-    const payload = buildTripPayload(
-      { origin, destination, route, detourList },
-      name
-    );
-    new TripRequester()
-      .updateTrip(currentTrip.tripId, payload)
-      .then((data) => {
-        const trip = data.trip || {};
-        dispatch({
-          type: "SET_CURRENT_TRIP",
-          data: {
-            currentTrip: {
-              tripId: trip.tripId || currentTrip.tripId,
-              tripName: trip.tripName || name,
-              updatedAt: trip.updatedAt,
-            },
-          },
-        });
-        showToast("Trip updated", "success");
-      })
-      .catch(() => {
-        showToast("Could not update trip. Please try again.", "error");
-      })
-      .finally(() => setSaving(false));
-  }, [
-    tripName,
-    currentTrip,
-    origin,
-    destination,
-    route,
-    detourList,
-    dispatch,
-    showToast,
-  ]);
-
-  // Start a save for a new trip: save directly when a name is present, else
-  // prompt for one.
-  const saveNewTrip = useCallback(() => {
+  // Start a save: save directly when a name is present, else prompt for one.
+  const requestSave = useCallback(() => {
     const name = (tripName || "").trim();
     if (name) {
-      createTrip(name);
+      persist(name);
     } else {
       setDialogName("");
       setNameDialogOpen(true);
     }
-  }, [tripName, createTrip]);
+  }, [tripName, persist]);
 
   // Clicking "Sign in" from the save prompt is an intent to save. We stash a
   // one-shot flag before the login redirect; once authenticated on return,
@@ -189,20 +175,16 @@ export default function SaveTrip() {
   useEffect(() => {
     if (user && sessionStorage.getItem(RESUME_SAVE_KEY)) {
       sessionStorage.removeItem(RESUME_SAVE_KEY);
-      saveNewTrip();
+      requestSave();
     }
-  }, [user, saveNewTrip]);
+  }, [user, requestSave]);
 
   const handlePrimaryClick = () => {
     if (!user) {
       setSignInDialogOpen(true);
       return;
     }
-    if (currentTrip) {
-      updateTrip();
-    } else {
-      saveNewTrip();
-    }
+    requestSave();
   };
 
   const handleSignIn = () => {
@@ -211,45 +193,34 @@ export default function SaveTrip() {
     auth.login();
   };
 
-  const isUpdate = Boolean(currentTrip);
-  const lastSaved = isUpdate ? formatLastSaved(currentTrip.updatedAt) : "";
-
   return (
     <>
       <Toaster toasterId={toasterId} />
 
-      {/* Editable trip name — populated when a saved trip is loaded. */}
-      <Field className="trip-name-field mt-2" label="Trip name">
-        <Input
-          value={tripName || ""}
-          placeholder="e.g. Coastal weekend"
-          onChange={(event) => setTripName(event.target.value)}
-        />
-      </Field>
+      <div className="save-trip-section">
+        {/* Editable trip name — populated when a saved trip is loaded. */}
+        <Field className="trip-name-field" label="Trip name">
+          <Input
+            size="large"
+            className="trip-name-input"
+            value={tripName || ""}
+            placeholder="e.g. Coastal weekend"
+            onChange={(event) => setTripName(event.target.value)}
+          />
+        </Field>
 
-      <Button
-        appearance="primary"
-        className="save-trip-btn mt-2"
-        id="save-trip-button"
-        disabled={saving || (isUpdate && !(tripName || "").trim())}
-        onClick={handlePrimaryClick}
-      >
-        {isUpdate
-          ? saving
-            ? "Updating..."
-            : "Update Trip"
-          : saving
-            ? "Saving..."
-            : "Save Trip"}
-      </Button>
+        <Button
+          appearance="primary"
+          className="save-trip-btn"
+          id="save-trip-button"
+          disabled={saving}
+          onClick={handlePrimaryClick}
+        >
+          {saving ? "Saving..." : "Save Trip"}
+        </Button>
+      </div>
 
-      {lastSaved && (
-        <Text size={200} className="last-saved-text">
-          Last saved {lastSaved}
-        </Text>
-      )}
-
-      {/* Fallback: prompt for a name when saving a new trip without one. */}
+      {/* Fallback: prompt for a name when saving without one. */}
       <Dialog
         open={nameDialogOpen}
         onOpenChange={(event, data) => setNameDialogOpen(data.open)}
@@ -277,7 +248,7 @@ export default function SaveTrip() {
               <Button
                 appearance="primary"
                 disabled={saving || !dialogName.trim()}
-                onClick={() => createTrip(dialogName.trim())}
+                onClick={() => persist(dialogName.trim())}
               >
                 {saving ? "Saving..." : "Save"}
               </Button>

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import React, { useState, useEffect, useCallback } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
   Dialog,
@@ -10,6 +10,7 @@ import {
   DialogActions,
   Field,
   Input,
+  Text,
   Toaster,
   Toast,
   ToastTitle,
@@ -20,53 +21,187 @@ import TripRequester, { buildTripPayload } from "../../scripts/TripRequester";
 import AuthRequester from "../../scripts/AuthRequester";
 
 // sessionStorage flag: set when a signed-out user opts to sign in from the save
-// prompt, so the name dialog reopens automatically after the login redirect.
+// prompt, so the save resumes automatically after the login redirect.
 const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
 
+// Format an ISO timestamp for the "Last saved" line. Returns "" when absent.
+function formatLastSaved(updatedAt) {
+  if (!updatedAt) {
+    return "";
+  }
+  const date = new Date(updatedAt);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
 /**
- * SaveTrip — "Save Trip" button plus its Fluent dialogs and toast.
+ * SaveTrip — the trip name field plus the save/update control and its dialogs.
  *
- * Reads the current trip straight from Redux, so it can drop into TripSummary
- * with no prop threading. Signed-out users get a prompt to sign in; signed-in
- * users get a name dialog, and the result is reported via a Fluent toast.
+ * Reads the current trip straight from Redux. The trip name is a first-class,
+ * editable field (Redux `tripName`): when a saved trip is loaded its name
+ * populates here and the primary button becomes "Update Trip"; for a brand-new
+ * trip the button is "Save Trip" (saving directly when a name is present, or
+ * prompting for one when it is blank). Signed-out users are prompted to sign in.
  */
 export default function SaveTrip() {
-  const { user, origin, destination, route, detourList } = useSelector(
-    (state) => ({
-      user: state.user,
-      origin: state.origin,
-      destination: state.destination,
-      route: state.route,
-      detourList: state.detourList,
-    })
-  );
+  const {
+    user,
+    origin,
+    destination,
+    route,
+    detourList,
+    tripName,
+    currentTrip,
+  } = useSelector((state) => ({
+    user: state.user,
+    origin: state.origin,
+    destination: state.destination,
+    route: state.route,
+    detourList: state.detourList,
+    tripName: state.tripName,
+    currentTrip: state.currentTrip,
+  }));
+  const dispatch = useDispatch();
 
   const [nameDialogOpen, setNameDialogOpen] = useState(false);
   const [signInDialogOpen, setSignInDialogOpen] = useState(false);
-  const [tripName, setTripName] = useState("");
+  // Local buffer for the fallback "name required" dialog input.
+  const [dialogName, setDialogName] = useState("");
   const [saving, setSaving] = useState(false);
 
   const toasterId = useId("save-trip-toaster");
   const { dispatchToast } = useToastController(toasterId);
   const auth = new AuthRequester();
 
+  const setTripName = useCallback(
+    (name) => dispatch({ type: "SET_TRIP_NAME", data: { tripName: name } }),
+    [dispatch]
+  );
+
+  const showToast = useCallback(
+    (message, intent) =>
+      dispatchToast(
+        <Toast>
+          <ToastTitle>{message}</ToastTitle>
+        </Toast>,
+        { intent }
+      ),
+    [dispatchToast]
+  );
+
+  // Create a brand-new trip, then remember it as the current trip so subsequent
+  // saves update it in place.
+  const createTrip = useCallback(
+    (name) => {
+      setSaving(true);
+      const payload = buildTripPayload(
+        { origin, destination, route, detourList },
+        name
+      );
+      return new TripRequester()
+        .saveTrip(payload)
+        .then((data) => {
+          const trip = data.trip || {};
+          setNameDialogOpen(false);
+          setTripName(name);
+          dispatch({
+            type: "SET_CURRENT_TRIP",
+            data: {
+              currentTrip: {
+                tripId: trip.trip_id,
+                tripName: name,
+                updatedAt: trip.updated_at,
+              },
+            },
+          });
+          showToast("Trip saved", "success");
+        })
+        .catch(() => {
+          showToast("Could not save trip. Please try again.", "error");
+        })
+        .finally(() => setSaving(false));
+    },
+    [origin, destination, route, detourList, dispatch, setTripName, showToast]
+  );
+
+  // Update the currently loaded trip in place (persists any name edits too).
+  const updateTrip = useCallback(() => {
+    const name = (tripName || "").trim();
+    if (!name || !currentTrip) {
+      return;
+    }
+    setSaving(true);
+    const payload = buildTripPayload(
+      { origin, destination, route, detourList },
+      name
+    );
+    new TripRequester()
+      .updateTrip(currentTrip.tripId, payload)
+      .then((data) => {
+        const trip = data.trip || {};
+        dispatch({
+          type: "SET_CURRENT_TRIP",
+          data: {
+            currentTrip: {
+              tripId: trip.tripId || currentTrip.tripId,
+              tripName: trip.tripName || name,
+              updatedAt: trip.updatedAt,
+            },
+          },
+        });
+        showToast("Trip updated", "success");
+      })
+      .catch(() => {
+        showToast("Could not update trip. Please try again.", "error");
+      })
+      .finally(() => setSaving(false));
+  }, [
+    tripName,
+    currentTrip,
+    origin,
+    destination,
+    route,
+    detourList,
+    dispatch,
+    showToast,
+  ]);
+
+  // Start a save for a new trip: save directly when a name is present, else
+  // prompt for one.
+  const saveNewTrip = useCallback(() => {
+    const name = (tripName || "").trim();
+    if (name) {
+      createTrip(name);
+    } else {
+      setDialogName("");
+      setNameDialogOpen(true);
+    }
+  }, [tripName, createTrip]);
+
   // Clicking "Sign in" from the save prompt is an intent to save. We stash a
-  // one-shot flag before the login redirect; once the user is authenticated on
-  // return, reopen the name dialog automatically.
+  // one-shot flag before the login redirect; once authenticated on return,
+  // resume the save automatically.
   useEffect(() => {
     if (user && sessionStorage.getItem(RESUME_SAVE_KEY)) {
       sessionStorage.removeItem(RESUME_SAVE_KEY);
-      setTripName("");
-      setNameDialogOpen(true);
+      saveNewTrip();
     }
-  }, [user]);
+  }, [user, saveNewTrip]);
 
-  const handleClick = () => {
+  const handlePrimaryClick = () => {
     if (!user) {
       setSignInDialogOpen(true);
+      return;
+    }
+    if (currentTrip) {
+      updateTrip();
     } else {
-      setTripName("");
-      setNameDialogOpen(true);
+      saveNewTrip();
     }
   };
 
@@ -76,54 +211,45 @@ export default function SaveTrip() {
     auth.login();
   };
 
-  const handleSave = () => {
-    const name = tripName.trim();
-    if (!name) {
-      return;
-    }
-    setSaving(true);
-    const payload = buildTripPayload(
-      { origin, destination, route, detourList },
-      name
-    );
-    new TripRequester()
-      .saveTrip(payload)
-      .then(() => {
-        setNameDialogOpen(false);
-        dispatchToast(
-          <Toast>
-            <ToastTitle>Trip saved</ToastTitle>
-          </Toast>,
-          { intent: "success" }
-        );
-      })
-      .catch(() => {
-        dispatchToast(
-          <Toast>
-            <ToastTitle>Could not save trip. Please try again.</ToastTitle>
-          </Toast>,
-          { intent: "error" }
-        );
-      })
-      .finally(() => {
-        setSaving(false);
-      });
-  };
+  const isUpdate = Boolean(currentTrip);
+  const lastSaved = isUpdate ? formatLastSaved(currentTrip.updatedAt) : "";
 
   return (
     <>
       <Toaster toasterId={toasterId} />
 
+      {/* Editable trip name — populated when a saved trip is loaded. */}
+      <Field className="trip-name-field mt-2" label="Trip name">
+        <Input
+          value={tripName || ""}
+          placeholder="e.g. Coastal weekend"
+          onChange={(event) => setTripName(event.target.value)}
+        />
+      </Field>
+
       <Button
         appearance="primary"
         className="save-trip-btn mt-2"
         id="save-trip-button"
-        onClick={handleClick}
+        disabled={saving || (isUpdate && !(tripName || "").trim())}
+        onClick={handlePrimaryClick}
       >
-        Save Trip
+        {isUpdate
+          ? saving
+            ? "Updating..."
+            : "Update Trip"
+          : saving
+            ? "Saving..."
+            : "Save Trip"}
       </Button>
 
-      {/* Signed-in: prompt for a trip name. */}
+      {lastSaved && (
+        <Text size={200} className="last-saved-text">
+          Last saved {lastSaved}
+        </Text>
+      )}
+
+      {/* Fallback: prompt for a name when saving a new trip without one. */}
       <Dialog
         open={nameDialogOpen}
         onOpenChange={(event, data) => setNameDialogOpen(data.open)}
@@ -134,9 +260,9 @@ export default function SaveTrip() {
             <DialogContent>
               <Field label="Trip name" required>
                 <Input
-                  value={tripName}
+                  value={dialogName}
                   placeholder="e.g. Coastal weekend"
-                  onChange={(event) => setTripName(event.target.value)}
+                  onChange={(event) => setDialogName(event.target.value)}
                 />
               </Field>
             </DialogContent>
@@ -150,8 +276,8 @@ export default function SaveTrip() {
               </Button>
               <Button
                 appearance="primary"
-                disabled={saving || !tripName.trim()}
-                onClick={handleSave}
+                disabled={saving || !dialogName.trim()}
+                onClick={() => createTrip(dialogName.trim())}
               >
                 {saving ? "Saving..." : "Save"}
               </Button>

--- a/frontend/src/components/sidebar/TripNameField.jsx
+++ b/frontend/src/components/sidebar/TripNameField.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Field, Input } from "@fluentui/react-components";
+
+/**
+ * TripNameField — the editable trip name, shown above the trip timeline.
+ *
+ * Reads/writes Redux `tripName` directly so it can sit anywhere in the sidebar
+ * without prop threading. When a saved trip is loaded its name populates here;
+ * the value is picked up by SaveTrip when saving/updating.
+ */
+export default function TripNameField() {
+  const tripName = useSelector((state) => state.tripName);
+  const dispatch = useDispatch();
+
+  return (
+    <div className="trip-name-section">
+      <Field className="trip-name-field" label="Trip name">
+        <Input
+          size="large"
+          className="trip-name-input"
+          value={tripName || ""}
+          placeholder="e.g. Coastal weekend"
+          onChange={(event) =>
+            dispatch({
+              type: "SET_TRIP_NAME",
+              data: { tripName: event.target.value },
+            })
+          }
+        />
+      </Field>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/TripSummary.jsx
+++ b/frontend/src/components/sidebar/TripSummary.jsx
@@ -52,7 +52,6 @@ class TripSummary extends React.Component {
                     id="export-route-button"
                     text="Open in Google Maps"
                   ></Button>
-                  <SaveTrip></SaveTrip>
                 </div>
               </div>
             </div>
@@ -65,6 +64,7 @@ class TripSummary extends React.Component {
               setTripSummary={this.props.setTripSummary}
               setDetourList={this.props.setDetourList}
             ></TripTimeline>
+            <SaveTrip></SaveTrip>
           </div>
         ) : (
           <div></div>

--- a/frontend/src/components/sidebar/TripSummary.jsx
+++ b/frontend/src/components/sidebar/TripSummary.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import TripTimeline from "./TripTimeline";
+import TripNameField from "./TripNameField";
 import SaveTrip from "./SaveTrip";
 import { exportToGoogleMaps } from "../../utils/googleMapsExport";
 
@@ -55,6 +56,7 @@ class TripSummary extends React.Component {
                 </div>
               </div>
             </div>
+            <TripNameField></TripNameField>
             <TripTimeline
               origin={this.props.origin}
               destination={this.props.destination}

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -8,6 +8,9 @@ let initialState = {
   // index.js) so they survive the sign-in redirect.
   tripName: "",
   currentTrip: null,
+  // Bumped whenever a trip is created/updated/deleted/duplicated so an open
+  // "My Trips" list can refresh itself without being closed and reopened.
+  tripsRevision: 0,
   detourType: "Hike",
   detourList: [],
   tripSummary: {},
@@ -55,6 +58,11 @@ const mainReducer = (state = initialState, action) => {
       return {
         ...state,
         currentTrip: action.data.currentTrip,
+      };
+    case "BUMP_TRIPS_REVISION":
+      return {
+        ...state,
+        tripsRevision: (state.tripsRevision || 0) + 1,
       };
     case "SET_ROUTE":
       return {
@@ -135,6 +143,9 @@ const mainReducer = (state = initialState, action) => {
         destination: "",
         tripName: "",
         currentTrip: null,
+        // Preserve the revision counter so clearing the planner doesn't look
+        // like a trip mutation to an open list.
+        tripsRevision: state.tripsRevision,
         detourType: "Hike",
         detourList: [],
         tripSummary: {},

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -2,6 +2,12 @@ let initialState = {
   user: null,
   origin: "",
   destination: "",
+  // The name the user has given the in-progress trip (bound to the sidebar
+  // name field). currentTrip identifies which saved trip, if any, is loaded —
+  // null means an unsaved/new trip. Both persist to sessionStorage (see
+  // index.js) so they survive the sign-in redirect.
+  tripName: "",
+  currentTrip: null,
   detourType: "Hike",
   detourList: [],
   tripSummary: {},
@@ -39,6 +45,16 @@ const mainReducer = (state = initialState, action) => {
       return {
         ...state,
         destination: action.data.destination,
+      };
+    case "SET_TRIP_NAME":
+      return {
+        ...state,
+        tripName: action.data.tripName,
+      };
+    case "SET_CURRENT_TRIP":
+      return {
+        ...state,
+        currentTrip: action.data.currentTrip,
       };
     case "SET_ROUTE":
       return {
@@ -117,6 +133,8 @@ const mainReducer = (state = initialState, action) => {
         user: state.user,
         origin: "",
         destination: "",
+        tripName: "",
+        currentTrip: null,
         detourType: "Hike",
         detourList: [],
         tripSummary: {},

--- a/frontend/src/reducers/main-reducer.test.js
+++ b/frontend/src/reducers/main-reducer.test.js
@@ -49,4 +49,17 @@ describe("mainReducer — trip name and current trip", () => {
     expect(cleared.currentTrip).toBeNull();
     expect(cleared.user).toEqual({ id: "u1" });
   });
+
+  it("BUMP_TRIPS_REVISION increments the revision counter", () => {
+    const first = mainReducer(undefined, { type: "BUMP_TRIPS_REVISION" });
+    expect(first.tripsRevision).toBe(1);
+    const second = mainReducer(first, { type: "BUMP_TRIPS_REVISION" });
+    expect(second.tripsRevision).toBe(2);
+  });
+
+  it("CLEAR_ALL preserves the trips revision counter", () => {
+    const bumped = mainReducer(undefined, { type: "BUMP_TRIPS_REVISION" });
+    const cleared = mainReducer(bumped, { type: "CLEAR_ALL" });
+    expect(cleared.tripsRevision).toBe(1);
+  });
 });

--- a/frontend/src/reducers/main-reducer.test.js
+++ b/frontend/src/reducers/main-reducer.test.js
@@ -1,0 +1,52 @@
+import mainReducer from "./main-reducer";
+
+describe("mainReducer — trip name and current trip", () => {
+  it("defaults tripName to an empty string and currentTrip to null", () => {
+    const state = mainReducer(undefined, { type: "@@INIT" });
+    expect(state.tripName).toBe("");
+    expect(state.currentTrip).toBeNull();
+  });
+
+  it("SET_TRIP_NAME updates the trip name", () => {
+    const state = mainReducer(undefined, {
+      type: "SET_TRIP_NAME",
+      data: { tripName: "Coastal weekend" },
+    });
+    expect(state.tripName).toBe("Coastal weekend");
+  });
+
+  it("SET_CURRENT_TRIP records the loaded trip", () => {
+    const currentTrip = {
+      tripId: "t1",
+      tripName: "Coastal weekend",
+      updatedAt: "2026-07-07T12:00:00.000Z",
+    };
+    const state = mainReducer(undefined, {
+      type: "SET_CURRENT_TRIP",
+      data: { currentTrip },
+    });
+    expect(state.currentTrip).toEqual(currentTrip);
+  });
+
+  it("CLEAR_ALL resets tripName and currentTrip but preserves the user", () => {
+    const loaded = mainReducer(
+      { user: { id: "u1" } },
+      {
+        type: "SET_CURRENT_TRIP",
+        data: {
+          currentTrip: { tripId: "t1", tripName: "X", updatedAt: "now" },
+        },
+      }
+    );
+    const withName = mainReducer(loaded, {
+      type: "SET_TRIP_NAME",
+      data: { tripName: "X" },
+    });
+
+    const cleared = mainReducer(withName, { type: "CLEAR_ALL" });
+
+    expect(cleared.tripName).toBe("");
+    expect(cleared.currentTrip).toBeNull();
+    expect(cleared.user).toEqual({ id: "u1" });
+  });
+});

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -10,11 +10,18 @@ import log from "../utils/logger";
  * no extra API calls. `origin`/`destination` in state are the address strings
  * the user typed; we pair them with the resolved leg coordinates.
  *
+ * When there are no route legs (e.g. a loaded trip that hasn't been re-routed,
+ * such as a plain rename), the live route can't supply distance/duration/coords,
+ * so we fall back to `fallback` — the saved values captured when the trip was
+ * loaded — to avoid wiping them on update.
+ *
  * @param {object} state - Redux state ({ origin, destination, route, detourList }).
  * @param {string} tripName - The name the user entered for the trip.
- * @returns {object} The request body for POST /api/trips.
+ * @param {object} [fallback] - Saved trip values ({ origin, destination,
+ *   routePolyline, distanceMeters, durationSeconds }) used when no live legs.
+ * @returns {object} The request body for POST/PUT /api/trips.
  */
-export function buildTripPayload(state, tripName) {
+export function buildTripPayload(state, tripName, fallback = null) {
   const { origin, destination, route, detourList } = state;
   const legs = (route && route.legs) || [];
   const firstLeg = legs[0] || {};
@@ -32,25 +39,31 @@ export function buildTripPayload(state, tripName) {
   );
   // Only report distance/duration when there is a route; preserve a genuine 0.
   const hasLegs = legs.length > 0;
+  const fb = fallback || {};
   const routePolyline =
     (route && route.overview_polyline && route.overview_polyline.points) ||
+    fb.routePolyline ||
     null;
 
   return {
     tripName,
-    origin: {
-      address: origin || "",
-      lat: startLocation.lat ?? null,
-      lng: startLocation.lng ?? null,
-    },
-    destination: {
-      address: destination || "",
-      lat: endLocation.lat ?? null,
-      lng: endLocation.lng ?? null,
-    },
+    origin: hasLegs
+      ? {
+          address: origin || "",
+          lat: startLocation.lat ?? null,
+          lng: startLocation.lng ?? null,
+        }
+      : fb.origin || { address: origin || "", lat: null, lng: null },
+    destination: hasLegs
+      ? {
+          address: destination || "",
+          lat: endLocation.lat ?? null,
+          lng: endLocation.lng ?? null,
+        }
+      : fb.destination || { address: destination || "", lat: null, lng: null },
     routePolyline,
-    distanceMeters: hasLegs ? distanceMeters : null,
-    durationSeconds: hasLegs ? durationSeconds : null,
+    distanceMeters: hasLegs ? distanceMeters : (fb.distanceMeters ?? null),
+    durationSeconds: hasLegs ? durationSeconds : (fb.durationSeconds ?? null),
     detours: (detourList || []).map((detour) => ({
       placeName: detour.name,
       placeType: detour.type || null,

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -129,4 +129,62 @@ export default class TripRequester {
         throw error;
       });
   }
+
+  /**
+   * Update an existing saved trip (and replace its detours). Resolves to the
+   * reconstructed trip view on success.
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @param {object} payload - Body from buildTripPayload.
+   * @returns {Promise<object>} { trip, route, detours }
+   */
+  updateTrip(tripId, payload) {
+    return axios
+      .put(this.getUrlBase() + "/api/trips/" + tripId, payload, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to update trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * Duplicate a saved trip (and all of its detours). Resolves to the new trip.
+   *
+   * @param {string} tripId - The source trip's UUID.
+   * @returns {Promise<object>} { trip, detours }
+   */
+  duplicateTrip(tripId) {
+    return axios
+      .post(
+        this.getUrlBase() + "/api/trips/" + tripId + "/duplicate",
+        {},
+        { withCredentials: true }
+      )
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to duplicate trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * Delete a saved trip (and its detours, via ON DELETE CASCADE).
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @returns {Promise<object>} { message }
+   */
+  deleteTrip(tripId) {
+    return axios
+      .delete(this.getUrlBase() + "/api/trips/" + tripId, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to delete trip:", error);
+        throw error;
+      });
+  }
 }

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -184,3 +184,82 @@ describe("TripRequester.getTrip", () => {
     );
   });
 });
+
+describe("TripRequester.updateTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("PUTs the payload to the trip id with credentials and returns the data", async () => {
+    const payload = { tripName: "Updated" };
+    const data = { trip: { tripId: "t1", tripName: "Updated" } };
+    axios.put.mockResolvedValue({ data });
+
+    const result = await new TripRequester().updateTrip("t1", payload);
+
+    const [url, body, options] = axios.put.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(body).toBe(payload);
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.put.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().updateTrip("t1", {})).rejects.toThrow(
+      "boom"
+    );
+  });
+});
+
+describe("TripRequester.duplicateTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("POSTs to the duplicate endpoint with credentials and returns the data", async () => {
+    const data = { trip: { trip_id: "copy-1" } };
+    axios.post.mockResolvedValue({ data });
+
+    const result = await new TripRequester().duplicateTrip("t1");
+
+    const [url, body, options] = axios.post.mock.calls[0];
+    expect(url).toContain("/api/trips/t1/duplicate");
+    expect(body).toEqual({});
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.post.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().duplicateTrip("t1")).rejects.toThrow(
+      "boom"
+    );
+  });
+});
+
+describe("TripRequester.deleteTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("DELETEs the trip by id with credentials and returns the data", async () => {
+    const data = { message: "Trip deleted" };
+    axios.delete.mockResolvedValue({ data });
+
+    const result = await new TripRequester().deleteTrip("t1");
+
+    const [url, options] = axios.delete.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.delete.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().deleteTrip("t1")).rejects.toThrow("boom");
+  });
+});

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -121,6 +121,69 @@ describe("buildTripPayload", () => {
     expect(payload.distanceMeters).toBe(0);
     expect(payload.durationSeconds).toBe(0);
   });
+
+  it("falls back to saved values when there are no route legs (rename)", () => {
+    // A loaded trip's route has an encoded polyline but no legs, so the payload
+    // must preserve the saved distance/duration/coords instead of nulling them.
+    const fallback = {
+      origin: { address: "San Francisco, CA", lat: 37.77, lng: -122.42 },
+      destination: { address: "Los Angeles, CA", lat: 34.05, lng: -118.24 },
+      routePolyline: "saved_polyline",
+      distanceMeters: 616000,
+      durationSeconds: 32400,
+    };
+    const payload = buildTripPayload(
+      {
+        origin: "San Francisco, CA",
+        destination: "Los Angeles, CA",
+        route: { overview_polyline: { points: "saved_polyline" } },
+        detourList: [],
+      },
+      "Renamed trip",
+      fallback
+    );
+
+    expect(payload.distanceMeters).toBe(616000);
+    expect(payload.durationSeconds).toBe(32400);
+    expect(payload.origin).toEqual(fallback.origin);
+    expect(payload.destination).toEqual(fallback.destination);
+    expect(payload.routePolyline).toBe("saved_polyline");
+  });
+
+  it("prefers live route legs over the fallback when the trip was re-routed", () => {
+    const fallback = {
+      origin: { address: "Old", lat: 1, lng: 1 },
+      destination: { address: "Old", lat: 2, lng: 2 },
+      routePolyline: "old",
+      distanceMeters: 100,
+      durationSeconds: 100,
+    };
+    const payload = buildTripPayload(
+      {
+        origin: "New A",
+        destination: "New B",
+        route: {
+          overview_polyline: { points: "new" },
+          legs: [
+            {
+              start_location: { lat: 10, lng: 20 },
+              end_location: { lat: 30, lng: 40 },
+              distance: { value: 5000 },
+              duration: { value: 600 },
+            },
+          ],
+        },
+        detourList: [],
+      },
+      "Re-routed",
+      fallback
+    );
+
+    expect(payload.distanceMeters).toBe(5000);
+    expect(payload.durationSeconds).toBe(600);
+    expect(payload.origin).toEqual({ address: "New A", lat: 10, lng: 20 });
+    expect(payload.routePolyline).toBe("new");
+  });
 });
 
 describe("TripRequester.listTrips", () => {

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -83,13 +83,23 @@
   flex-direction: column;
   gap: 4px;
   position: relative;
+  /* Leave room in the top-right corner for the options (ellipsis) menu. */
+  padding-right: 40px;
 }
 
-/* Overlay the load spinner in the corner so it never resizes the card. */
+/* Overlay the load spinner in the corner so it never resizes the card. Sits to
+   the left of the options menu so the two never overlap. */
 .my-trips-card__spinner {
   position: absolute;
   top: 8px;
-  right: 8px;
+  right: 44px;
+}
+
+/* Options (ellipsis) menu pinned to the card's top-right corner. */
+.my-trips-card__menu {
+  position: absolute;
+  top: 4px;
+  right: 4px;
 }
 
 .my-trips-pager {

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -295,6 +295,49 @@
   color: #ffffff !important;
 }
 
+/* Save Trip section — sits at the bottom of the trip timeline. Left-aligned to
+   override the app-wide centered text, with sidebar-matching side padding. */
+.save-trip-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 15px 20px;
+  text-align: left;
+}
+
+/* Trip name — full width, left-aligned, with a bit of polish over the plain
+   default input. */
+.trip-name-field {
+  width: 100%;
+}
+
+.trip-name-field label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: #1f3d2b;
+  margin-bottom: 4px;
+}
+
+.trip-name-input {
+  width: 100%;
+  border-radius: 8px;
+  background-color: #f4f9f5;
+  border-color: #cfe3d5;
+  transition:
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
+}
+
+.trip-name-input:hover {
+  background-color: #eef6f0;
+}
+
+.trip-name-input:focus-within {
+  background-color: #ffffff;
+  border-color: #188038;
+}
+
 /* Apply rounded pill-like styling to all buttons */
 .btn {
   border-radius: 1.5rem !important;

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -305,6 +305,12 @@
   text-align: left;
 }
 
+/* Trip name — sits above the trip timeline, sidebar-matching side padding. */
+.trip-name-section {
+  padding: 10px 15px 4px;
+  text-align: left;
+}
+
 /* Trip name — full width, left-aligned, with a bit of polish over the plain
    default input. */
 .trip-name-field {


### PR DESCRIPTION
## Update, Delete & Duplicate saved trips

> **Base branch:** `development` (not `main`)

Completes the saved-trip lifecycle: users can now update/rename an existing trip, delete a trip, and duplicate a trip — plus several UX refinements to the save flow.

### Summary

- **Update / rename** — after loading a trip, the sidebar shows a **Save Trip** button that persists changes back to the same trip (route, detours, and name) in a single transaction. Renaming falls out for free via the editable trip-name field. If the loaded trip was deleted elsewhere, the save transparently falls back to creating a new trip.
- **Delete** — each trip card in **My Trips** has a top-right **⋯ menu** with **Delete**, guarded by a confirmation dialog. Detours are removed via `ON DELETE CASCADE`.
- **Duplicate** — the same **⋯ menu** offers **Duplicate**, which server-side copies the trip and all its detours as "Copy of {name}".
- **UX polish** — a single always-labeled **Save Trip** button, an editable **Trip name** field styled and positioned above the timeline, and the open My Trips list now refreshes live after a save (no more close/reopen).

### Backend

- `PUT /api/trips/:tripId` — transactional update: updates the trip row, then replaces its detours wholesale (delete-all + re-insert), mirroring the create flow. Returns the reconstructed trip view. Last-write-wins.
- `POST /api/trips/:tripId/duplicate` — transactional deep copy of trip + detours.
- `DELETE /api/trips/:tripId` — deletes the trip (detours cascade).
- All routes are behind `requireAuth`, scoped by `req.userId`, with a UUID guard (malformed id → 404, avoiding a Postgres `22P02` → 500), and return 404 for trips the user doesn't own.
- New `DetourRepository.deleteByTripId` (user-scoped) to support the update replace-all.
- `buildTripView` now also surfaces `updatedAt`, `distanceMeters`, and `durationSeconds`.

### Frontend

- New `TripRequester` methods: `updateTrip`, `duplicateTrip`, `deleteTrip`.
- New Redux state: `tripName` (editable field), `currentTrip` (which saved trip is loaded, with a snapshot of its saved values), and `tripsRevision` (bumped on save to refresh the open list); all cleared/preserved appropriately on `CLEAR_ALL`.
- `MyTrips` — clickable cards get a Fluent `Menu` (Duplicate + Delete), a confirmation `Dialog`, in-place list/count updates, and a live-refresh effect.
- `SaveTrip` — single **Save Trip** button that updates-in-place or creates, with a 404→save-as-new fallback; extracted the name field into `TripNameField` rendered above the timeline.
- Added `@fluentui/react-icons` as a direct dependency; set `GENERATE_SOURCEMAP=false` on `start`/`build` to silence the `tabster` source-map warnings.

**Notable fix:** updating a loaded trip that hadn't been re-routed (e.g. a plain rename) previously wiped its distance, duration, and endpoint coordinates because the reconstructed route has no `legs`. `buildTripPayload` now falls back to the loaded trip's saved values when there are no live legs, and prefers live route data when the user has re-routed.

### Files changed

- **Backend:** `routes/trips.js` (+tests), `repositories/DetourRepository.js` (+tests), `modules/tripView.js` (+tests)
- **Frontend:** `scripts/TripRequester.js` (+tests), `reducers/main-reducer.js` (+tests), `components/sidebar/{MyTrips,SaveTrip,TripNameField,TripSummary}.jsx`, `styles/App.css`, `package.json`

### How to test

1. `cd backend && npm test` → 149 passing. `cd frontend && CI=true npm test` → 69 passing.
2. **Update/rename:** load a trip → the name is pre-filled → change the name and/or add/remove a detour → **Save Trip** → reopen from My Trips and confirm the changes (and distance/time) persisted.
3. **Rename-only regression:** load a trip → change *only* the name → Save → reopen; distance, time, and endpoints must be unchanged.
4. **Delete:** ⋯ → Delete → confirm → the card disappears, count decrements, success toast; Cancel does nothing; clicking ⋯ never loads the trip.
5. **Duplicate:** ⋯ → Duplicate → "Copy of …" appears in the list; the original is untouched.
6. **Live refresh:** open My Trips, save a trip from the planner, and confirm the list updates without closing the drawer.
7. **Not-owned/unauth:** `PUT`/`DELETE`/`duplicate` on another user's trip → 404; unauthenticated → 401.

### Notes / assumptions

- Concurrency is **last-write-wins** (no version/optimistic-locking column).
- Duplicated trips are a full copy, including `status`.
- Deferred (out of scope): plan-based detour-count limit, a card-level nested-interactive a11y cleanup, jumping to page 1 after a duplicate, and the tabbed-drawer refactor.