### PR TITLE
Release v1.2.0 — Accounts, database, infrastructure & saved trips

### DIFF
--- a/.copilot/plans/auth-implementation-plan.md
+++ b/.copilot/plans/auth-implementation-plan.md
@@ -1,0 +1,150 @@
+<!-- markdownlint-disable-file -->
+# Plan: End-to-End User Authentication (Entra External ID)
+
+## Goal
+
+Wire real user registration, login, and logout into the app using the
+already-provisioned Microsoft Entra External ID tenant. Use a **backend-driven
+confidential-client flow** (MSAL Node) with a server-side session, prove the whole chain
+with one protected, `user_id`-scoped data route, then add a minimal frontend login/logout
+UI. Email/password only for this pass; Google/social login is deferred (it is additive
+later with no code change).
+
+## Status / Context
+
+- **Phase 0 (provisioning) is DONE** by the user: external tenant, `SignUpSignIn` user
+  flow (Email with password, collecting Email + Display Name), app registration associated
+  with the flow, admin consent granted, and the four `ENTRA_*` values collected.
+- **Single tenant** is used for both dev and prod for now (no users yet, low risk; split
+  later is a config-only change).
+- **Secrets** live in `.devcontainer/devcontainer.env` (user runs inside the dev
+  container).
+
+## Confirmed Decisions
+
+- **Option A — backend-driven**: Express performs the OAuth authorization-code + PKCE
+  exchange (MSAL Node) and issues a server session cookie. App registration platform =
+  **Web** (uses a client secret). Chosen over an MSAL-React SPA approach.
+- **Session-based authorization**: `req.session.userId` is the boundary; `requireAuth`
+  middleware resolves it to `req.userId`.
+- **Env vars collected**: `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_CLIENT_ID`,
+  `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback`.
+
+## Current State (investigated)
+
+- `backend/index.js`: Express 5.1, `express-session` 1.18 with a **hardcoded**
+  `"temporarySecretKey"`, wide-open `app.use(cors())`, only `/test`, `/route`, `/places`.
+  Listens on port 3000.
+- `backend/app/db/pool.js`: shared `pg` pool from env vars; exports
+  `{ query, getClient, pool }`; `DB_SSL=false` disables SSL for local Postgres.
+- `backend/app/repositories/UserRepository.js`: has `getUserByExternalId`, `createUser`,
+  `updateUser` (`UPDATABLE_COLUMNS` includes `email`, `displayName`, `lastLogin`). **No
+  `upsertByExternalId`** — this is the one real gap.
+- Repository test pattern: `pool = { query: jest.fn() }`; assert SQL substrings + params;
+  `logger` mocked. 74 tests currently passing.
+- Frontend: CRA + Redux; `axios` to an absolute backend base (`getUrlBase()` in
+  `RouteRequester`); frontend on `:3001`, backend on `:3000` (cross-origin). No
+  client-side callback route needed — the backend handles `/auth/callback`.
+- Cookie note: `localhost:3000` and `localhost:3001` are the **same site** (site =
+  eTLD+1, port-agnostic), so a `sameSite=lax` cookie **is** sent on XHR. CORS must still
+  use `credentials: true` with an explicit origin (not `*`), and axios needs
+  `withCredentials: true`. (Alt: add a CRA `proxy` for same-origin dev.)
+
+## Phase 1 — Backend Auth Foundation
+
+1. Add dependencies to `backend/`: `@azure/msal-node`, `jose`.
+2. **CREATE** `backend/config/auth.js`: MSAL `ConfidentialClientApplication`
+   (`clientId`, `clientSecret`, `authority = https://<sub>.ciamlogin.com/`,
+   `knownAuthorities`). Export `msalClient`, `authority`, and a `CryptoProvider` for
+   PKCE/state. Also export a `jose` `JWKS` (`createRemoteJWKSet` on
+   `authority + discovery/v2.0/keys`) for future bearer-token verification.
+3. **`UserRepository.upsertByExternalId({ externalId, email, displayName })`**:
+   `getUserByExternalId`; if found → `updateUser(user_id, { email, displayName, lastLogin: now })`;
+   else `createUser`. Return the row. Add unit tests (found path, create path,
+   update-on-login path).
+4. **CREATE** `backend/app/routes/auth.js`:
+   - `GET /auth/login`: PKCE (verifier + challenge) + state stored in `req.session` →
+     `msalClient.getAuthCodeUrl({ scopes: [openid, profile, email], redirectUri,
+     codeChallenge, codeChallengeMethod: "S256", state })` → `res.redirect`.
+   - `GET /auth/callback`: validate `state`; `acquireTokenByCode({ code, scopes,
+     redirectUri, codeVerifier })`; read `idTokenClaims { sub, email, name }`;
+     `upsertByExternalId`; set `req.session.userId`; redirect to `FRONTEND_URL`.
+   - `POST /auth/logout`: `req.session.destroy` → redirect to the Entra logout endpoint
+     (`authority + oauth2/v2.0/logout?post_logout_redirect_uri=FRONTEND_URL`).
+   - `GET /auth/me`: return the current user (`getUserById(req.session.userId)`) or 401 —
+     lets the SPA know login state.
+5. **CREATE** `backend/app/middleware/requireAuth.js`: if `req.session.userId` → set
+   `req.userId` and `next()`; else `401 { error: "Unauthorized" }`.
+6. **MODIFY** `backend/index.js`: `SESSION_SECRET` from env; `resave: false`;
+   `saveUninitialized: false`; `cookie { httpOnly: true, sameSite: "lax", secure: prod,
+   maxAge }`. Replace wide-open `cors()` with `{ origin: FRONTEND_URL, credentials: true }`.
+   Mount the auth and API routes. Keep the existing `/route` and `/places`.
+
+## Phase 2 — Prove the Chain (protected data route)
+
+7. **CREATE** `backend/app/routes/trips.js`: `GET /api/trips` (behind `requireAuth`) →
+   `TripRepository.getTripsByUserId(req.userId)`; optional `POST /api/trips`.
+8. Composition: instantiate the pool + `UserRepository`/`TripRepository` once (small module
+   or in `index.js`) and inject into the routes.
+
+## Phase 3 — Frontend Login/Logout UI
+
+9. On app load, call `GET /auth/me` (axios `withCredentials`) → store the user in
+   Redux/state.
+10. "Sign in" button → `window.location = ${backendBase}/auth/login` (full-page redirect).
+    "Sign out" → `POST /auth/logout` then clear the user/redirect.
+11. Header (`frontend/src/components/header/Header.jsx`) or a new `AuthButton`: show
+    "Sign in" when logged out; display name + "Sign out" when logged in.
+12. Set axios `withCredentials: true` (global or per auth call). Add
+    `REACT_APP_BACKEND_URL` to `frontend/src/config/config.js` (currently only `NODE_ENV`
+    and `GOOGLE_API_KEY`).
+
+## Phase 4 — Config, Docs, Tests
+
+13. **UPDATE** `backend/.env.example` (create if missing) and
+    `.devcontainer/devcontainer.env.example` with `ENTRA_*` + `SESSION_SECRET` +
+    `FRONTEND_URL` (placeholders / local values).
+14. Reconcile docs: `docs/authentication/implementation-guide.md` references
+    `app/models/User` and `Trip.findByUserId` → update to `repositories/UserRepository`
+    and `getTripsByUserId`.
+15. Tests: `upsertByExternalId` (repository); `requireAuth` (unit); auth routes (mock
+    `msalClient` + upsert). Keep the existing 74 passing.
+
+## Relevant Files
+
+- `backend/index.js` — session/CORS hardening, mount routes.
+- `backend/app/db/pool.js` — reuse the shared pool (no change).
+- `backend/app/repositories/UserRepository.js` — add `upsertByExternalId` (+ `.test.js`).
+- `backend/app/repositories/TripRepository.js` — reuse `getTripsByUserId`.
+- **New**: `backend/config/auth.js`, `backend/app/routes/auth.js`,
+  `backend/app/routes/trips.js`, `backend/app/middleware/requireAuth.js`.
+- `frontend/src/config/config.js` — add backend URL; `frontend/src/App.js` /
+  `frontend/src/components/header/Header.jsx` — auth UI.
+- `docs/authentication/implementation-guide.md` — naming reconcile.
+
+## Verification
+
+1. `npm test` in `backend/` — new tests pass, 74 existing still green.
+2. Manual E2E: start the stack → **Sign in** → Entra hosted sign-up → create a test
+   account → callback → `GET /auth/me` returns the user → a row appears in `users` keyed
+   by `external_id` → `GET /api/trips` returns `[]` scoped to that user → **Sign out**
+   clears the session.
+3. Confirm the session cookie is `httpOnly`, and an unauthenticated `GET /api/trips`
+   returns 401.
+
+## Further Considerations (decide during build)
+
+1. **Logout scope** — full Entra logout (ends the IdP SSO session, user re-enters password
+   next time) vs. local-only (clears the app session, Entra still remembers).
+   **Recommendation: full Entra logout** for a true "logout" story.
+2. **Session contents** — store `userId` only and fetch via `/auth/me` (DB = source of
+   truth) vs. store the whole user object. **Recommendation: `userId` only.**
+3. **Dev cross-origin cookie** — explicit CORS `origin` + `credentials: true`
+   (**recommended**) vs. a CRA `proxy` for same-origin dev.
+4. **Frontend state** — a small Redux auth reducer (matches the existing pattern,
+   **recommended**) vs. local component state.
+
+## Out of Scope (this pass)
+
+- Google/social login. A second (prod) Entra tenant. Azure Key Vault wiring. DB
+  migrations. Full trip/detour REST CRUD beyond the one proof route. Node version bump.

--- a/.copilot/plans/local-devcontainer-postgres-plan.md
+++ b/.copilot/plans/local-devcontainer-postgres-plan.md
@@ -1,0 +1,95 @@
+<!-- markdownlint-disable-file -->
+# Plan: Local Dev Container with PostgreSQL Sidecar
+
+## Goal
+
+Convert the single-image dev container into a Docker Compose setup with the existing
+`app` service plus a `postgres:14` `db` sidecar, so local full-stack development runs
+against a containerized database (no Azure, no cost). No application code changes are
+required — `backend/app/db/pool.js` already honors `DB_SSL=false`, and `.env.example`
+already documents the `DB_*` variables.
+
+## Branch Workflow (do first)
+
+1. PR the current branch (`49-database-initialization`: repositories, Husky, `.vscode`, formatting).
+2. After merge:
+
+   ```bash
+   git checkout main && git pull && git checkout -b feature/local-devcontainer-postgres
+   ```
+
+   Do all the work below on that new branch.
+
+## Current State (investigated)
+
+- `.devcontainer/devcontainer.json`: single `image`
+  (`mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye`), features git + gh,
+  `forwardPorts` 3000/3001/8080, `postCreateCommand` commented out, and
+  `runArgs: ["--env-file", ".devcontainer/devcontainer.env"]`.
+- `.devcontainer/devcontainer.env` EXISTS (gitignored): `GOOGLE_API_KEY`,
+  `REACT_APP_GOOGLE_API_KEY`, `NODE_ENV`, `NODE_OPTIONS`, `BACKEND_PORT`,
+  `FRONTEND_PORT`, and a commented `DATABASE_URL` placeholder.
+- SECURITY: the Google API key value appears in git history (6 commits, some pushed).
+  Rotate the key before continuing.
+- `backend/` and `frontend/` have PRODUCTION Dockerfiles — separate concern; do NOT
+  reuse them for the dev container.
+- Schema lives at `docs/database/schema.sql` (PostgreSQL 14; includes demo data,
+  which is acceptable for local dev).
+
+## Files to Create / Modify
+
+1. CREATE `.devcontainer/docker-compose.yml`
+   - Service `app`: image `mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye`;
+     `command: sleep infinity`; bind-mount `..:/workspaces/jauntdetour`;
+     `env_file: devcontainer.env`; `depends_on: db` (condition `service_healthy`);
+     shared network.
+   - Service `db`: image `postgres:14`; environment `POSTGRES_USER=dbadmin`,
+     `POSTGRES_PASSWORD=localdev`, `POSTGRES_DB=jauntdetour`; volume
+     `pgdata:/var/lib/postgresql/data`; mount
+     `../docs/database/schema.sql -> /docker-entrypoint-initdb.d/init.sql:ro`
+     (auto-load on first init only); `ports: 5432:5432`; healthcheck
+     `pg_isready -U dbadmin`.
+   - Volumes: `pgdata` (named; persists across restarts).
+2. MODIFY `.devcontainer/devcontainer.json`
+   - Remove `image` and `runArgs` (`--env-file`); env now flows via Compose `env_file`.
+   - Add `dockerComposeFile: "docker-compose.yml"`, `service: "app"`,
+     `workspaceFolder: "/workspaces/jauntdetour"`.
+   - Keep features, customizations (extensions/settings), `portsAttributes`.
+   - `forwardPorts`: add `5432` (host DB GUI tools); keep 3000/3001/8080.
+   - Re-enable `postCreateCommand`:
+     `npm install --prefix ./backend && npm install --prefix ./frontend && npm install`.
+3. MODIFY `.devcontainer/devcontainer.env` (gitignored) — add:
+   `DB_HOST=db`, `DB_PORT=5432`, `DB_NAME=jauntdetour`, `DB_USER=dbadmin`,
+   `DB_PASSWORD=localdev`, `DB_SSL=false`.
+4. CREATE `.devcontainer/devcontainer.env.example` (committed) — same keys, placeholder
+   secrets, so teammates know what to fill in. Ensure the real `devcontainer.env` stays
+   gitignored.
+5. (Optional) Update `DEV-SETUP.md` / `README.md` with "Open in Dev Container"
+   local-DB instructions.
+
+## Key Decisions / Considerations
+
+- Pin `postgres:14` to match Azure + the schema.
+- `node_modules`: bind-mounting the workspace is simplest; if host/container
+  native-module conflicts appear, switch to a named volume for `node_modules`
+  (decide during implementation).
+- `depends_on` with `service_healthy` + a healthcheck so the backend never races the DB.
+- Schema auto-load runs ONLY when the `pgdata` volume is empty (first create); demo
+  data is included.
+- Reset the DB: `docker compose down -v` (wipes `pgdata`), then reopen/rebuild.
+- Local DB credentials are throwaway/local-only — safe to keep in the compose/env file.
+- Do NOT reuse the production `backend`/`frontend` Dockerfiles for the dev container.
+- Windows: ensure any mounted `.sql`/scripts use LF line endings.
+
+## Verification
+
+1. Dev Containers: Rebuild and Reopen in Container — builds `app` + `db`.
+2. `docker compose ps` (or VS Code) shows `db` healthy.
+3. From the `app` container:
+   `psql -h db -U dbadmin -d jauntdetour -c "\dt"` shows `users`/`trips`/`detours`;
+   `SELECT email FROM users;` returns `demo@jauntdetour.com`.
+4. Backend: with `DB_*` env set, run a quick query (or start the backend) — connects,
+   no SSL error.
+5. Frontend: `npm start` serves on 3001; forwarded.
+6. Persistence: restart the container — data remains. `down -v` resets and reloads schema.
+7. Confirm `devcontainer.env` is NOT tracked (`git check-ignore`) and the `.example` IS tracked.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.7",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a",
+      "integrity": "sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,0 +1,29 @@
+# Environment variables for Jauntdetour development.
+# Copy this file to devcontainer.env and fill in the secret values.
+#   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+# devcontainer.env is gitignored; never commit real secrets.
+
+# Google Maps API Key (required for both frontend and backend)
+GOOGLE_API_KEY=your_google_api_key_here
+REACT_APP_GOOGLE_API_KEY=your_google_api_key_here
+
+# Node.js environment
+NODE_ENV=development
+NODE_OPTIONS=--openssl-legacy-provider
+
+# Backend server configuration
+BACKEND_PORT=3000
+
+# Frontend development server configuration
+FRONTEND_PORT=3001
+
+# Local containerized database (see .devcontainer/docker-compose.yml).
+# These are local-only development values, safe to use as-is. The backend
+# connects as the least-privilege app user; DB_PASSWORD must match the password
+# in .devcontainer/init/02-create-app-user.sql.
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=jauntdetour
+DB_USER=jauntdetour_app
+DB_PASSWORD=localdevapp
+DB_SSL=false

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -17,6 +17,23 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
+# Frontend origin used by the backend for CORS and post-login/logout redirects.
+FRONTEND_URL=http://localhost:3001
+
+# Express session signing secret. Generate a long random value, e.g.
+#   openssl rand -base64 32
+SESSION_SECRET=change_me_to_a_long_random_string
+
+# Microsoft Entra External ID (CIAM) — from the app registration + user flow.
+# ENTRA_TENANT_SUBDOMAIN is the tenant subdomain (the "<sub>" in <sub>.ciamlogin.com);
+# the full "<sub>.onmicrosoft.com" form is also accepted.
+# ENTRA_TENANT_ID is the tenant (directory) GUID — required in the CIAM authority path.
+ENTRA_TENANT_SUBDOMAIN=your_tenant_subdomain
+ENTRA_TENANT_ID=your_tenant_directory_guid
+ENTRA_CLIENT_ID=your_app_registration_client_id
+ENTRA_CLIENT_SECRET=your_app_registration_client_secret
+ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
+
 # Local containerized database (see .devcontainer/docker-compose.yml).
 # These are local-only development values, safe to use as-is. The backend
 # connects as the least-privilege app user; DB_PASSWORD must match the password

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
   "name": "Jauntdetour Full Stack",
-  // Use the Node.js image with additional tools
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+  // Use Docker Compose: the `app` dev container plus a PostgreSQL `db` sidecar.
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/jauntdetour",
 
   // Features to add to the dev container
   "features": {
@@ -12,7 +14,7 @@
   },
 
   // Forward ports for both frontend and backend
-  "forwardPorts": [3000, 3001, 8080],
+  "forwardPorts": [3000, 3001, 8080, 5432],
   "portsAttributes": {
     "3000": {
       "label": "Backend API",
@@ -25,10 +27,20 @@
     "8080": {
       "label": "Frontend Production",
       "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "PostgreSQL",
+      "onAutoForward": "silent"
     }
   },
-  // Install dependencies for both frontend and backend after container creation
-  //"postCreateCommand": "npm install --prefix ./backend && npm install --prefix ./frontend && npm install",
+  // Install system packages once at container creation. postgresql-client provides
+  // the `psql` CLI for inspecting the local database. Clean up apt lists afterward
+  // to keep the container lean.
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client && sudo rm -rf /var/lib/apt/lists/*",
+  // Install dependencies for root, backend, and frontend after the container is created.
+  // The node_modules named volumes are created root-owned, so hand them to the `node`
+  // user first (they're empty at this point, so the chown is instant).
+  "postCreateCommand": "sudo chown node:node node_modules backend/node_modules frontend/node_modules && npm install && npm install --prefix ./backend && npm install --prefix ./frontend",
 
   // Configure VS Code extensions and settings
   "customizations": {
@@ -56,11 +68,13 @@
   // Set environment variables for development
   "containerEnv": {
     "NODE_ENV": "development",
-    "NODE_OPTIONS": "--openssl-legacy-provider"
+    "NODE_OPTIONS": "--openssl-legacy-provider",
+    // Let VS Code's port forwarding open the browser for 3001; stop react-scripts
+    // from opening a second one.
+    "BROWSER": "none"
   },
-  // Load .env file if it exists
-  //"onCreateCommand": "if [ -f .env ]; then echo 'Found .env file for environment variables'; else echo 'No .env file found - create one with GOOGLE_API_KEY=your_key_here'; fi",
+  // Environment variables (Google keys, DB_*, ports) are also provided via the
+  // Compose `env_file` (.devcontainer/devcontainer.env). See devcontainer.env.example.
 
-  "remoteUser": "node",
-  "runArgs": ["--env-file", ".devcontainer/devcontainer.env"]
+  "remoteUser": "node"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,55 @@
+# Docker Compose for the local development container.
+# Provides the Node dev environment (`app`) plus a PostgreSQL 14 sidecar (`db`).
+# This is for LOCAL DEVELOPMENT ONLY — it does not use the production Dockerfiles.
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye
+    init: true
+    # Keep the container running so VS Code can attach and open a shell.
+    command: sleep infinity
+    volumes:
+      # Mount the repository into the container workspace.
+      - ..:/workspaces/jauntdetour:cached
+      # Container-only node_modules (named volumes) so the container's Linux-built
+      # dependencies never collide with the host's copies via the bind mount.
+      - node_modules_root:/workspaces/jauntdetour/node_modules
+      - node_modules_backend:/workspaces/jauntdetour/backend/node_modules
+      - node_modules_frontend:/workspaces/jauntdetour/frontend/node_modules
+    env_file:
+      # Local secrets + config (gitignored). See devcontainer.env.example.
+      - devcontainer.env
+    # Wait for the database to be accepting connections before the app is usable.
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:14
+    restart: unless-stopped
+    environment:
+      # Superuser used only for initialization; the app connects as jauntdetour_app.
+      POSTGRES_USER: dbadmin
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: jauntdetour
+    volumes:
+      # Persist database data across container restarts.
+      - pgdata:/var/lib/postgresql/data
+      # Init scripts run in filename order, and ONLY when pgdata is empty (first boot).
+      # 01 creates the schema (tables must exist before 02 grants on them).
+      - ../docs/database/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./init/02-create-app-user.sql:/docker-entrypoint-initdb.d/02-create-app-user.sql:ro
+    ports:
+      # Exposed to the host so GUI tools (DBeaver/pgAdmin) can connect on localhost:5432.
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dbadmin -d jauntdetour"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:
+  node_modules_root:
+  node_modules_backend:
+  node_modules_frontend:

--- a/.devcontainer/init/02-create-app-user.sql
+++ b/.devcontainer/init/02-create-app-user.sql
@@ -1,0 +1,16 @@
+-- Local development only: create the least-privilege application user.
+-- Mirrors the production setup (the app connects as jauntdetour_app, never as the
+-- superuser). Runs after 01-schema.sql so the tables it grants on already exist.
+-- The password here is a throwaway LOCAL value and must match DB_PASSWORD in
+-- .devcontainer/devcontainer.env.
+
+CREATE USER jauntdetour_app WITH PASSWORD 'localdevapp';
+
+GRANT CONNECT ON DATABASE jauntdetour TO jauntdetour_app;
+GRANT USAGE ON SCHEMA public TO jauntdetour_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO jauntdetour_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO jauntdetour_app;
+
+-- Ensure the app user also gets privileges on any tables created later.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO jauntdetour_app;

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,12 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
-# Optional: Database connection string if you add a database later
-# DATABASE_URL=your_database_url_here
+# Database connection (Azure Database for PostgreSQL - Flexible Server)
+# DB_HOST is the server FQDN from `terraform output server_fqdn`
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+# Set to "false" only for a local non-SSL Postgres; Azure requires SSL (leave unset).
+# DB_SSL=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,11 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 
+# Shell scripts and Git hooks must use LF, or the shell mis-parses the trailing
+# carriage return (e.g. husky hooks fail with a bogus package name).
+*.sh text eol=lf
+.husky/* text eol=lf
+
 # Denote all files that are truly binary and should not be modified
 *.png binary
 *.jpg binary

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,55 @@ trips.
 - Frontend: `cd frontend && CI=true npm test`.
 - Keep the suite green and add tests for new backend routes/repos.
 
+## Reviewing code
+
+When reviewing code, focus on:
+
+### Security Critical Issues
+
+- Check for hardcoded secrets, API keys, or credentials
+- Look for SQL injection and XSS vulnerabilities
+- Verify proper input validation and sanitization
+- Review authentication and authorization logic
+
+### Performance Red Flags
+
+- Identify N+1 database query problems
+- Spot inefficient loops and algorithmic issues
+- Check for memory leaks and resource cleanup
+- Review caching opportunities for expensive operations
+
+### Code Quality Essentials
+
+- Functions should be focused and appropriately sized
+- Use clear, descriptive naming conventions
+- Ensure proper error handling throughout
+
+### Review Style
+
+- Be specific and actionable in feedback
+- Explain the "why" behind recommendations
+- Acknowledge good patterns when you see them
+- Ask clarifying questions when code intent is unclear
+
+Always prioritize security vulnerabilities and performance issues that could impact users.
+
+Always suggest changes to improve readability. For example, this suggestion seeks to make the code more readable and also makes the validation logic reusable and testable.
+
+// Instead of:
+if (user.email && user.email.includes('@') && user.email.length > 5) {
+submitButton.enabled = true;
+} else {
+submitButton.enabled = false;
+}
+
+// Consider:
+function isValidEmail(email) {
+return email && email.includes('@') && email.length > 5;
+}
+
+submitButton.enabled = isValidEmail(user.email);
+
 ## Pull Requests
 
 - When asked for a PR description, provide a summary of the change, what files were modified, how to test the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+# JauntDetour — Copilot Instructions
+
+Road-trip planner: React frontend + Node/Express backend + PostgreSQL, using
+Google Maps APIs to build routes and find detours, with user accounts and saved
+trips.
+
+## Architecture at a glance
+
+- **Frontend**: React 19 (CRA) + Redux, runs on `:3001`. Entry: `frontend/src/index.js`.
+- **Backend**: Node/Express (CommonJS), runs on `:3000`. Entry: `backend/index.js`.
+- **Database**: PostgreSQL (`users → trips → detours`). Local DB via the dev
+  container; Azure Database for PostgreSQL in production. Schema:
+  `docs/database/schema.sql`.
+- **Dev**: runs inside a dev container; env comes from `.devcontainer/devcontainer.env`
+  (see `.env.example` / `.devcontainer/devcontainer.env.example`). `npm run dev`
+  starts both apps.
+
+## High-level tech decisions
+
+- **UI library: Fluent 2 (`@fluentui/react-components`).** Build NEW frontend UI
+  (dialogs, drawers, toasts, buttons, inputs) with Fluent. The app root is wrapped
+  in `<FluentProvider theme={webLightTheme}>` (`frontend/src/index.js`). The
+  original planning UI is legacy custom CSS/Bootstrap-ish markup — don't expand it;
+  prefer Fluent for new work.
+- **Auth: Microsoft Entra External ID (CIAM)**, backend-driven confidential-client
+  OAuth (MSAL Node, authorization-code + PKCE) with a server-side session cookie.
+  - `requireAuth` middleware sets `req.userId` — the **authorization boundary**.
+    Never trust a `userId` from the client; always use `req.userId`.
+  - The MSAL authority **must include the tenant ID in the path**
+    (`https://<subdomain>.ciamlogin.com/<tenantId>`) or CIAM discovery fails with
+    `endpoints_resolution_error`. Config: `backend/config/auth.js`.
+  - Env: `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_TENANT_ID`, `ENTRA_CLIENT_ID`,
+    `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI`, `SESSION_SECRET`, `FRONTEND_URL`.
+- **Cookies/CORS**: session cookie is `httpOnly`; `sameSite="none"` + `secure` in
+  prod (frontend/backend are cross-site on `*.azurewebsites.net`), `lax` in dev.
+  CORS uses an explicit origin (`FRONTEND_URL`) + `credentials: true`; frontend
+  axios calls that need auth use `withCredentials: true`.
+- **Data access: repository pattern** (`backend/app/repositories/*Repository.js`).
+  A `pg` pool (or a transaction client) is injected via the constructor. All SQL
+  is parameterized. Every query is scoped by `user_id`.
+- **Transactions**: use `db.getClient()` and construct client-scoped repositories
+  (`new TripRepository(client)`) inside `BEGIN`/`COMMIT`/`ROLLBACK` (see the
+  `POST /api/trips` handler in `backend/app/routes/trips.js`).
+- **Routes are injectable factories** (`createXRouter({ ...deps })`) so they can be
+  unit-tested with mock repositories.
+- **Redux state persists to `sessionStorage`** (`frontend/src/index.js`) so an
+  in-progress trip survives the full-page login redirect. `user` is NOT persisted —
+  auth state is always re-resolved from `GET /auth/me`.
+- **Frontend requesters** (`frontend/src/scripts/*Requester.js`) wrap axios, build
+  URLs from `config.BACKEND_URL`, and pass `withCredentials: true` for authed calls.
+
+## Conventions
+
+- Backend is CommonJS (`require`/`module.exports`), `var`/`const` mixed in older
+  files — match the file you're editing.
+- Prettier + ESLint enforced via husky `pre-commit` + lint-staged. **Git hooks and
+  shell scripts must be LF** (see `.gitattributes`) or the hook breaks on CRLF.
+- Don't commit secrets; real values live in the gitignored `devcontainer.env`.
+
+## Testing
+
+- Backend: Jest. Repos tested with a mock pool (`{ query: jest.fn() }`, assert SQL
+  substrings + params); routes tested with `supertest` + mocked repos/db. Run
+  `cd backend && npm test`.
+- Frontend: `cd frontend && CI=true npm test`.
+- Keep the suite green and add tests for new backend routes/repos.
+
+## Pull Requests
+
+- When asked for a PR description, provide a summary of the change, what files were modified, how to test the
+  changes, and any other relevant information or assumtpions. Provide all of this in markdown to be copy and pasted.
+- Once a PR is active, the user will review the changes with you based on feedback from a Github Copilot agent.
+  For each comment, do not assume the comment is correct, but investigate if the feedback is accurate and within
+  scope of this PR. If it is, work with the user to make changes based on the feedback.
+
+## Known constraints / follow-ups
+
+- `@azure/msal-node` requires **Node >= 20** (dev container is 20). CI still uses
+  Node 18 — bump tracked separately.
+- Sessions use the default in-memory `MemoryStore` — fine for a single instance;
+  needs a persistent store (e.g. `connect-pg-simple`) before scaling out.

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,19 @@ typings/
 .env
 .env.production
 
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+!*.tfvars.example
+.terraform.lock.hcl
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
 # next.js build output
 .next
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+# Run the root-pinned lint-staged. It auto-discovers each package's config
+# (backend/, frontend/) and applies it to that package's staged files, using
+# that package's local ESLint/Prettier. --no-install keeps it deterministic:
+# it uses the installed root binary and never downloads an arbitrary version.
+npx --no-install lint-staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.requireConfig": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
+}

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -48,6 +48,36 @@ export NODE_OPTIONS=--openssl-legacy-provider
 - Nodemon for backend auto-restart on file changes
 - React fast refresh for frontend live reloading
 
+## Local Database (Dev Container)
+
+The dev container runs a PostgreSQL 14 sidecar (via `.devcontainer/docker-compose.yml`),
+so you can develop against a local database with no Azure dependency or cost.
+
+### First-time setup
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   # edit GOOGLE_API_KEY / REACT_APP_GOOGLE_API_KEY (DB_* values work as-is)
+   ```
+2. In VS Code, run **Dev Containers: Reopen in Container**. On first build the database
+   is created and seeded automatically:
+   - `01-schema.sql` loads the schema (tables, indexes, triggers, demo data).
+   - `02-create-app-user.sql` creates the least-privilege `jauntdetour_app` user.
+3. `npm run dev` starts the frontend and backend, which connect to the `db` service.
+
+### Connecting to the database
+- **From the app container:** host `db`, port `5432`.
+- **From your host machine** (DBeaver, pgAdmin, psql): `localhost:5432`.
+- The backend connects as `jauntdetour_app` (least privilege). The `dbadmin` superuser
+  (password `localdev`) is used only for initialization.
+
+### Resetting the database
+Init scripts run only when the data volume is empty (first boot). To wipe and reseed (note: `-v` also removes node_modules_* volumes, so deps will reinstall on next start):
+```bash
+docker compose -f .devcontainer/docker-compose.yml down -v
+```
+Then rebuild/reopen the container.
+
 ## Development Tips
 1. The backend will auto-restart when you change files (thanks to nodemon)
 2. The frontend has fast refresh enabled for live updates

--- a/backend/app/db/pool.js
+++ b/backend/app/db/pool.js
@@ -1,0 +1,49 @@
+/**
+ * PostgreSQL connection pool.
+ *
+ * Creates a single shared `pg` Pool for the application. Pooling keeps a set of
+ * open connections ready so each request reuses one instead of paying a fresh
+ * TCP + TLS + auth handshake. Configuration is read from environment variables
+ * (see `.env.example`). Azure Database for PostgreSQL requires SSL.
+ */
+
+const { Pool } = require("pg");
+const logger = require("../utils/logger");
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT || 5432,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD, // from Key Vault in production
+  ssl: process.env.DB_SSL === "false" ? false : { rejectUnauthorized: true }, // Azure requires SSL; disable only for local Postgres
+  max: 20, // maximum number of clients in the pool
+  idleTimeoutMillis: 30000, // close idle clients after 30s
+  connectionTimeoutMillis: 2000, // fail fast if a connection can't be acquired
+});
+
+// Surface unexpected errors on idle clients (e.g. a dropped network/DB restart).
+pool.on("error", (err) => {
+  logger.error("Unexpected error on idle PostgreSQL client", err);
+  process.exit(-1);
+});
+
+module.exports = {
+  /**
+   * Run a parameterized query against the pool.
+   *
+   * @param {string} text - SQL with $1, $2, ... placeholders.
+   * @param {Array} [params] - Parameter values.
+   * @returns {Promise<import('pg').QueryResult>}
+   */
+  query: (text, params) => pool.query(text, params),
+
+  /**
+   * Acquire a dedicated client (for transactions). Caller must release it.
+   *
+   * @returns {Promise<import('pg').PoolClient>}
+   */
+  getClient: () => pool.connect(),
+
+  pool,
+};

--- a/backend/app/middleware/requireAuth.js
+++ b/backend/app/middleware/requireAuth.js
@@ -1,0 +1,21 @@
+/**
+ * requireAuth — session-based authorization middleware.
+ *
+ * The server session is the authorization boundary: a successful sign-in stores
+ * the user's primary key in `req.session.userId`. This middleware promotes that
+ * value to `req.userId` for downstream handlers (so they never read the session
+ * directly) and rejects unauthenticated requests with 401.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+function requireAuth(req, res, next) {
+  if (req.session && req.session.userId) {
+    req.userId = req.session.userId;
+    return next();
+  }
+  return res.status(401).json({ error: "Unauthorized" });
+}
+
+module.exports = requireAuth;

--- a/backend/app/middleware/requireAuth.test.js
+++ b/backend/app/middleware/requireAuth.test.js
@@ -1,0 +1,52 @@
+const requireAuth = require("./requireAuth");
+
+describe("requireAuth", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = { session: {} };
+    res = {
+      statusCode: null,
+      body: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.body = payload;
+        return this;
+      },
+    };
+    next = jest.fn();
+  });
+
+  it("promotes session.userId to req.userId and calls next when authenticated", () => {
+    req.session.userId = "user-123";
+
+    requireAuth(req, res, next);
+
+    expect(req.userId).toBe("user-123");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it("responds 401 when there is no session", () => {
+    req.session = undefined;
+
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("responds 401 when the session has no userId", () => {
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+});

--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -111,6 +111,11 @@ function buildTripView(trip, detours = []) {
       tripName: trip.trip_name,
       origin: trip.origin,
       destination: trip.destination,
+      updatedAt: trip.updated_at,
+      // Raw stored values so the client can persist them back on an update that
+      // hasn't re-routed (a rename), without recomputing from a route it lacks.
+      distanceMeters: trip.distance_meters ?? null,
+      durationSeconds: trip.duration_seconds ?? null,
     },
     route,
     detours: (detours || []).map(mapDetour),

--- a/backend/app/modules/tripView.js
+++ b/backend/app/modules/tripView.js
@@ -1,0 +1,120 @@
+/**
+ * tripView — reconstructs a render-ready view of a saved trip.
+ *
+ * A saved trip persists only the *encoded* route polyline plus distance/duration
+ * (see POST /api/trips). The frontend map, however, renders from a decoded
+ * points array and needs map bounds and a formatted summary. The frontend has
+ * no polyline decoder, so we rebuild all of that here (the backend already
+ * depends on `polyline-encoded`) and hand the client a route object shaped like
+ * the one it gets during normal planning.
+ */
+
+const polylineEncoder = require("polyline-encoded");
+
+// Meters per mile (matches routeAPI's conversion).
+const METERS_PER_MILE = 1609.34;
+
+/**
+ * Format distance (meters) + duration (seconds) into the summary shape the
+ * sidebar renders: { time: { hours, min }, distance }. Mirrors
+ * routeAPI.createSummaryData so a loaded trip reads identically to a fresh one.
+ */
+function buildSummary(distanceMeters, durationSeconds) {
+  const seconds = durationSeconds || 0;
+  const hours = Math.floor(seconds / 3600);
+  const min = Math.floor((seconds / 3600 - hours) * 60);
+
+  let distance = (distanceMeters || 0) / METERS_PER_MILE;
+  // Match routeAPI.createSummaryData exactly: under 100 mi the distance is a
+  // toPrecision(3) STRING (preserving trailing zeros like "2.00"), at/above 100
+  // it is a rounded number. Keeping the string means a loaded trip displays
+  // identically to a freshly planned one.
+  distance = distance < 100 ? distance.toPrecision(3) : Math.round(distance);
+
+  return { time: { hours, min }, distance };
+}
+
+/**
+ * Compute Google-style bounds from an array of [lat, lng] points.
+ *
+ * @param {Array<[number, number]>} points
+ * @returns {{northeast:{lat:number,lng:number}, southwest:{lat:number,lng:number}}|null}
+ */
+function computeBounds(points) {
+  if (!points || points.length === 0) {
+    return null;
+  }
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+  for (const [lat, lng] of points) {
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+  }
+  return {
+    northeast: { lat: maxLat, lng: maxLng },
+    southwest: { lat: minLat, lng: minLng },
+  };
+}
+
+/**
+ * Map a stored detour row to the frontend detour shape. DECIMAL columns come
+ * back from pg as strings, so coerce the numerics.
+ */
+function mapDetour(row) {
+  return {
+    name: row.place_name,
+    type: row.place_type,
+    lat: Number(row.latitude),
+    lng: Number(row.longitude),
+    id: row.place_id,
+    placeId: row.place_id,
+    rating: row.rating != null ? Number(row.rating) : null,
+    addedTime: row.metadata ? row.metadata.addedTime : undefined,
+  };
+}
+
+/**
+ * Build the client-facing view of a saved trip.
+ *
+ * @param {object} trip - A row from TripRepository.getTripById.
+ * @param {object[]} [detours] - Rows from DetourRepository.getDetoursByTripId.
+ * @returns {{trip: object, route: object|null, detours: object[]}}
+ */
+function buildTripView(trip, detours = []) {
+  const points = trip.route_polyline
+    ? polylineEncoder.decode(trip.route_polyline)
+    : [];
+
+  const route =
+    points.length > 0
+      ? {
+          overview_polyline: {
+            points: trip.route_polyline,
+            // MapContainer reads complete_overview; DetourForm reads
+            // decodedPoints — provide both so loaded trips render and can still
+            // be extended with new detours.
+            complete_overview: points,
+            decodedPoints: points,
+          },
+          bounds: computeBounds(points),
+          summary: buildSummary(trip.distance_meters, trip.duration_seconds),
+        }
+      : null;
+
+  return {
+    trip: {
+      tripId: trip.trip_id,
+      tripName: trip.trip_name,
+      origin: trip.origin,
+      destination: trip.destination,
+    },
+    route,
+    detours: (detours || []).map(mapDetour),
+  };
+}
+
+module.exports = { buildTripView, buildSummary, computeBounds };

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -58,6 +58,7 @@ describe("buildTripView", () => {
     route_polyline: SAMPLE_POLYLINE,
     distance_meters: 3218.68,
     duration_seconds: 5400,
+    updated_at: "2026-07-07T12:00:00.000Z",
   };
 
   it("decodes the polyline into complete_overview and decodedPoints", () => {
@@ -92,6 +93,9 @@ describe("buildTripView", () => {
       tripName: "Coastal drive",
       origin: { address: "SF", lat: 37.77, lng: -122.42 },
       destination: { address: "LA", lat: 34.05, lng: -118.24 },
+      updatedAt: "2026-07-07T12:00:00.000Z",
+      distanceMeters: 3218.68,
+      durationSeconds: 5400,
     });
   });
 

--- a/backend/app/modules/tripView.test.js
+++ b/backend/app/modules/tripView.test.js
@@ -1,0 +1,130 @@
+const { buildTripView, buildSummary, computeBounds } = require("./tripView");
+
+// The canonical Google-documented polyline; decodes to three points.
+const SAMPLE_POLYLINE = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+const SAMPLE_POINTS = [
+  [38.5, -120.2],
+  [40.7, -120.95],
+  [43.252, -126.453],
+];
+
+describe("buildSummary", () => {
+  it("converts meters to miles and seconds to hours/min", () => {
+    // 3218.68 m = 2 mi; 5400 s = 1 h 30 m. Under 100 mi is a toPrecision(3)
+    // string (matches routeAPI), so "2.00" not 2.
+    const summary = buildSummary(3218.68, 5400);
+    expect(summary.distance).toBe("2.00");
+    expect(summary.time).toEqual({ hours: 1, min: 30 });
+  });
+
+  it("keeps 3 significant digits under 100 miles", () => {
+    const summary = buildSummary(16093.4, 0); // ~10 mi
+    expect(summary.distance).toBe("10.0");
+    expect(summary.time).toEqual({ hours: 0, min: 0 });
+  });
+
+  it("rounds to whole miles at or above 100", () => {
+    const summary = buildSummary(200000, 0); // ~124.3 mi
+    expect(summary.distance).toBe(124);
+  });
+
+  it("treats null distance/duration as zero", () => {
+    expect(buildSummary(null, null)).toEqual({
+      distance: "0.00",
+      time: { hours: 0, min: 0 },
+    });
+  });
+});
+
+describe("computeBounds", () => {
+  it("returns north-east / south-west corners", () => {
+    expect(computeBounds(SAMPLE_POINTS)).toEqual({
+      northeast: { lat: 43.252, lng: -120.2 },
+      southwest: { lat: 38.5, lng: -126.453 },
+    });
+  });
+
+  it("returns null for empty points", () => {
+    expect(computeBounds([])).toBeNull();
+  });
+});
+
+describe("buildTripView", () => {
+  const trip = {
+    trip_id: "t1",
+    trip_name: "Coastal drive",
+    origin: { address: "SF", lat: 37.77, lng: -122.42 },
+    destination: { address: "LA", lat: 34.05, lng: -118.24 },
+    route_polyline: SAMPLE_POLYLINE,
+    distance_meters: 3218.68,
+    duration_seconds: 5400,
+  };
+
+  it("decodes the polyline into complete_overview and decodedPoints", () => {
+    const view = buildTripView(trip, []);
+
+    expect(view.route.overview_polyline.points).toBe(SAMPLE_POLYLINE);
+    expect(view.route.overview_polyline.complete_overview).toHaveLength(3);
+    // Same array is exposed under both keys the frontend reads.
+    expect(view.route.overview_polyline.decodedPoints).toBe(
+      view.route.overview_polyline.complete_overview
+    );
+    view.route.overview_polyline.complete_overview.forEach((point, i) => {
+      expect(point[0]).toBeCloseTo(SAMPLE_POINTS[i][0], 3);
+      expect(point[1]).toBeCloseTo(SAMPLE_POINTS[i][1], 3);
+    });
+  });
+
+  it("includes bounds and a formatted summary", () => {
+    const view = buildTripView(trip, []);
+    expect(view.route.bounds.northeast.lat).toBeCloseTo(43.252, 3);
+    expect(view.route.bounds.southwest.lng).toBeCloseTo(-126.453, 3);
+    expect(view.route.summary).toEqual({
+      distance: "2.00",
+      time: { hours: 1, min: 30 },
+    });
+  });
+
+  it("returns the trip identity and endpoints", () => {
+    const view = buildTripView(trip, []);
+    expect(view.trip).toEqual({
+      tripId: "t1",
+      tripName: "Coastal drive",
+      origin: { address: "SF", lat: 37.77, lng: -122.42 },
+      destination: { address: "LA", lat: 34.05, lng: -118.24 },
+    });
+  });
+
+  it("maps detours and coerces DECIMAL string columns to numbers", () => {
+    const view = buildTripView(trip, [
+      {
+        place_name: "Big Sur",
+        place_type: "Landmark",
+        latitude: "36.27000000",
+        longitude: "-121.80000000",
+        place_id: "gp-1",
+        rating: "4.8",
+        metadata: { addedTime: 45 },
+      },
+    ]);
+
+    expect(view.detours).toEqual([
+      {
+        name: "Big Sur",
+        type: "Landmark",
+        lat: 36.27,
+        lng: -121.8,
+        id: "gp-1",
+        placeId: "gp-1",
+        rating: 4.8,
+        addedTime: 45,
+      },
+    ]);
+  });
+
+  it("returns a null route when the trip has no polyline", () => {
+    const view = buildTripView({ ...trip, route_polyline: null }, []);
+    expect(view.route).toBeNull();
+    expect(view.trip.tripId).toBe("t1");
+  });
+});

--- a/backend/app/repositories/DetourRepository.js
+++ b/backend/app/repositories/DetourRepository.js
@@ -1,0 +1,270 @@
+/**
+ * DetourRepository — data access layer for the `detours` table.
+ *
+ * Encapsulates all SQL for detour records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * Detours belong to a user only transitively, through their parent trip. Every
+ * operation is therefore scoped by `user_id` — the authorization boundary — by
+ * verifying ownership via the `trips` table. A user can only read or modify
+ * detours on trips they own. All queries use parameterized placeholders
+ * ($1, $2, ...) — prepared statements that prevent SQL injection.
+ */
+
+const logger = require("../utils/logger");
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  placeId: "place_id",
+  placeName: "place_name",
+  placeType: "place_type",
+  latitude: "latitude",
+  longitude: "longitude",
+  address: "address",
+  positionOnRoute: "position_on_route",
+  estimatedDetourDurationSeconds: "estimated_detour_duration_seconds",
+  estimatedDetourDistanceMeters: "estimated_detour_distance_meters",
+  rating: "rating",
+  priceLevel: "price_level",
+  stopDurationMinutes: "stop_duration_minutes",
+  visitTime: "visit_time",
+  notes: "notes",
+  metadata: "metadata",
+};
+
+// Columns returned to callers. Shared by every query that returns a full row.
+// Prefixed with `d.` so it can be reused inside JOIN queries against trips.
+const RETURNING_COLUMNS = `
+      detour_id, trip_id, place_id, place_name, place_type, latitude, longitude,
+      address, position_on_route, estimated_detour_duration_seconds,
+      estimated_detour_distance_meters, rating, price_level, stop_duration_minutes,
+      visit_time, notes, created_at, updated_at, metadata
+`;
+const RETURNING_COLUMNS_PREFIXED = RETURNING_COLUMNS.replace(/(\w+)/g, "d.$1");
+
+class DetourRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "DetourRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a detour on a trip the user owns. The insert only succeeds if the
+   * parent trip exists and belongs to the given user; otherwise it is a no-op
+   * and null is returned (trip not found or not owned).
+   *
+   * @param {object} detour
+   * @param {string} detour.tripId - Parent trip UUID.
+   * @param {string} detour.userId - Owning user's UUID (authorization scope).
+   * @param {string} detour.placeName - Name of the place.
+   * @param {number} detour.latitude - Latitude (-90..90).
+   * @param {number} detour.longitude - Longitude (-180..180).
+   * @param {string} [detour.placeId] - Google Places ID.
+   * @param {string} [detour.placeType] - e.g. restaurant, park.
+   * @param {string} [detour.address] - Formatted address.
+   * @param {number} [detour.positionOnRoute] - Normalized 0.0-1.0.
+   * @param {number} [detour.estimatedDetourDurationSeconds]
+   * @param {number} [detour.estimatedDetourDistanceMeters]
+   * @param {number} [detour.rating] - Google rating 0.0-5.0.
+   * @param {number} [detour.priceLevel] - 1-4.
+   * @param {number} [detour.stopDurationMinutes] - Defaults to 30.
+   * @param {string|Date} [detour.visitTime]
+   * @param {string} [detour.notes]
+   * @param {object} [detour.metadata] - Arbitrary JSON blob.
+   * @returns {Promise<object|null>} The created detour row, or null if the trip
+   *   was not found / not owned by the user.
+   */
+  async createDetour({
+    tripId,
+    userId,
+    placeName,
+    latitude,
+    longitude,
+    placeId = null,
+    placeType = null,
+    address = null,
+    positionOnRoute = null,
+    estimatedDetourDurationSeconds = null,
+    estimatedDetourDistanceMeters = null,
+    rating = null,
+    priceLevel = null,
+    stopDurationMinutes = 30,
+    visitTime = null,
+    notes = null,
+    metadata = {},
+  }) {
+    // INSERT ... SELECT ... WHERE EXISTS enforces trip ownership atomically:
+    // no row is inserted unless the parent trip belongs to the user.
+    const text = `
+      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude,
+                           longitude, address, position_on_route,
+                           estimated_detour_duration_seconds,
+                           estimated_detour_distance_meters, rating, price_level,
+                           stop_duration_minutes, visit_time, notes, metadata)
+      SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+      WHERE EXISTS (
+        SELECT 1 FROM trips WHERE trip_id = $1 AND user_id = $17
+      )
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+    const params = [
+      tripId,
+      placeId,
+      placeName,
+      placeType,
+      latitude,
+      longitude,
+      address,
+      positionOnRoute,
+      estimatedDetourDurationSeconds,
+      estimatedDetourDistanceMeters,
+      rating,
+      priceLevel,
+      stopDurationMinutes,
+      visitTime,
+      notes,
+      metadata,
+      userId,
+    ];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("createDetour failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a single detour, scoped to the owning user via its parent trip.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The detour row, or null if not found / not owned.
+   */
+  async getDetourById(detourId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS_PREFIXED}
+      FROM detours d
+      JOIN trips t ON d.trip_id = t.trip_id
+      WHERE d.detour_id = $1 AND t.user_id = $2
+    `;
+    try {
+      const result = await this.pool.query(text, [detourId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getDetourById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * List all detours on a trip, ordered by position along the route. Scoped to
+   * the owning user via the parent trip, so passing a trip the user does not own
+   * returns an empty array.
+   *
+   * @param {string} tripId - Parent trip UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object[]>} Array of detour rows (empty if none / not owned).
+   */
+  async getDetoursByTripId(tripId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS_PREFIXED}
+      FROM detours d
+      JOIN trips t ON d.trip_id = t.trip_id
+      WHERE d.trip_id = $1 AND t.user_id = $2
+      ORDER BY d.position_on_route ASC NULLS LAST
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows;
+    } catch (err) {
+      logger.error("getDetoursByTripId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a detour's columns. `updated_at` is maintained
+   * by a database trigger. Scoped by user_id via the parent trip so a user
+   * cannot modify detours on another user's trips.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} fields - Any of the updatable detour columns.
+   * @returns {Promise<object|null>} The updated detour row, or null if not found / not owned.
+   * @throws {Error} If no valid fields are supplied.
+   */
+  async updateDetour(detourId, userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateDetour requires at least one updatable field");
+    }
+
+    params.push(detourId);
+    const detourPosition = position;
+    position += 1;
+    params.push(userId);
+    const text = `
+      UPDATE detours
+      SET ${setClauses.join(", ")}
+      WHERE detour_id = $${detourPosition}
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $${position})
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("updateDetour failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a detour. Scoped by user_id via the parent trip.
+   *
+   * @param {string} detourId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The deleted detour's id, or null if not found / not owned.
+   */
+  async deleteDetour(detourId, userId) {
+    const text = `
+      DELETE FROM detours
+      WHERE detour_id = $1
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)
+      RETURNING detour_id
+    `;
+    try {
+      const result = await this.pool.query(text, [detourId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteDetour failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = DetourRepository;

--- a/backend/app/repositories/DetourRepository.js
+++ b/backend/app/repositories/DetourRepository.js
@@ -265,6 +265,31 @@ class DetourRepository {
       throw err;
     }
   }
+
+  /**
+   * Delete every detour on a trip. Used by "update trip" to replace the trip's
+   * detours wholesale (delete-all then re-insert) inside a transaction. Scoped
+   * by user_id via the parent trip, so a user cannot clear detours on a trip
+   * they do not own (the subquery matches no trip and nothing is deleted).
+   *
+   * @param {string} tripId - Parent trip UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<number>} The number of detours deleted.
+   */
+  async deleteByTripId(tripId, userId) {
+    const text = `
+      DELETE FROM detours
+      WHERE trip_id = $1
+        AND trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rowCount;
+    } catch (err) {
+      logger.error("deleteByTripId failed", err);
+      throw err;
+    }
+  }
 }
 
 module.exports = DetourRepository;

--- a/backend/app/repositories/DetourRepository.test.js
+++ b/backend/app/repositories/DetourRepository.test.js
@@ -292,4 +292,33 @@ describe("DetourRepository", () => {
       );
     });
   });
+
+  describe("deleteByTripId", () => {
+    it("deletes all detours on a trip, scoped via the parent trip", async () => {
+      pool.query.mockResolvedValue({ rowCount: 3 });
+
+      const result = await repo.deleteByTripId(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM detours");
+      expect(sql).toContain("WHERE trip_id = $1");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)"
+      );
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(3);
+    });
+
+    it("returns 0 when the trip has no detours or is not owned", async () => {
+      pool.query.mockResolvedValue({ rowCount: 0 });
+      expect(await repo.deleteByTripId(TRIP_ID, "not-the-owner")).toBe(0);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteByTripId(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
 });

--- a/backend/app/repositories/DetourRepository.test.js
+++ b/backend/app/repositories/DetourRepository.test.js
@@ -1,0 +1,295 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const DetourRepository = require("./DetourRepository");
+
+describe("DetourRepository", () => {
+  let pool;
+  let repo;
+
+  const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const TRIP_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  const DETOUR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new DetourRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new DetourRepository()).toThrow(
+        "DetourRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new DetourRepository({})).toThrow(
+        "DetourRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createDetour", () => {
+    it("inserts only when the parent trip is owned, with parameterized values", async () => {
+      const newDetour = { detour_id: DETOUR_ID, trip_id: TRIP_ID };
+      pool.query.mockResolvedValue({ rows: [newDetour] });
+
+      const result = await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: USER_ID,
+        placeName: "Yosemite Falls",
+        latitude: 37.7455,
+        longitude: -119.5967,
+        placeId: "gp1",
+        placeType: "park",
+        address: "Yosemite Valley, CA",
+        positionOnRoute: 0.85,
+        estimatedDetourDurationSeconds: 300,
+        estimatedDetourDistanceMeters: 500,
+        rating: 4.8,
+        priceLevel: 2,
+        stopDurationMinutes: 120,
+        visitTime: "2026-07-04T12:00:00Z",
+        notes: "Bring water",
+        metadata: { source: "test" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO detours");
+      // Ownership enforced atomically via EXISTS against trips.
+      expect(sql).toContain("WHERE EXISTS");
+      expect(sql).toContain("FROM trips WHERE trip_id = $1 AND user_id = $17");
+      expect(params).toEqual([
+        TRIP_ID,
+        "gp1",
+        "Yosemite Falls",
+        "park",
+        37.7455,
+        -119.5967,
+        "Yosemite Valley, CA",
+        0.85,
+        300,
+        500,
+        4.8,
+        2,
+        120,
+        "2026-07-04T12:00:00Z",
+        "Bring water",
+        { source: "test" },
+        USER_ID,
+      ]);
+      expect(result).toBe(newDetour);
+    });
+
+    it("applies defaults for optional fields", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: USER_ID,
+        placeName: "Rest Stop",
+        latitude: 40,
+        longitude: -100,
+      });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual([
+        TRIP_ID,
+        null, // placeId
+        "Rest Stop",
+        null, // placeType
+        40,
+        -100,
+        null, // address
+        null, // positionOnRoute
+        null, // estimatedDetourDurationSeconds
+        null, // estimatedDetourDistanceMeters
+        null, // rating
+        null, // priceLevel
+        30, // stopDurationMinutes default
+        null, // visitTime
+        null, // notes
+        {}, // metadata default
+        USER_ID,
+      ]);
+    });
+
+    it("returns null when the trip is not found or not owned", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await repo.createDetour({
+        tripId: TRIP_ID,
+        userId: "not-the-owner",
+        placeName: "X",
+        latitude: 1,
+        longitude: 2,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createDetour({
+          tripId: TRIP_ID,
+          userId: USER_ID,
+          placeName: "X",
+          latitude: 1,
+          longitude: 2,
+        })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getDetourById", () => {
+    it("joins trips and scopes by detour_id and user_id", async () => {
+      const detour = { detour_id: DETOUR_ID };
+      pool.query.mockResolvedValue({ rows: [detour] });
+
+      const result = await repo.getDetourById(DETOUR_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("JOIN trips t ON d.trip_id = t.trip_id");
+      expect(sql).toContain("WHERE d.detour_id = $1 AND t.user_id = $2");
+      expect(params).toEqual([DETOUR_ID, USER_ID]);
+      expect(result).toBe(detour);
+    });
+
+    it("returns null when no detour is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getDetourById("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getDetourById(DETOUR_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("getDetoursByTripId", () => {
+    it("joins trips, scopes by trip_id and user_id, ordered by position", async () => {
+      const detours = [{ detour_id: DETOUR_ID }];
+      pool.query.mockResolvedValue({ rows: detours });
+
+      const result = await repo.getDetoursByTripId(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("JOIN trips t ON d.trip_id = t.trip_id");
+      expect(sql).toContain("WHERE d.trip_id = $1 AND t.user_id = $2");
+      expect(sql).toContain("ORDER BY d.position_on_route ASC NULLS LAST");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(detours);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getDetoursByTripId(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("updateDetour", () => {
+    it("builds a dynamic SET clause scoped via the parent trip", async () => {
+      const updated = { detour_id: DETOUR_ID, notes: "Updated" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "Updated",
+        stopDurationMinutes: 45,
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("UPDATE detours");
+      // SET columns follow the allow-list declaration order, not input order:
+      // stopDurationMinutes precedes notes in UPDATABLE_COLUMNS.
+      expect(sql).toContain("stop_duration_minutes = $1");
+      expect(sql).toContain("notes = $2");
+      expect(sql).toContain("WHERE detour_id = $3");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $4)"
+      );
+      expect(params).toEqual([45, "Updated", DETOUR_ID, USER_ID]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores fields that are not in the allow-list", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "OK",
+        detour_id: "hacked",
+        trip_id: "hacked",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("notes = $1");
+      expect(params).toEqual(["OK", DETOUR_ID, USER_ID]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateDetour(DETOUR_ID, USER_ID, {})).rejects.toThrow(
+        "updateDetour requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no detour is updated", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      const result = await repo.updateDetour(DETOUR_ID, USER_ID, {
+        notes: "X",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(
+        repo.updateDetour(DETOUR_ID, USER_ID, { notes: "X" })
+      ).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("deleteDetour", () => {
+    it("deletes a detour scoped via the parent trip", async () => {
+      pool.query.mockResolvedValue({ rows: [{ detour_id: DETOUR_ID }] });
+
+      const result = await repo.deleteDetour(DETOUR_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM detours");
+      expect(sql).toContain("WHERE detour_id = $1");
+      expect(sql).toContain(
+        "trip_id IN (SELECT trip_id FROM trips WHERE user_id = $2)"
+      );
+      expect(params).toEqual([DETOUR_ID, USER_ID]);
+      expect(result).toEqual({ detour_id: DETOUR_ID });
+    });
+
+    it("returns null when no detour is deleted", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteDetour("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteDetour(DETOUR_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+});

--- a/backend/app/repositories/TripRepository.js
+++ b/backend/app/repositories/TripRepository.js
@@ -1,0 +1,240 @@
+/**
+ * TripRepository — data access layer for the `trips` table.
+ *
+ * Encapsulates all SQL for trip records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * Every operation is scoped by `user_id` — the authorization boundary. A user
+ * can only read or modify their own trips. All queries use parameterized
+ * placeholders ($1, $2, ...) — prepared statements that prevent SQL injection.
+ */
+
+const logger = require("../utils/logger");
+
+// PostgreSQL error code for a foreign-key-constraint violation.
+const PG_FK_VIOLATION = "23503";
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  tripName: "trip_name",
+  origin: "origin",
+  destination: "destination",
+  routePolyline: "route_polyline",
+  distanceMeters: "distance_meters",
+  durationSeconds: "duration_seconds",
+  departureTime: "departure_time",
+  status: "status",
+  metadata: "metadata",
+};
+
+// Columns returned to callers. Shared by every query that returns a full row.
+const RETURNING_COLUMNS = `
+      trip_id, user_id, trip_name, origin, destination, route_polyline,
+      distance_meters, duration_seconds, departure_time, status,
+      created_at, updated_at, metadata
+`;
+
+class TripRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "TripRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a new trip for a user.
+   *
+   * @param {object} trip
+   * @param {string} trip.userId - Owning user's UUID.
+   * @param {string} trip.tripName - Human-readable trip name.
+   * @param {object} trip.origin - JSON { lat, lng, address }.
+   * @param {object} trip.destination - JSON { lat, lng, address }.
+   * @param {string} [trip.routePolyline] - Google encoded polyline.
+   * @param {number} [trip.distanceMeters] - Cached distance.
+   * @param {number} [trip.durationSeconds] - Cached duration.
+   * @param {string|Date} [trip.departureTime] - Planned departure.
+   * @param {string} [trip.status] - One of planned|active|completed|cancelled.
+   * @param {object} [trip.metadata] - Arbitrary JSON blob.
+   * @returns {Promise<object>} The created trip row.
+   * @throws {Error} `INVALID_USER` if the user_id does not reference a user.
+   */
+  async createTrip({
+    userId,
+    tripName,
+    origin,
+    destination,
+    routePolyline = null,
+    distanceMeters = null,
+    durationSeconds = null,
+    departureTime = null,
+    status = "planned",
+    metadata = {},
+  }) {
+    const text = `
+      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline,
+                         distance_meters, duration_seconds, departure_time, status, metadata)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+    const params = [
+      userId,
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      departureTime,
+      status,
+      metadata,
+    ];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0];
+    } catch (err) {
+      if (err.code === PG_FK_VIOLATION) {
+        logger.warn(`createTrip: invalid user_id (${err.constraint || "fk"})`);
+        const fkErr = new Error("The specified user does not exist");
+        fkErr.code = "INVALID_USER";
+        throw fkErr;
+      }
+      logger.error("createTrip failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a single trip owned by the given user.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The trip row, or null if not found / not owned.
+   */
+  async getTripById(tripId, userId) {
+    const text = `
+      SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE trip_id = $1 AND user_id = $2
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getTripById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * List a user's trips, newest first. Optionally filter by status.
+   *
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} [options]
+   * @param {string} [options.status] - Filter to a single status value.
+   * @returns {Promise<object[]>} Array of trip rows (empty if none).
+   */
+  async getTripsByUserId(userId, { status } = {}) {
+    const params = [userId];
+    let text = `
+      SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE user_id = $1
+    `;
+    if (status !== undefined) {
+      params.push(status);
+      text += ` AND status = $2`;
+    }
+    text += ` ORDER BY created_at DESC`;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows;
+    } catch (err) {
+      logger.error("getTripsByUserId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a trip's columns. `updated_at` is maintained by
+   * a database trigger. Scoped by user_id so a user cannot modify another user's
+   * trips.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} fields - Any of the updatable trip columns.
+   * @returns {Promise<object|null>} The updated trip row, or null if not found / not owned.
+   * @throws {Error} If no valid fields are supplied.
+   */
+  async updateTrip(tripId, userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateTrip requires at least one updatable field");
+    }
+
+    params.push(tripId);
+    const tripPosition = position;
+    position += 1;
+    params.push(userId);
+    const text = `
+      UPDATE trips
+      SET ${setClauses.join(", ")}
+      WHERE trip_id = $${tripPosition} AND user_id = $${position}
+      RETURNING ${RETURNING_COLUMNS}
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("updateTrip failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a trip. Cascades to the trip's detours via
+   * ON DELETE CASCADE. Scoped by user_id. To "cancel" a trip without deleting
+   * it, use updateTrip with status = 'cancelled'.
+   *
+   * @param {string} tripId - UUID.
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @returns {Promise<object|null>} The deleted trip's id, or null if not found / not owned.
+   */
+  async deleteTrip(tripId, userId) {
+    const text = `
+      DELETE FROM trips
+      WHERE trip_id = $1 AND user_id = $2
+      RETURNING trip_id
+    `;
+    try {
+      const result = await this.pool.query(text, [tripId, userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteTrip failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = TripRepository;

--- a/backend/app/repositories/TripRepository.js
+++ b/backend/app/repositories/TripRepository.js
@@ -135,17 +135,62 @@ class TripRepository {
   }
 
   /**
-   * List a user's trips, newest first. Optionally filter by status.
+   * List a user's trips, newest first. Optionally filter by status and
+   * paginate with limit/offset.
    *
    * @param {string} userId - Owning user's UUID (authorization scope).
    * @param {object} [options]
    * @param {string} [options.status] - Filter to a single status value.
+   * @param {number} [options.limit] - Max rows to return (pagination).
+   * @param {number} [options.offset] - Rows to skip (pagination).
    * @returns {Promise<object[]>} Array of trip rows (empty if none).
    */
-  async getTripsByUserId(userId, { status } = {}) {
+  async getTripsByUserId(userId, { status, limit, offset } = {}) {
     const params = [userId];
+    let position = 1;
     let text = `
       SELECT ${RETURNING_COLUMNS}
+      FROM trips
+      WHERE user_id = $1
+    `;
+    if (status !== undefined) {
+      position += 1;
+      params.push(status);
+      text += ` AND status = $${position}`;
+    }
+    text += ` ORDER BY created_at DESC`;
+    if (limit !== undefined) {
+      position += 1;
+      params.push(limit);
+      text += ` LIMIT $${position}`;
+    }
+    if (offset !== undefined) {
+      position += 1;
+      params.push(offset);
+      text += ` OFFSET $${position}`;
+    }
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows;
+    } catch (err) {
+      logger.error("getTripsByUserId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Count a user's trips (for pagination). Optionally filter by status.
+   *
+   * @param {string} userId - Owning user's UUID (authorization scope).
+   * @param {object} [options]
+   * @param {string} [options.status] - Filter to a single status value.
+   * @returns {Promise<number>} Total matching trips.
+   */
+  async countTripsByUserId(userId, { status } = {}) {
+    const params = [userId];
+    let text = `
+      SELECT COUNT(*)::int AS total
       FROM trips
       WHERE user_id = $1
     `;
@@ -153,13 +198,12 @@ class TripRepository {
       params.push(status);
       text += ` AND status = $2`;
     }
-    text += ` ORDER BY created_at DESC`;
 
     try {
       const result = await this.pool.query(text, params);
-      return result.rows;
+      return result.rows[0].total;
     } catch (err) {
-      logger.error("getTripsByUserId failed", err);
+      logger.error("countTripsByUserId failed", err);
       throw err;
     }
   }

--- a/backend/app/repositories/TripRepository.test.js
+++ b/backend/app/repositories/TripRepository.test.js
@@ -1,0 +1,273 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const TripRepository = require("./TripRepository");
+
+describe("TripRepository", () => {
+  let pool;
+  let repo;
+
+  const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const TRIP_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new TripRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new TripRepository()).toThrow(
+        "TripRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new TripRepository({})).toThrow(
+        "TripRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createTrip", () => {
+    it("inserts a trip with parameterized values and returns the row", async () => {
+      const newTrip = { trip_id: TRIP_ID, user_id: USER_ID };
+      pool.query.mockResolvedValue({ rows: [newTrip] });
+
+      const origin = { lat: 1, lng: 2, address: "A" };
+      const destination = { lat: 3, lng: 4, address: "B" };
+      const result = await repo.createTrip({
+        userId: USER_ID,
+        tripName: "Road Trip",
+        origin,
+        destination,
+        routePolyline: "poly",
+        distanceMeters: 1000,
+        durationSeconds: 600,
+        departureTime: "2026-07-04T00:00:00Z",
+        status: "active",
+        metadata: { source: "test" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO trips");
+      expect(sql).toContain("$1, $2, $3, $4, $5, $6, $7, $8, $9, $10");
+      expect(params).toEqual([
+        USER_ID,
+        "Road Trip",
+        origin,
+        destination,
+        "poly",
+        1000,
+        600,
+        "2026-07-04T00:00:00Z",
+        "active",
+        { source: "test" },
+      ]);
+      expect(result).toBe(newTrip);
+    });
+
+    it("applies defaults for optional fields", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      await repo.createTrip({
+        userId: USER_ID,
+        tripName: "Minimal",
+        origin: { lat: 1, lng: 2 },
+        destination: { lat: 3, lng: 4 },
+      });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual([
+        USER_ID,
+        "Minimal",
+        { lat: 1, lng: 2 },
+        { lat: 3, lng: 4 },
+        null,
+        null,
+        null,
+        null,
+        "planned",
+        {},
+      ]);
+    });
+
+    it("maps a foreign-key violation to an INVALID_USER error", async () => {
+      const pgError = new Error("insert or update violates foreign key");
+      pgError.code = "23503";
+      pgError.constraint = "trips_user_id_fkey";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.createTrip({
+          userId: "missing",
+          tripName: "X",
+          origin: {},
+          destination: {},
+        })
+      ).rejects.toMatchObject({ code: "INVALID_USER" });
+    });
+
+    it("rethrows non-foreign-key database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createTrip({
+          userId: USER_ID,
+          tripName: "X",
+          origin: {},
+          destination: {},
+        })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getTripById", () => {
+    it("selects a trip scoped by trip_id and user_id", async () => {
+      const trip = { trip_id: TRIP_ID, user_id: USER_ID };
+      pool.query.mockResolvedValue({ rows: [trip] });
+
+      const result = await repo.getTripById(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE trip_id = $1 AND user_id = $2");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toBe(trip);
+    });
+
+    it("returns null when no trip is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getTripById("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getTripById(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+
+  describe("getTripsByUserId", () => {
+    it("selects all of a user's trips newest first", async () => {
+      const trips = [{ trip_id: TRIP_ID }];
+      pool.query.mockResolvedValue({ rows: trips });
+
+      const result = await repo.getTripsByUserId(USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(sql).toContain("ORDER BY created_at DESC");
+      expect(sql).not.toContain("status = $2");
+      expect(params).toEqual([USER_ID]);
+      expect(result).toBe(trips);
+    });
+
+    it("adds a status filter when provided", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, { status: "completed" });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(params).toEqual([USER_ID, "completed"]);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getTripsByUserId(USER_ID)).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("updateTrip", () => {
+    it("builds a dynamic SET clause scoped by trip_id and user_id", async () => {
+      const updated = { trip_id: TRIP_ID, trip_name: "Renamed" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "Renamed",
+        status: "completed",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("UPDATE trips");
+      expect(sql).toContain("trip_name = $1");
+      expect(sql).toContain("status = $2");
+      expect(sql).toContain("WHERE trip_id = $3 AND user_id = $4");
+      expect(params).toEqual(["Renamed", "completed", TRIP_ID, USER_ID]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores fields that are not in the allow-list", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "OK",
+        trip_id: "hacked",
+        userId: "hacked",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("trip_name = $1");
+      // Only the allow-listed field, plus the trip_id and user_id scope.
+      expect(params).toEqual(["OK", TRIP_ID, USER_ID]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateTrip(TRIP_ID, USER_ID, {})).rejects.toThrow(
+        "updateTrip requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no trip is updated", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      const result = await repo.updateTrip(TRIP_ID, USER_ID, {
+        tripName: "X",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(
+        repo.updateTrip(TRIP_ID, USER_ID, { tripName: "X" })
+      ).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("deleteTrip", () => {
+    it("deletes a trip scoped by trip_id and user_id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ trip_id: TRIP_ID }] });
+
+      const result = await repo.deleteTrip(TRIP_ID, USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM trips");
+      expect(sql).toContain("WHERE trip_id = $1 AND user_id = $2");
+      expect(params).toEqual([TRIP_ID, USER_ID]);
+      expect(result).toEqual({ trip_id: TRIP_ID });
+    });
+
+    it("returns null when no trip is deleted", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteTrip("missing", USER_ID)).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.deleteTrip(TRIP_ID, USER_ID)).rejects.toThrow(
+        "DB down"
+      );
+    });
+  });
+});

--- a/backend/app/repositories/TripRepository.test.js
+++ b/backend/app/repositories/TripRepository.test.js
@@ -182,9 +182,69 @@ describe("TripRepository", () => {
       expect(params).toEqual([USER_ID, "completed"]);
     });
 
+    it("appends LIMIT and OFFSET when paginating", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, { limit: 10, offset: 20 });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("LIMIT $2");
+      expect(sql).toContain("OFFSET $3");
+      expect(params).toEqual([USER_ID, 10, 20]);
+    });
+
+    it("numbers pagination placeholders after a status filter", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await repo.getTripsByUserId(USER_ID, {
+        status: "planned",
+        limit: 5,
+        offset: 5,
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(sql).toContain("LIMIT $3");
+      expect(sql).toContain("OFFSET $4");
+      expect(params).toEqual([USER_ID, "planned", 5, 5]);
+    });
+
     it("rethrows database errors", async () => {
       pool.query.mockRejectedValue(new Error("DB down"));
       await expect(repo.getTripsByUserId(USER_ID)).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("countTripsByUserId", () => {
+    it("counts a user's trips scoped by user id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ total: 7 }] });
+
+      const result = await repo.countTripsByUserId(USER_ID);
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("SELECT COUNT(*)::int AS total");
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(sql).not.toContain("status = $2");
+      expect(params).toEqual([USER_ID]);
+      expect(result).toBe(7);
+    });
+
+    it("adds a status filter when provided", async () => {
+      pool.query.mockResolvedValue({ rows: [{ total: 2 }] });
+
+      const result = await repo.countTripsByUserId(USER_ID, {
+        status: "completed",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("AND status = $2");
+      expect(params).toEqual([USER_ID, "completed"]);
+      expect(result).toBe(2);
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.countTripsByUserId(USER_ID)).rejects.toThrow("DB down");
     });
   });
 

--- a/backend/app/repositories/UserRepository.js
+++ b/backend/app/repositories/UserRepository.js
@@ -1,0 +1,248 @@
+/**
+ * UserRepository — data access layer for the `users` table.
+ *
+ * Encapsulates all SQL for user records so business logic never touches the
+ * database directly. The pool is injected via the constructor, which keeps the
+ * class easy to unit test (pass a mock pool) and lets callers supply a different
+ * pool per environment.
+ *
+ * All queries use parameterized placeholders ($1, $2, ...) — prepared statements
+ * that prevent SQL injection. There is no password column; identity is keyed off
+ * the Entra `external_id` (the token `sub` claim). See
+ * ../../../docs/authentication/authentication.md.
+ */
+
+const logger = require("../utils/logger");
+
+// PostgreSQL error code for a unique-constraint violation.
+const PG_UNIQUE_VIOLATION = "23505";
+
+// Columns a client is allowed to update, mapped to their DB column names.
+const UPDATABLE_COLUMNS = {
+  email: "email",
+  displayName: "display_name",
+  preferences: "preferences",
+  isActive: "is_active",
+  lastLogin: "last_login",
+};
+
+class UserRepository {
+  /**
+   * @param {{ query: Function }} pool - A pg Pool (or compatible) with a `query` method.
+   */
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error(
+        "UserRepository requires a database pool with a query method"
+      );
+    }
+    this.pool = pool;
+  }
+
+  /**
+   * Create a new user.
+   *
+   * @param {object} user
+   * @param {string} user.externalId - Entra `sub` claim (unique).
+   * @param {string} user.email - User email (unique).
+   * @param {string} [user.displayName] - Display name.
+   * @param {object} [user.preferences] - JSON preferences blob.
+   * @returns {Promise<object>} The created user row.
+   * @throws {Error} `DUPLICATE_USER` if external_id or email already exists.
+   */
+  async createUser({
+    externalId,
+    email,
+    displayName = null,
+    preferences = {},
+  }) {
+    const text = `
+      INSERT INTO users (external_id, email, display_name, preferences)
+      VALUES ($1, $2, $3, $4)
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
+    `;
+    const params = [externalId, email, displayName, preferences];
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0];
+    } catch (err) {
+      if (err.code === PG_UNIQUE_VIOLATION) {
+        logger.warn(
+          `createUser: duplicate user (${err.constraint || "unique"})`
+        );
+        const dupErr = new Error(
+          "A user with that email or external ID already exists"
+        );
+        dupErr.code = "DUPLICATE_USER";
+        throw dupErr;
+      }
+      logger.error("createUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch an active user by primary key.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserById(userId) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE user_id = $1 AND is_active = true
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserById failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch an active user by email.
+   *
+   * @param {string} email
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserByEmail(email) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE email = $1 AND is_active = true
+    `;
+    try {
+      const result = await this.pool.query(text, [email]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserByEmail failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch a user by Entra external ID (the token `sub` claim).
+   *
+   * @param {string} externalId
+   * @returns {Promise<object|null>} The user row, or null if not found.
+   */
+  async getUserByExternalId(externalId) {
+    const text = `
+      SELECT user_id, external_id, email, display_name, preferences,
+             is_active, created_at, updated_at, last_login
+      FROM users
+      WHERE external_id = $1
+    `;
+    try {
+      const result = await this.pool.query(text, [externalId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("getUserByExternalId failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Update an allowed subset of a user's columns. `updated_at` is maintained by
+   * a database trigger.
+   *
+   * @param {string} userId - UUID.
+   * @param {object} fields - Any of: email, displayName, preferences, isActive, lastLogin.
+   * @returns {Promise<object|null>} The updated user row, or null if not found.
+   * @throws {Error} If no valid fields are supplied, or `DUPLICATE_USER` on email clash.
+   */
+  async updateUser(userId, fields = {}) {
+    const setClauses = [];
+    const params = [];
+    let position = 1;
+
+    for (const [key, column] of Object.entries(UPDATABLE_COLUMNS)) {
+      if (Object.prototype.hasOwnProperty.call(fields, key)) {
+        setClauses.push(`${column} = $${position}`);
+        params.push(fields[key]);
+        position += 1;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      throw new Error("updateUser requires at least one updatable field");
+    }
+
+    params.push(userId);
+    const text = `
+      UPDATE users
+      SET ${setClauses.join(", ")}
+      WHERE user_id = $${position} AND is_active = true
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
+    `;
+
+    try {
+      const result = await this.pool.query(text, params);
+      return result.rows[0] || null;
+    } catch (err) {
+      if (err.code === PG_UNIQUE_VIOLATION) {
+        logger.warn("updateUser: duplicate email");
+        const dupErr = new Error("A user with that email already exists");
+        dupErr.code = "DUPLICATE_USER";
+        throw dupErr;
+      }
+      logger.error("updateUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Soft-delete a user by marking the account inactive. Preserves the row (and
+   * its trips/detours) for audit and potential reactivation.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The deactivated user row, or null if not found.
+   */
+  async deleteUser(userId) {
+    const text = `
+      UPDATE users
+      SET is_active = false
+      WHERE user_id = $1 AND is_active = true
+      RETURNING user_id, external_id, email, is_active
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("deleteUser failed", err);
+      throw err;
+    }
+  }
+
+  /**
+   * Permanently delete a user row. Cascades to the user's trips and detours via
+   * ON DELETE CASCADE. Use for GDPR account erasure, not routine deletes.
+   *
+   * @param {string} userId - UUID.
+   * @returns {Promise<object|null>} The deleted user's id, or null if not found.
+   */
+  async hardDeleteUser(userId) {
+    const text = `
+      DELETE FROM users
+      WHERE user_id = $1
+      RETURNING user_id
+    `;
+    try {
+      const result = await this.pool.query(text, [userId]);
+      return result.rows[0] || null;
+    } catch (err) {
+      logger.error("hardDeleteUser failed", err);
+      throw err;
+    }
+  }
+}
+
+module.exports = UserRepository;

--- a/backend/app/repositories/UserRepository.js
+++ b/backend/app/repositories/UserRepository.js
@@ -150,6 +150,39 @@ class UserRepository {
   }
 
   /**
+   * Create the user if they do not yet exist, otherwise refresh their profile
+   * and login timestamp. Called on every successful sign-in: the Entra
+   * `external_id` (token `sub`) is the identity key. First login creates the
+   * row; subsequent logins update email/display name (in case they changed at
+   * the IdP) and stamp `last_login`.
+   *
+   * @param {object} identity
+   * @param {string} identity.externalId - Entra `sub` claim (unique).
+   * @param {string} identity.email - User email from the ID token.
+   * @param {string} [identity.displayName] - Display name from the ID token.
+   * @returns {Promise<object>} The created or updated user row.
+   */
+  async upsertByExternalId({ externalId, email, displayName = null }) {
+    const existing = await this.getUserByExternalId(externalId);
+
+    if (existing) {
+      // Always stamp the login time, but only refresh profile fields the IdP
+      // actually provided — otherwise a missing claim would overwrite existing
+      // non-null data with null.
+      const updates = { lastLogin: new Date() };
+      if (email != null) {
+        updates.email = email;
+      }
+      if (displayName != null) {
+        updates.displayName = displayName;
+      }
+      return this.updateUser(existing.user_id, updates);
+    }
+
+    return this.createUser({ externalId, email, displayName });
+  }
+
+  /**
    * Update an allowed subset of a user's columns. `updated_at` is maintained by
    * a database trigger.
    *

--- a/backend/app/repositories/UserRepository.test.js
+++ b/backend/app/repositories/UserRepository.test.js
@@ -1,0 +1,262 @@
+// Mock the logger so tests don't produce noisy output.
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const UserRepository = require("./UserRepository");
+
+describe("UserRepository", () => {
+  let pool;
+  let repo;
+
+  beforeEach(() => {
+    pool = { query: jest.fn() };
+    repo = new UserRepository(pool);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws when no pool is provided", () => {
+      expect(() => new UserRepository()).toThrow(
+        "UserRepository requires a database pool with a query method"
+      );
+    });
+
+    it("throws when the pool has no query method", () => {
+      expect(() => new UserRepository({})).toThrow(
+        "UserRepository requires a database pool with a query method"
+      );
+    });
+  });
+
+  describe("createUser", () => {
+    it("inserts a user with parameterized values and returns the row", async () => {
+      const newUser = {
+        user_id: "11111111-1111-1111-1111-111111111111",
+        external_id: "entra-sub-1",
+        email: "alice@example.com",
+        display_name: "Alice",
+        preferences: {},
+      };
+      pool.query.mockResolvedValue({ rows: [newUser] });
+
+      const result = await repo.createUser({
+        externalId: "entra-sub-1",
+        email: "alice@example.com",
+        displayName: "Alice",
+        preferences: { theme: "dark" },
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO users");
+      expect(sql).toContain("$1, $2, $3, $4");
+      expect(params).toEqual([
+        "entra-sub-1",
+        "alice@example.com",
+        "Alice",
+        { theme: "dark" },
+      ]);
+      expect(result).toBe(newUser);
+    });
+
+    it("defaults displayName to null and preferences to an empty object", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      await repo.createUser({ externalId: "x", email: "b@example.com" });
+
+      const [, params] = pool.query.mock.calls[0];
+      expect(params).toEqual(["x", "b@example.com", null, {}]);
+    });
+
+    it("maps a unique-violation to a DUPLICATE_USER error", async () => {
+      const pgError = new Error("duplicate key value");
+      pgError.code = "23505";
+      pgError.constraint = "users_email_key";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.createUser({ externalId: "x", email: "dup@example.com" })
+      ).rejects.toMatchObject({ code: "DUPLICATE_USER" });
+    });
+
+    it("rethrows non-unique database errors", async () => {
+      pool.query.mockRejectedValue(new Error("connection terminated"));
+
+      await expect(
+        repo.createUser({ externalId: "x", email: "c@example.com" })
+      ).rejects.toThrow("connection terminated");
+    });
+  });
+
+  describe("getUserById", () => {
+    it("selects an active user by id and returns the row", async () => {
+      const user = { user_id: "u1", email: "a@example.com" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserById("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE user_id = $1 AND is_active = true");
+      expect(params).toEqual(["u1"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserById("missing")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB down"));
+      await expect(repo.getUserById("u1")).rejects.toThrow("DB down");
+    });
+  });
+
+  describe("getUserByEmail", () => {
+    it("selects an active user by email", async () => {
+      const user = { user_id: "u1", email: "a@example.com" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserByEmail("a@example.com");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE email = $1 AND is_active = true");
+      expect(params).toEqual(["a@example.com"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserByEmail("nope@example.com")).toBeNull();
+    });
+  });
+
+  describe("getUserByExternalId", () => {
+    it("selects a user by external_id (no active filter)", async () => {
+      const user = { user_id: "u1", external_id: "entra-sub-1" };
+      pool.query.mockResolvedValue({ rows: [user] });
+
+      const result = await repo.getUserByExternalId("entra-sub-1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("WHERE external_id = $1");
+      expect(params).toEqual(["entra-sub-1"]);
+      expect(result).toBe(user);
+    });
+
+    it("returns null when no user is found", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.getUserByExternalId("missing")).toBeNull();
+    });
+  });
+
+  describe("updateUser", () => {
+    it("builds a parameterized SET clause for provided fields only", async () => {
+      const updated = { user_id: "u1", display_name: "New Name" };
+      pool.query.mockResolvedValue({ rows: [updated] });
+
+      const result = await repo.updateUser("u1", {
+        displayName: "New Name",
+        preferences: { theme: "light" },
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("display_name = $1");
+      expect(sql).toContain("preferences = $2");
+      expect(sql).toContain("WHERE user_id = $3 AND is_active = true");
+      expect(params).toEqual(["New Name", { theme: "light" }, "u1"]);
+      expect(result).toBe(updated);
+    });
+
+    it("ignores unknown fields and only updates allowed columns", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      await repo.updateUser("u1", {
+        email: "new@example.com",
+        hacker: "DROP TABLE",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("email = $1");
+      expect(sql).not.toContain("hacker");
+      expect(params).toEqual(["new@example.com", "u1"]);
+    });
+
+    it("throws when no updatable fields are supplied", async () => {
+      await expect(repo.updateUser("u1", {})).rejects.toThrow(
+        "updateUser requires at least one updatable field"
+      );
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the user does not exist", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.updateUser("missing", { displayName: "X" })).toBeNull();
+    });
+
+    it("maps a unique-violation to a DUPLICATE_USER error", async () => {
+      const pgError = new Error("duplicate key value");
+      pgError.code = "23505";
+      pool.query.mockRejectedValue(pgError);
+
+      await expect(
+        repo.updateUser("u1", { email: "taken@example.com" })
+      ).rejects.toMatchObject({ code: "DUPLICATE_USER" });
+    });
+  });
+
+  describe("deleteUser (soft delete)", () => {
+    it("sets is_active = false and returns the row", async () => {
+      const row = { user_id: "u1", is_active: false };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await repo.deleteUser("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("SET is_active = false");
+      expect(sql).toContain("WHERE user_id = $1 AND is_active = true");
+      expect(params).toEqual(["u1"]);
+      expect(result).toBe(row);
+    });
+
+    it("returns null when the user is already inactive or missing", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.deleteUser("u1")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("DB error"));
+      await expect(repo.deleteUser("u1")).rejects.toThrow("DB error");
+    });
+  });
+
+  describe("hardDeleteUser", () => {
+    it("deletes the row and returns its id", async () => {
+      pool.query.mockResolvedValue({ rows: [{ user_id: "u1" }] });
+
+      const result = await repo.hardDeleteUser("u1");
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("DELETE FROM users");
+      expect(sql).toContain("WHERE user_id = $1");
+      expect(params).toEqual(["u1"]);
+      expect(result).toEqual({ user_id: "u1" });
+    });
+
+    it("returns null when the user does not exist", async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await repo.hardDeleteUser("missing")).toBeNull();
+    });
+
+    it("rethrows database errors", async () => {
+      pool.query.mockRejectedValue(new Error("FK violation"));
+      await expect(repo.hardDeleteUser("u1")).rejects.toThrow("FK violation");
+    });
+  });
+});

--- a/backend/app/repositories/UserRepository.test.js
+++ b/backend/app/repositories/UserRepository.test.js
@@ -156,6 +156,112 @@ describe("UserRepository", () => {
     });
   });
 
+  describe("upsertByExternalId", () => {
+    it("creates a new user when none exists for the external_id", async () => {
+      const created = {
+        user_id: "u-new",
+        external_id: "entra-sub-9",
+        email: "new@example.com",
+        display_name: "New User",
+      };
+      // First query: getUserByExternalId -> no rows. Second query: createUser insert.
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [created] });
+
+      const result = await repo.upsertByExternalId({
+        externalId: "entra-sub-9",
+        email: "new@example.com",
+        displayName: "New User",
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+      const [insertSql, insertParams] = pool.query.mock.calls[1];
+      expect(insertSql).toContain("INSERT INTO users");
+      expect(insertParams).toEqual([
+        "entra-sub-9",
+        "new@example.com",
+        "New User",
+        {},
+      ]);
+      expect(result).toBe(created);
+    });
+
+    it("updates email, display name, and last_login when the user exists", async () => {
+      const existing = {
+        user_id: "u-existing",
+        external_id: "entra-sub-1",
+        email: "old@example.com",
+        display_name: "Old Name",
+      };
+      const updated = {
+        ...existing,
+        email: "fresh@example.com",
+        display_name: "Fresh",
+      };
+      // First query: getUserByExternalId -> the existing row. Second: updateUser.
+      pool.query
+        .mockResolvedValueOnce({ rows: [existing] })
+        .mockResolvedValueOnce({ rows: [updated] });
+
+      const result = await repo.upsertByExternalId({
+        externalId: "entra-sub-1",
+        email: "fresh@example.com",
+        displayName: "Fresh",
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+      const [updateSql, updateParams] = pool.query.mock.calls[1];
+      expect(updateSql).toContain("UPDATE users");
+      expect(updateSql).toContain("email = $1");
+      expect(updateSql).toContain("display_name = $2");
+      expect(updateSql).toContain("last_login = $3");
+      // email, displayName, lastLogin (a Date), then the user_id in the WHERE clause.
+      expect(updateParams[0]).toBe("fresh@example.com");
+      expect(updateParams[1]).toBe("Fresh");
+      expect(updateParams[2]).toBeInstanceOf(Date);
+      expect(updateParams[3]).toBe("u-existing");
+      expect(result).toBe(updated);
+    });
+
+    it("only stamps last_login (no profile overwrite) when claims are omitted", async () => {
+      const existing = { user_id: "u-existing", external_id: "entra-sub-1" };
+      pool.query
+        .mockResolvedValueOnce({ rows: [existing] })
+        .mockResolvedValueOnce({ rows: [existing] });
+
+      await repo.upsertByExternalId({ externalId: "entra-sub-1" });
+
+      const [updateSql, updateParams] = pool.query.mock.calls[1];
+      expect(updateSql).toContain("UPDATE users");
+      expect(updateSql).not.toContain("email =");
+      expect(updateSql).not.toContain("display_name =");
+      expect(updateSql).toContain("last_login = $1");
+      // Only last_login (a Date), then the user_id in the WHERE clause.
+      expect(updateParams[0]).toBeInstanceOf(Date);
+      expect(updateParams[1]).toBe("u-existing");
+    });
+
+    it("defaults displayName to null when omitted", async () => {
+      pool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ user_id: "u2" }] });
+
+      await repo.upsertByExternalId({
+        externalId: "entra-sub-2",
+        email: "noname@example.com",
+      });
+
+      const [, insertParams] = pool.query.mock.calls[1];
+      expect(insertParams).toEqual([
+        "entra-sub-2",
+        "noname@example.com",
+        null,
+        {},
+      ]);
+    });
+  });
+
   describe("updateUser", () => {
     it("builds a parameterized SET clause for provided fields only", async () => {
       const updated = { user_id: "u1", display_name: "New Name" };

--- a/backend/app/routes/auth.js
+++ b/backend/app/routes/auth.js
@@ -1,0 +1,171 @@
+/**
+ * Authentication routes — Entra External ID OAuth 2.0 (authorization-code + PKCE).
+ *
+ * A confidential-client, backend-driven flow. The browser is redirected to the
+ * Entra hosted pages for sign-up/sign-in; Entra redirects back to /auth/callback
+ * with an authorization code, which the server exchanges (with the PKCE verifier
+ * and client secret) for tokens. The user is upserted into the local `users`
+ * table and their primary key is stored in the server session.
+ *
+ * Exported as a factory so the UserRepository can be injected (keeps the routes
+ * unit-testable with a mock repository and a mocked MSAL client).
+ */
+
+const express = require("express");
+const {
+  msalClient,
+  authority,
+  redirectUri,
+  scopes,
+  cryptoProvider,
+} = require("../../config/auth");
+const logger = require("../utils/logger");
+
+// Where to send the browser after login/logout completes.
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+
+/**
+ * @param {object} deps
+ * @param {import('../repositories/UserRepository')} deps.userRepository
+ * @returns {import('express').Router}
+ */
+function createAuthRouter({ userRepository }) {
+  if (!userRepository) {
+    throw new Error("createAuthRouter requires a userRepository");
+  }
+
+  const router = express.Router();
+
+  /**
+   * Begin sign-in: generate PKCE + state, stash them in the session, and
+   * redirect the browser to the Entra authorization endpoint.
+   */
+  router.get("/login", async (req, res) => {
+    try {
+      const { verifier, challenge } = await cryptoProvider.generatePkceCodes();
+      const state = cryptoProvider.createNewGuid();
+
+      // Persist PKCE verifier + state server-side to validate the callback.
+      req.session.pkceVerifier = verifier;
+      req.session.authState = state;
+
+      const authCodeUrl = await msalClient.getAuthCodeUrl({
+        scopes,
+        redirectUri,
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        state,
+      });
+
+      return res.redirect(authCodeUrl);
+    } catch (err) {
+      logger.error("/auth/login failed", err);
+      return res.status(500).json({ error: "Failed to start login" });
+    }
+  });
+
+  /**
+   * Handle the redirect back from Entra: validate state, exchange the code for
+   * tokens, upsert the user, and establish the session.
+   */
+  router.get("/callback", async (req, res) => {
+    try {
+      const { code, state } = req.query;
+
+      if (!code) {
+        return res.status(400).json({ error: "Missing authorization code" });
+      }
+      if (!state || state !== req.session.authState) {
+        logger.warn("/auth/callback: state mismatch");
+        return res.status(400).json({ error: "Invalid state" });
+      }
+
+      const tokenResponse = await msalClient.acquireTokenByCode({
+        code,
+        scopes,
+        redirectUri,
+        codeVerifier: req.session.pkceVerifier,
+      });
+
+      const claims = tokenResponse.idTokenClaims || {};
+      const externalId = claims.sub;
+      const email = claims.email || claims.preferred_username || null;
+      const displayName = claims.name || null;
+
+      if (!externalId) {
+        logger.error("/auth/callback: ID token missing sub claim");
+        return res.status(400).json({ error: "Invalid identity token" });
+      }
+
+      // email is NOT NULL (and format-checked) in the users table, so a missing
+      // email claim would fail the upsert. Reject before touching the DB.
+      if (!email) {
+        logger.error("/auth/callback: ID token missing email claim");
+        return res.status(400).json({ error: "Invalid identity token" });
+      }
+
+      const user = await userRepository.upsertByExternalId({
+        externalId,
+        email,
+        displayName,
+      });
+
+      // Clear the one-time login artifacts, then bind the session to the user.
+      delete req.session.pkceVerifier;
+      delete req.session.authState;
+      req.session.userId = user.user_id;
+
+      return res.redirect(FRONTEND_URL);
+    } catch (err) {
+      logger.error("/auth/callback failed", err);
+      return res.status(500).json({ error: "Authentication failed" });
+    }
+  });
+
+  /**
+   * Return the currently authenticated user, or 401 if not signed in. Lets the
+   * SPA determine login state on load.
+   */
+  router.get("/me", async (req, res) => {
+    if (!req.session || !req.session.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    try {
+      const user = await userRepository.getUserById(req.session.userId);
+      if (!user) {
+        // Session references a user that no longer exists — clear it.
+        req.session.destroy(() => {});
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+      return res.json({ user });
+    } catch (err) {
+      logger.error("/auth/me failed", err);
+      return res.status(500).json({ error: "Failed to load user" });
+    }
+  });
+
+  /**
+   * Sign out: destroy the local session and redirect to the Entra logout
+   * endpoint so the IdP SSO session is also ended (full logout).
+   */
+  router.post("/logout", (req, res) => {
+    const logoutUrl =
+      `${authority}/oauth2/v2.0/logout` +
+      `?post_logout_redirect_uri=${encodeURIComponent(FRONTEND_URL)}`;
+
+    if (!req.session) {
+      return res.json({ logoutUrl });
+    }
+    req.session.destroy((err) => {
+      if (err) {
+        logger.error("/auth/logout: session destroy failed", err);
+      }
+      res.clearCookie("connect.sid");
+      return res.json({ logoutUrl });
+    });
+  });
+
+  return router;
+}
+
+module.exports = createAuthRouter;

--- a/backend/app/routes/auth.test.js
+++ b/backend/app/routes/auth.test.js
@@ -1,0 +1,214 @@
+// Mock the MSAL/Entra config so the router can be imported without real env vars
+// or network access. Each function is a jest mock we can program per test.
+jest.mock("../../config/auth", () => ({
+  msalClient: {
+    getAuthCodeUrl: jest.fn(),
+    acquireTokenByCode: jest.fn(),
+  },
+  authority: "https://testtenant.ciamlogin.com/tenant-guid",
+  redirectUri: "http://localhost:3000/auth/callback",
+  scopes: ["openid", "profile", "email"],
+  cryptoProvider: {
+    generatePkceCodes: jest.fn(),
+    createNewGuid: jest.fn(),
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const { msalClient, cryptoProvider } = require("../../config/auth");
+const createAuthRouter = require("./auth");
+
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+
+describe("auth routes", () => {
+  let app;
+  let session;
+  let userRepository;
+
+  // Minimal fake session middleware: a plain object with a destroy() method,
+  // seeded per test so we can assert what the routes read and write.
+  function buildApp(initialSession = {}) {
+    session = { ...initialSession };
+    const application = express();
+    application.use((req, res, next) => {
+      req.session = session;
+      req.session.destroy = (cb) => {
+        session = {};
+        req.session = {};
+        if (cb) cb();
+      };
+      next();
+    });
+    application.use("/auth", createAuthRouter({ userRepository }));
+    return application;
+  }
+
+  beforeEach(() => {
+    userRepository = {
+      upsertByExternalId: jest.fn(),
+      getUserById: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("factory", () => {
+    it("throws when no userRepository is provided", () => {
+      expect(() => createAuthRouter({})).toThrow(
+        "createAuthRouter requires a userRepository"
+      );
+    });
+  });
+
+  describe("GET /auth/login", () => {
+    it("stores PKCE + state in the session and redirects to the auth URL", async () => {
+      cryptoProvider.generatePkceCodes.mockResolvedValue({
+        verifier: "verifier-1",
+        challenge: "challenge-1",
+      });
+      cryptoProvider.createNewGuid.mockReturnValue("state-1");
+      msalClient.getAuthCodeUrl.mockResolvedValue(
+        "https://testtenant.ciamlogin.com/authorize?x=1"
+      );
+
+      app = buildApp();
+      const res = await request(app).get("/auth/login");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(
+        "https://testtenant.ciamlogin.com/authorize?x=1"
+      );
+      expect(session.pkceVerifier).toBe("verifier-1");
+      expect(session.authState).toBe("state-1");
+
+      const [args] = msalClient.getAuthCodeUrl.mock.calls[0];
+      expect(args).toMatchObject({
+        codeChallenge: "challenge-1",
+        codeChallengeMethod: "S256",
+        state: "state-1",
+      });
+    });
+
+    it("returns 500 when building the auth URL fails", async () => {
+      cryptoProvider.generatePkceCodes.mockRejectedValue(new Error("boom"));
+
+      app = buildApp();
+      const res = await request(app).get("/auth/login");
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("GET /auth/callback", () => {
+    it("exchanges the code, upserts the user, sets the session, and redirects", async () => {
+      msalClient.acquireTokenByCode.mockResolvedValue({
+        idTokenClaims: {
+          sub: "entra-sub-1",
+          email: "alice@example.com",
+          name: "Alice",
+        },
+      });
+      userRepository.upsertByExternalId.mockResolvedValue({
+        user_id: "user-1",
+      });
+
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "state-1" });
+
+      expect(msalClient.acquireTokenByCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "auth-code",
+          codeVerifier: "verifier-1",
+        })
+      );
+      expect(userRepository.upsertByExternalId).toHaveBeenCalledWith({
+        externalId: "entra-sub-1",
+        email: "alice@example.com",
+        displayName: "Alice",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(FRONTEND_URL);
+      expect(session.userId).toBe("user-1");
+      expect(session.pkceVerifier).toBeUndefined();
+      expect(session.authState).toBeUndefined();
+    });
+
+    it("rejects a state mismatch with 400 and does not exchange the code", async () => {
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "wrong-state" });
+
+      expect(res.status).toBe(400);
+      expect(msalClient.acquireTokenByCode).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the authorization code is missing", async () => {
+      app = buildApp({ authState: "state-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ state: "state-1" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 and does not upsert when the ID token has no email claim", async () => {
+      msalClient.acquireTokenByCode.mockResolvedValue({
+        idTokenClaims: { sub: "entra-sub-1", name: "Alice" },
+      });
+
+      app = buildApp({ authState: "state-1", pkceVerifier: "verifier-1" });
+      const res = await request(app)
+        .get("/auth/callback")
+        .query({ code: "auth-code", state: "state-1" });
+
+      expect(res.status).toBe(400);
+      expect(userRepository.upsertByExternalId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /auth/me", () => {
+    it("returns the current user when authenticated", async () => {
+      const user = { user_id: "user-1", email: "alice@example.com" };
+      userRepository.getUserById.mockResolvedValue(user);
+
+      app = buildApp({ userId: "user-1" });
+      const res = await request(app).get("/auth/me");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ user });
+    });
+
+    it("returns 401 when there is no session user", async () => {
+      app = buildApp();
+      const res = await request(app).get("/auth/me");
+
+      expect(res.status).toBe(401);
+      expect(userRepository.getUserById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /auth/logout", () => {
+    it("destroys the session and returns the Entra logout URL", async () => {
+      app = buildApp({ userId: "user-1" });
+      const res = await request(app).post("/auth/logout");
+
+      expect(res.status).toBe(200);
+      expect(res.body.logoutUrl).toContain(
+        "https://testtenant.ciamlogin.com/tenant-guid/oauth2/v2.0/logout"
+      );
+      expect(res.body.logoutUrl).toContain(encodeURIComponent(FRONTEND_URL));
+    });
+  });
+});

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -1,0 +1,42 @@
+/**
+ * Trip routes — the proof-of-chain protected resource.
+ *
+ * Every route is behind `requireAuth`, so `req.userId` is always the signed-in
+ * user. All data access is scoped by that id via the TripRepository, which is
+ * the authorization boundary: a user can only ever see their own trips.
+ *
+ * Exported as a factory so the TripRepository can be injected (keeps the routes
+ * unit-testable with a mock repository).
+ */
+
+const express = require("express");
+const requireAuth = require("../middleware/requireAuth");
+const logger = require("../utils/logger");
+
+/**
+ * @param {object} deps
+ * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @returns {import('express').Router}
+ */
+function createTripsRouter({ tripRepository }) {
+  if (!tripRepository) {
+    throw new Error("createTripsRouter requires a tripRepository");
+  }
+
+  const router = express.Router();
+
+  // List the signed-in user's trips, newest first.
+  router.get("/", requireAuth, async (req, res) => {
+    try {
+      const trips = await tripRepository.getTripsByUserId(req.userId);
+      return res.json({ trips });
+    } catch (err) {
+      logger.error("GET /api/trips failed", err);
+      return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createTripsRouter;

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -25,6 +25,22 @@ const MAX_LIMIT = 50;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Validate an inbound detour list (shared by POST create and PUT update).
+// Returns an error message string, or null when every detour is well-formed.
+function validateDetours(detours) {
+  for (const d of detours) {
+    if (
+      !d ||
+      !d.placeName ||
+      !Number.isFinite(d.latitude) ||
+      !Number.isFinite(d.longitude)
+    ) {
+      return "Each detour requires placeName, latitude, and longitude";
+    }
+  }
+  return null;
+}
+
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
@@ -115,17 +131,9 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
     }
 
     const detourList = Array.isArray(detours) ? detours : [];
-    for (const d of detourList) {
-      if (
-        !d ||
-        !d.placeName ||
-        typeof d.latitude !== "number" ||
-        typeof d.longitude !== "number"
-      ) {
-        return res.status(400).json({
-          error: "Each detour requires placeName, latitude, and longitude",
-        });
-      }
+    const detourError = validateDetours(detourList);
+    if (detourError) {
+      return res.status(400).json({ error: detourError });
     }
 
     let client;
@@ -164,7 +172,7 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
           placeId: d.placeId || null,
           placeType: d.placeType || null,
           address: d.address || null,
-          rating: d.rating || null,
+          rating: d.rating != null ? Number(d.rating) : null,
           metadata: d.metadata || {},
         });
         savedDetours.push(detour);
@@ -181,6 +189,215 @@ function createTripsRouter({ tripRepository, detourRepository, db }) {
       return res.status(500).json({ error: "Failed to save trip" });
     } finally {
       client.release();
+    }
+  });
+
+  // Update an existing trip (and replace its detours) for the signed-in user.
+  // The trip row and its detours are rewritten in a single transaction:
+  // update the trip, delete all its current detours, then re-insert the ones in
+  // the request. Replacing wholesale mirrors the create flow and keeps the
+  // persisted detours exactly in sync with the client's list. Scoped by
+  // req.userId — updateTrip returns null for a trip the user does not own, which
+  // rolls back and 404s. Last-write-wins (no optimistic concurrency check).
+  router.put("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+
+    const {
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      detours,
+    } = req.body || {};
+
+    if (!tripName || typeof tripName !== "string" || !tripName.trim()) {
+      return res.status(400).json({ error: "tripName is required" });
+    }
+    if (!origin || !destination) {
+      return res
+        .status(400)
+        .json({ error: "origin and destination are required" });
+    }
+
+    const detourList = Array.isArray(detours) ? detours : [];
+    const detourError = validateDetours(detourList);
+    if (detourError) {
+      return res.status(400).json({ error: detourError });
+    }
+
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error("PUT /api/trips/:tripId failed to acquire DB client", err);
+      return res.status(500).json({ error: "Failed to update trip" });
+    }
+
+    try {
+      await client.query("BEGIN");
+
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const trip = await txTripRepo.updateTrip(req.params.tripId, req.userId, {
+        tripName: tripName.trim(),
+        origin,
+        destination,
+        routePolyline: routePolyline || null,
+        distanceMeters: distanceMeters ?? null,
+        durationSeconds: durationSeconds ?? null,
+      });
+
+      // Not found / not owned — nothing was updated, so unwind and 404.
+      if (!trip) {
+        await client.query("ROLLBACK");
+        return res.status(404).json({ error: "Trip not found" });
+      }
+
+      // Replace the trip's detours wholesale.
+      await txDetourRepo.deleteByTripId(req.params.tripId, req.userId);
+      const savedDetours = [];
+      for (const d of detourList) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: trip.trip_id,
+          userId: req.userId,
+          placeName: d.placeName,
+          latitude: d.latitude,
+          longitude: d.longitude,
+          placeId: d.placeId || null,
+          placeType: d.placeType || null,
+          address: d.address || null,
+          rating: d.rating != null ? Number(d.rating) : null,
+          metadata: d.metadata || {},
+        });
+        savedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.json(buildTripView(trip, savedDetours));
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("PUT /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to update trip" });
+    } finally {
+      client.release();
+    }
+  });
+
+  // Duplicate a trip (and all of its detours) for the signed-in user. The copy
+  // is named "Copy of <name>" and is written in a single transaction so a
+  // partial failure never leaves a half-copied trip. Scoped by req.userId — the
+  // source read returns null for a trip the user does not own, which 404s.
+  router.post("/:tripId/duplicate", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error(
+        "POST /api/trips/:tripId/duplicate failed to acquire DB client",
+        err
+      );
+      return res.status(500).json({ error: "Failed to duplicate trip" });
+    }
+
+    try {
+      await client.query("BEGIN");
+
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const source = await txTripRepo.getTripById(
+        req.params.tripId,
+        req.userId
+      );
+      if (!source) {
+        await client.query("ROLLBACK");
+        return res.status(404).json({ error: "Trip not found" });
+      }
+
+      const sourceDetours = await txDetourRepo.getDetoursByTripId(
+        req.params.tripId,
+        req.userId
+      );
+
+      const copy = await txTripRepo.createTrip({
+        userId: req.userId,
+        tripName: `Copy of ${source.trip_name}`,
+        origin: source.origin,
+        destination: source.destination,
+        routePolyline: source.route_polyline || null,
+        distanceMeters: source.distance_meters ?? null,
+        durationSeconds: source.duration_seconds ?? null,
+        departureTime: source.departure_time || null,
+        status: source.status,
+        metadata: source.metadata || {},
+      });
+
+      const copiedDetours = [];
+      for (const d of sourceDetours) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: copy.trip_id,
+          userId: req.userId,
+          placeName: d.place_name,
+          // DECIMAL columns come back from pg as strings — coerce to numbers.
+          latitude: Number(d.latitude),
+          longitude: Number(d.longitude),
+          placeId: d.place_id || null,
+          placeType: d.place_type || null,
+          address: d.address || null,
+          positionOnRoute: d.position_on_route ?? null,
+          estimatedDetourDurationSeconds:
+            d.estimated_detour_duration_seconds ?? null,
+          estimatedDetourDistanceMeters:
+            d.estimated_detour_distance_meters ?? null,
+          rating: d.rating != null ? Number(d.rating) : null,
+          priceLevel: d.price_level ?? null,
+          stopDurationMinutes: d.stop_duration_minutes ?? 30,
+          visitTime: d.visit_time || null,
+          notes: d.notes || null,
+          metadata: d.metadata || {},
+        });
+        copiedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.status(201).json({ trip: copy, detours: copiedDetours });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("POST /api/trips/:tripId/duplicate failed", err);
+      return res.status(500).json({ error: "Failed to duplicate trip" });
+    } finally {
+      client.release();
+    }
+  });
+
+  // Delete a trip (and its detours, via ON DELETE CASCADE) for the signed-in
+  // user. Scoped by req.userId — deleteTrip returns null for a trip the user
+  // does not own, which 404s.
+  router.delete("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+    try {
+      const deleted = await tripRepository.deleteTrip(
+        req.params.tripId,
+        req.userId
+      );
+      if (!deleted) {
+        return res.status(404).json({ error: "Trip not found" });
+      }
+      return res.json({ message: "Trip deleted" });
+    } catch (err) {
+      logger.error("DELETE /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to delete trip" });
     }
   });
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -14,20 +14,30 @@ const requireAuth = require("../middleware/requireAuth");
 const logger = require("../utils/logger");
 const TripRepository = require("../repositories/TripRepository");
 const DetourRepository = require("../repositories/DetourRepository");
+const { buildTripView } = require("../modules/tripView");
 
 // Pagination defaults for GET /api/trips.
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 
+// trip_id is a uuid column, so reject malformed ids up front (otherwise
+// Postgres throws 22P02 and the request surfaces as a 500).
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @param {import('../repositories/DetourRepository')} deps.detourRepository
  * @param {{ getClient: Function }} deps.db - Pool with getClient() for transactions.
  * @returns {import('express').Router}
  */
-function createTripsRouter({ tripRepository, db }) {
+function createTripsRouter({ tripRepository, detourRepository, db }) {
   if (!tripRepository) {
     throw new Error("createTripsRouter requires a tripRepository");
+  }
+  if (!detourRepository) {
+    throw new Error("createTripsRouter requires a detourRepository");
   }
   if (!db || typeof db.getClient !== "function") {
     throw new Error("createTripsRouter requires a db with a getClient method");
@@ -51,6 +61,32 @@ function createTripsRouter({ tripRepository, db }) {
     } catch (err) {
       logger.error("GET /api/trips failed", err);
       return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  // Load a single trip (with its detours) for the signed-in user, reconstructed
+  // into a render-ready view (decoded route + bounds + summary). Scoped by
+  // req.userId — getTripById returns null for a trip the user does not own.
+  router.get("/:tripId", requireAuth, async (req, res) => {
+    if (!UUID_RE.test(req.params.tripId)) {
+      return res.status(404).json({ error: "Trip not found" });
+    }
+    try {
+      const trip = await tripRepository.getTripById(
+        req.params.tripId,
+        req.userId
+      );
+      if (!trip) {
+        return res.status(404).json({ error: "Trip not found" });
+      }
+      const detours = await detourRepository.getDetoursByTripId(
+        req.params.tripId,
+        req.userId
+      );
+      return res.json(buildTripView(trip, detours));
+    } catch (err) {
+      logger.error("GET /api/trips/:tripId failed", err);
+      return res.status(500).json({ error: "Failed to load trip" });
     }
   });
 

--- a/backend/app/routes/trips.js
+++ b/backend/app/routes/trips.js
@@ -12,27 +12,139 @@
 const express = require("express");
 const requireAuth = require("../middleware/requireAuth");
 const logger = require("../utils/logger");
+const TripRepository = require("../repositories/TripRepository");
+const DetourRepository = require("../repositories/DetourRepository");
+
+// Pagination defaults for GET /api/trips.
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
 
 /**
  * @param {object} deps
  * @param {import('../repositories/TripRepository')} deps.tripRepository
+ * @param {{ getClient: Function }} deps.db - Pool with getClient() for transactions.
  * @returns {import('express').Router}
  */
-function createTripsRouter({ tripRepository }) {
+function createTripsRouter({ tripRepository, db }) {
   if (!tripRepository) {
     throw new Error("createTripsRouter requires a tripRepository");
+  }
+  if (!db || typeof db.getClient !== "function") {
+    throw new Error("createTripsRouter requires a db with a getClient method");
   }
 
   const router = express.Router();
 
-  // List the signed-in user's trips, newest first.
+  // List the signed-in user's trips, newest first, paginated.
   router.get("/", requireAuth, async (req, res) => {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const requestedLimit = parseInt(req.query.limit, 10) || DEFAULT_LIMIT;
+    const limit = Math.min(MAX_LIMIT, Math.max(1, requestedLimit));
+    const offset = (page - 1) * limit;
+
     try {
-      const trips = await tripRepository.getTripsByUserId(req.userId);
-      return res.json({ trips });
+      const [trips, total] = await Promise.all([
+        tripRepository.getTripsByUserId(req.userId, { limit, offset }),
+        tripRepository.countTripsByUserId(req.userId),
+      ]);
+      return res.json({ trips, total, page, limit });
     } catch (err) {
       logger.error("GET /api/trips failed", err);
       return res.status(500).json({ error: "Failed to load trips" });
+    }
+  });
+
+  // Save a new trip (with its detours) for the signed-in user. The trip and all
+  // its detours are written in a single transaction so a partial failure never
+  // leaves an orphan trip. The owner is always req.userId — never trusted from
+  // the request body.
+  router.post("/", requireAuth, async (req, res) => {
+    const {
+      tripName,
+      origin,
+      destination,
+      routePolyline,
+      distanceMeters,
+      durationSeconds,
+      detours,
+    } = req.body || {};
+
+    if (!tripName || typeof tripName !== "string" || !tripName.trim()) {
+      return res.status(400).json({ error: "tripName is required" });
+    }
+    if (!origin || !destination) {
+      return res
+        .status(400)
+        .json({ error: "origin and destination are required" });
+    }
+
+    const detourList = Array.isArray(detours) ? detours : [];
+    for (const d of detourList) {
+      if (
+        !d ||
+        !d.placeName ||
+        typeof d.latitude !== "number" ||
+        typeof d.longitude !== "number"
+      ) {
+        return res.status(400).json({
+          error: "Each detour requires placeName, latitude, and longitude",
+        });
+      }
+    }
+
+    let client;
+    try {
+      client = await db.getClient();
+    } catch (err) {
+      logger.error("POST /api/trips failed to acquire DB client", err);
+      return res.status(500).json({ error: "Failed to save trip" });
+    }
+
+    try {
+      await client.query("BEGIN");
+
+      // Client-scoped repositories so every write runs on the same transaction.
+      const txTripRepo = new TripRepository(client);
+      const txDetourRepo = new DetourRepository(client);
+
+      const trip = await txTripRepo.createTrip({
+        userId: req.userId,
+        tripName: tripName.trim(),
+        origin,
+        destination,
+        routePolyline: routePolyline || null,
+        distanceMeters: distanceMeters ?? null,
+        durationSeconds: durationSeconds ?? null,
+      });
+
+      const savedDetours = [];
+      for (const d of detourList) {
+        const detour = await txDetourRepo.createDetour({
+          tripId: trip.trip_id,
+          userId: req.userId,
+          placeName: d.placeName,
+          latitude: d.latitude,
+          longitude: d.longitude,
+          placeId: d.placeId || null,
+          placeType: d.placeType || null,
+          address: d.address || null,
+          rating: d.rating || null,
+          metadata: d.metadata || {},
+        });
+        savedDetours.push(detour);
+      }
+
+      await client.query("COMMIT");
+      return res.status(201).json({ trip, detours: savedDetours });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("POST /api/trips failed", err);
+      if (err.code === "INVALID_USER") {
+        return res.status(400).json({ error: "Invalid user" });
+      }
+      return res.status(500).json({ error: "Failed to save trip" });
+    } finally {
+      client.release();
     }
   });
 

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -4,17 +4,30 @@ jest.mock("../utils/logger", () => ({
   error: jest.fn(),
 }));
 
-// Shared mocks for the transaction-scoped repositories. The POST handler does
-// `new TripRepository(client)` / `new DetourRepository(client)`, so we replace
-// the classes with constructors that return these controllable instances.
+// Shared mocks for the transaction-scoped repositories. The POST/PUT/duplicate
+// handlers do `new TripRepository(client)` / `new DetourRepository(client)`, so
+// we replace the classes with constructors that return these controllable
+// instances.
 const mockCreateTrip = jest.fn();
 const mockCreateDetour = jest.fn();
+const mockUpdateTrip = jest.fn();
+const mockDeleteByTripId = jest.fn();
+const mockTxGetTripById = jest.fn();
+const mockTxGetDetoursByTripId = jest.fn();
 
 jest.mock("../repositories/TripRepository", () =>
-  jest.fn().mockImplementation(() => ({ createTrip: mockCreateTrip }))
+  jest.fn().mockImplementation(() => ({
+    createTrip: mockCreateTrip,
+    updateTrip: mockUpdateTrip,
+    getTripById: mockTxGetTripById,
+  }))
 );
 jest.mock("../repositories/DetourRepository", () =>
-  jest.fn().mockImplementation(() => ({ createDetour: mockCreateDetour }))
+  jest.fn().mockImplementation(() => ({
+    createDetour: mockCreateDetour,
+    deleteByTripId: mockDeleteByTripId,
+    getDetoursByTripId: mockTxGetDetoursByTripId,
+  }))
 );
 
 const express = require("express");
@@ -33,6 +46,7 @@ describe("trips routes", () => {
       getTripsByUserId: jest.fn(),
       countTripsByUserId: jest.fn(),
       getTripById: jest.fn(),
+      deleteTrip: jest.fn(),
     };
     detourRepository = {
       getDetoursByTripId: jest.fn(),
@@ -363,6 +377,314 @@ describe("trips routes", () => {
       tripRepository.getTripById.mockRejectedValue(new Error("DB down"));
 
       const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("PUT /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const validBody = {
+      tripName: "Updated trip",
+      origin: { address: "A", lat: 1, lng: 2 },
+      destination: { address: "B", lat: 3, lng: 4 },
+      routePolyline: "abc",
+      distanceMeters: 2000,
+      durationSeconds: 1200,
+      detours: [
+        { placeName: "Park", latitude: 1.5, longitude: 2.5, placeType: "park" },
+      ],
+    };
+
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put("/api/trips/not-a-uuid")
+        .send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when tripName is missing", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, tripName: "  " });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when a detour is missing coordinates", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, detours: [{ placeName: "No coords" }] });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("updates the trip and replaces its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({
+        trip_id: TRIP_ID,
+        trip_name: "Updated trip",
+        updated_at: "2026-07-07T12:00:00.000Z",
+      });
+      mockDeleteByTripId.mockResolvedValue(1);
+      mockCreateDetour.mockResolvedValue({
+        place_name: "Park",
+        place_type: "park",
+        latitude: "1.5",
+        longitude: "2.5",
+        place_id: null,
+        rating: null,
+      });
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(200);
+      // Response is the reconstructed trip view (includes updatedAt).
+      expect(res.body.trip).toMatchObject({
+        tripId: TRIP_ID,
+        tripName: "Updated trip",
+        updatedAt: "2026-07-07T12:00:00.000Z",
+      });
+
+      // Owner comes from the session, not the body.
+      expect(mockUpdateTrip).toHaveBeenCalledWith(
+        TRIP_ID,
+        "user-1",
+        expect.objectContaining({
+          tripName: "Updated trip",
+          routePolyline: "abc",
+          distanceMeters: 2000,
+          durationSeconds: 1200,
+        })
+      );
+      expect(mockDeleteByTripId).toHaveBeenCalledWith(TRIP_ID, "user-1");
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: TRIP_ID,
+          userId: "user-1",
+          placeName: "Park",
+          latitude: 1.5,
+          longitude: 2.5,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("BEGIN");
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue(null);
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(404);
+      expect(mockDeleteByTripId).not.toHaveBeenCalled();
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a detour insert fails", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({ trip_id: TRIP_ID });
+      mockDeleteByTripId.mockResolvedValue(1);
+      mockCreateDetour.mockRejectedValue(new Error("detour insert failed"));
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send(validBody);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("updates a trip and clears its detours when none are supplied", async () => {
+      const app = buildApp("user-1");
+      mockUpdateTrip.mockResolvedValue({ trip_id: TRIP_ID });
+      mockDeleteByTripId.mockResolvedValue(2);
+
+      const res = await request(app)
+        .put(`/api/trips/${TRIP_ID}`)
+        .send({ ...validBody, detours: [] });
+
+      expect(res.status).toBe(200);
+      expect(mockDeleteByTripId).toHaveBeenCalledWith(TRIP_ID, "user-1");
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
+  });
+
+  describe("POST /api/trips/:tripId/duplicate", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const sourceTrip = {
+      trip_id: TRIP_ID,
+      trip_name: "Coastal drive",
+      origin: { address: "SF" },
+      destination: { address: "LA" },
+      route_polyline: "abc",
+      distance_meters: 3218,
+      duration_seconds: 5400,
+      status: "planned",
+      metadata: {},
+    };
+
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app).post("/api/trips/not-a-uuid/duplicate");
+
+      expect(res.status).toBe(404);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 404 when the source is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(null);
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(404);
+      expect(mockCreateTrip).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("copies the trip and its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(sourceTrip);
+      mockTxGetDetoursByTripId.mockResolvedValue([
+        {
+          place_name: "Big Sur",
+          place_type: "Landmark",
+          latitude: "36.27",
+          longitude: "-121.8",
+          place_id: "gp-1",
+          rating: "4.8",
+          metadata: {},
+        },
+      ]);
+      mockCreateTrip.mockResolvedValue({ trip_id: "copy-1" });
+      mockCreateDetour.mockResolvedValue({ detour_id: "d1" });
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(201);
+      expect(res.body.trip).toEqual({ trip_id: "copy-1" });
+      // The copy is named "Copy of <name>" and owned by the session user.
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user-1",
+          tripName: "Copy of Coastal drive",
+          routePolyline: "abc",
+        })
+      );
+      // Detours are copied onto the new trip, with numerics coerced.
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: "copy-1",
+          userId: "user-1",
+          placeName: "Big Sur",
+          latitude: 36.27,
+          longitude: -121.8,
+          rating: 4.8,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a copy insert fails", async () => {
+      const app = buildApp("user-1");
+      mockTxGetTripById.mockResolvedValue(sourceTrip);
+      mockTxGetDetoursByTripId.mockResolvedValue([]);
+      mockCreateTrip.mockRejectedValue(new Error("insert failed"));
+
+      const res = await request(app).post(`/api/trips/${TRIP_ID}/duplicate`);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(tripRepository.deleteTrip).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app).delete("/api/trips/not-a-uuid");
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.deleteTrip).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockResolvedValue(null);
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.deleteTrip).toHaveBeenCalledWith(TRIP_ID, "user-1");
+    });
+
+    it("deletes a trip the user owns", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockResolvedValue({ trip_id: TRIP_ID });
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ message: "Trip deleted" });
+      expect(tripRepository.deleteTrip).toHaveBeenCalledWith(TRIP_ID, "user-1");
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.deleteTrip.mockRejectedValue(new Error("DB down"));
+
+      const res = await request(app).delete(`/api/trips/${TRIP_ID}`);
 
       expect(res.status).toBe(500);
     });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -23,6 +23,7 @@ const createTripsRouter = require("./trips");
 
 describe("trips routes", () => {
   let tripRepository;
+  let detourRepository;
   let db;
   let client;
 
@@ -31,6 +32,10 @@ describe("trips routes", () => {
     tripRepository = {
       getTripsByUserId: jest.fn(),
       countTripsByUserId: jest.fn(),
+      getTripById: jest.fn(),
+    };
+    detourRepository = {
+      getDetoursByTripId: jest.fn(),
     };
     client = {
       query: jest.fn().mockResolvedValue({}),
@@ -44,7 +49,10 @@ describe("trips routes", () => {
       req.session = userId ? { userId } : {};
       next();
     });
-    app.use("/api/trips", createTripsRouter({ tripRepository, db }));
+    app.use(
+      "/api/trips",
+      createTripsRouter({ tripRepository, detourRepository, db })
+    );
     return app;
   }
 
@@ -59,10 +67,16 @@ describe("trips routes", () => {
       );
     });
 
+    it("throws when no detourRepository is provided", () => {
+      expect(() =>
+        createTripsRouter({ tripRepository: {}, db: { getClient: jest.fn() } })
+      ).toThrow("createTripsRouter requires a detourRepository");
+    });
+
     it("throws when no db with getClient is provided", () => {
-      expect(() => createTripsRouter({ tripRepository: {} })).toThrow(
-        "createTripsRouter requires a db with a getClient method"
-      );
+      expect(() =>
+        createTripsRouter({ tripRepository: {}, detourRepository: {} })
+      ).toThrow("createTripsRouter requires a db with a getClient method");
     });
   });
 
@@ -255,6 +269,102 @@ describe("trips routes", () => {
       expect(mockCreateTrip).toHaveBeenCalledWith(
         expect.objectContaining({ distanceMeters: 0, durationSeconds: 0 })
       );
+    });
+  });
+
+  describe("GET /api/trips/:tripId", () => {
+    const TRIP_ID = "11111111-1111-4111-8111-111111111111";
+    const tripRow = {
+      trip_id: TRIP_ID,
+      trip_name: "Coastal drive",
+      origin: { address: "SF", lat: 37.77, lng: -122.42 },
+      destination: { address: "LA", lat: 34.05, lng: -118.24 },
+      route_polyline: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+      distance_meters: 3218.68,
+      duration_seconds: 5400,
+    };
+
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(401);
+      expect(tripRepository.getTripById).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a malformed (non-UUID) tripId without querying", async () => {
+      const app = buildApp("user-1");
+
+      const res = await request(app).get("/api/trips/not-a-uuid");
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.getTripById).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the trip is not found / not owned", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockResolvedValue(null);
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(404);
+      expect(tripRepository.getTripById).toHaveBeenCalledWith(
+        TRIP_ID,
+        "user-1"
+      );
+      expect(detourRepository.getDetoursByTripId).not.toHaveBeenCalled();
+    });
+
+    it("returns the reconstructed trip view (route + detours) for the owner", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockResolvedValue(tripRow);
+      detourRepository.getDetoursByTripId.mockResolvedValue([
+        {
+          place_name: "Big Sur",
+          place_type: "Landmark",
+          latitude: "36.27000000",
+          longitude: "-121.80000000",
+          place_id: "gp-1",
+          rating: "4.8",
+          metadata: { addedTime: 45 },
+        },
+      ]);
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.trip).toMatchObject({
+        tripId: TRIP_ID,
+        tripName: "Coastal drive",
+      });
+      expect(res.body.route.overview_polyline.complete_overview).toHaveLength(
+        3
+      );
+      expect(res.body.route.summary).toEqual({
+        distance: "2.00",
+        time: { hours: 1, min: 30 },
+      });
+      expect(res.body.detours).toEqual([
+        {
+          name: "Big Sur",
+          type: "Landmark",
+          lat: 36.27,
+          lng: -121.8,
+          id: "gp-1",
+          placeId: "gp-1",
+          rating: 4.8,
+          addedTime: 45,
+        },
+      ]);
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripById.mockRejectedValue(new Error("DB down"));
+
+      const res = await request(app).get(`/api/trips/${TRIP_ID}`);
+
+      expect(res.status).toBe(500);
     });
   });
 });

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -1,0 +1,66 @@
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const createTripsRouter = require("./trips");
+
+describe("trips routes", () => {
+  let tripRepository;
+
+  // Fake session middleware so we can toggle authentication per test.
+  function buildApp(userId) {
+    tripRepository = {
+      getTripsByUserId: jest.fn(),
+    };
+    const app = express();
+    app.use((req, res, next) => {
+      req.session = userId ? { userId } : {};
+      next();
+    });
+    app.use("/api/trips", createTripsRouter({ tripRepository }));
+    return app;
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws when no tripRepository is provided", () => {
+    expect(() => createTripsRouter({})).toThrow(
+      "createTripsRouter requires a tripRepository"
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const app = buildApp(null);
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(401);
+    expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+  });
+
+  it("returns the authenticated user's trips scoped by user id", async () => {
+    const trips = [{ trip_id: "t1", user_id: "user-1" }];
+    const app = buildApp("user-1");
+    tripRepository.getTripsByUserId.mockResolvedValue(trips);
+
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ trips });
+    expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
+  });
+
+  it("returns 500 when the repository throws", async () => {
+    const app = buildApp("user-1");
+    tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+
+    const res = await request(app).get("/api/trips");
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/app/routes/trips.test.js
+++ b/backend/app/routes/trips.test.js
@@ -4,24 +4,47 @@ jest.mock("../utils/logger", () => ({
   error: jest.fn(),
 }));
 
+// Shared mocks for the transaction-scoped repositories. The POST handler does
+// `new TripRepository(client)` / `new DetourRepository(client)`, so we replace
+// the classes with constructors that return these controllable instances.
+const mockCreateTrip = jest.fn();
+const mockCreateDetour = jest.fn();
+
+jest.mock("../repositories/TripRepository", () =>
+  jest.fn().mockImplementation(() => ({ createTrip: mockCreateTrip }))
+);
+jest.mock("../repositories/DetourRepository", () =>
+  jest.fn().mockImplementation(() => ({ createDetour: mockCreateDetour }))
+);
+
 const express = require("express");
 const request = require("supertest");
 const createTripsRouter = require("./trips");
 
 describe("trips routes", () => {
   let tripRepository;
+  let db;
+  let client;
 
   // Fake session middleware so we can toggle authentication per test.
   function buildApp(userId) {
     tripRepository = {
       getTripsByUserId: jest.fn(),
+      countTripsByUserId: jest.fn(),
     };
+    client = {
+      query: jest.fn().mockResolvedValue({}),
+      release: jest.fn(),
+    };
+    db = { getClient: jest.fn().mockResolvedValue(client) };
+
     const app = express();
+    app.use(express.json());
     app.use((req, res, next) => {
       req.session = userId ? { userId } : {};
       next();
     });
-    app.use("/api/trips", createTripsRouter({ tripRepository }));
+    app.use("/api/trips", createTripsRouter({ tripRepository, db }));
     return app;
   }
 
@@ -29,38 +52,209 @@ describe("trips routes", () => {
     jest.clearAllMocks();
   });
 
-  it("throws when no tripRepository is provided", () => {
-    expect(() => createTripsRouter({})).toThrow(
-      "createTripsRouter requires a tripRepository"
-    );
+  describe("factory", () => {
+    it("throws when no tripRepository is provided", () => {
+      expect(() => createTripsRouter({ db: { getClient: jest.fn() } })).toThrow(
+        "createTripsRouter requires a tripRepository"
+      );
+    });
+
+    it("throws when no db with getClient is provided", () => {
+      expect(() => createTripsRouter({ tripRepository: {} })).toThrow(
+        "createTripsRouter requires a db with a getClient method"
+      );
+    });
   });
 
-  it("returns 401 when unauthenticated", async () => {
-    const app = buildApp(null);
-    const res = await request(app).get("/api/trips");
+  describe("GET /api/trips", () => {
+    it("returns 401 when unauthenticated", async () => {
+      const app = buildApp(null);
+      const res = await request(app).get("/api/trips");
 
-    expect(res.status).toBe(401);
-    expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+      expect(res.status).toBe(401);
+      expect(tripRepository.getTripsByUserId).not.toHaveBeenCalled();
+    });
+
+    it("returns a paginated, user-scoped page of trips (defaults)", async () => {
+      const trips = [{ trip_id: "t1", user_id: "user-1" }];
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue(trips);
+      tripRepository.countTripsByUserId.mockResolvedValue(1);
+
+      const res = await request(app).get("/api/trips");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ trips, total: 1, page: 1, limit: 10 });
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 10,
+        offset: 0,
+      });
+      expect(tripRepository.countTripsByUserId).toHaveBeenCalledWith("user-1");
+    });
+
+    it("honors page and limit query params (offset computed)", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue([]);
+      tripRepository.countTripsByUserId.mockResolvedValue(25);
+
+      const res = await request(app).get("/api/trips?page=3&limit=5");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ total: 25, page: 3, limit: 5 });
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 5,
+        offset: 10,
+      });
+    });
+
+    it("clamps limit to the maximum and page to at least 1", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockResolvedValue([]);
+      tripRepository.countTripsByUserId.mockResolvedValue(0);
+
+      const res = await request(app).get("/api/trips?page=0&limit=999");
+
+      expect(res.body.page).toBe(1);
+      expect(res.body.limit).toBe(50);
+      expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1", {
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    it("returns 500 when the repository throws", async () => {
+      const app = buildApp("user-1");
+      tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+      tripRepository.countTripsByUserId.mockResolvedValue(0);
+
+      const res = await request(app).get("/api/trips");
+
+      expect(res.status).toBe(500);
+    });
   });
 
-  it("returns the authenticated user's trips scoped by user id", async () => {
-    const trips = [{ trip_id: "t1", user_id: "user-1" }];
-    const app = buildApp("user-1");
-    tripRepository.getTripsByUserId.mockResolvedValue(trips);
+  describe("POST /api/trips", () => {
+    const validBody = {
+      tripName: "Road trip",
+      origin: { address: "A", lat: 1, lng: 2 },
+      destination: { address: "B", lat: 3, lng: 4 },
+      routePolyline: "abc",
+      distanceMeters: 1000,
+      durationSeconds: 600,
+      detours: [
+        { placeName: "Park", latitude: 1.5, longitude: 2.5, placeType: "park" },
+      ],
+    };
 
-    const res = await request(app).get("/api/trips");
+    it("returns 401 when unauthenticated and never opens a transaction", async () => {
+      const app = buildApp(null);
+      const res = await request(app).post("/api/trips").send(validBody);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ trips });
-    expect(tripRepository.getTripsByUserId).toHaveBeenCalledWith("user-1");
-  });
+      expect(res.status).toBe(401);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
 
-  it("returns 500 when the repository throws", async () => {
-    const app = buildApp("user-1");
-    tripRepository.getTripsByUserId.mockRejectedValue(new Error("DB down"));
+    it("returns 400 when tripName is missing", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, tripName: "  " });
 
-    const res = await request(app).get("/api/trips");
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
 
-    expect(res.status).toBe(500);
+    it("returns 400 when a detour is missing coordinates", async () => {
+      const app = buildApp("user-1");
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, detours: [{ placeName: "No coords" }] });
+
+      expect(res.status).toBe(400);
+      expect(db.getClient).not.toHaveBeenCalled();
+    });
+
+    it("creates the trip and its detours in a committed transaction", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({
+        trip_id: "t1",
+        trip_name: "Road trip",
+      });
+      mockCreateDetour.mockResolvedValue({ detour_id: "d1" });
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(res.body.trip).toEqual({ trip_id: "t1", trip_name: "Road trip" });
+      expect(res.body.detours).toEqual([{ detour_id: "d1" }]);
+
+      // Owner comes from the session, not the body.
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user-1", tripName: "Road trip" })
+      );
+      expect(mockCreateDetour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tripId: "t1",
+          userId: "user-1",
+          placeName: "Park",
+          latitude: 1.5,
+          longitude: 2.5,
+        })
+      );
+      expect(client.query).toHaveBeenCalledWith("BEGIN");
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("rolls back and returns 500 when a detour insert fails", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+      mockCreateDetour.mockRejectedValue(new Error("detour insert failed"));
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(500);
+      expect(client.query).toHaveBeenCalledWith("ROLLBACK");
+      expect(client.query).not.toHaveBeenCalledWith("COMMIT");
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("saves a trip with no detours", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+
+      const res = await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, detours: [] });
+
+      expect(res.status).toBe(201);
+      expect(res.body.detours).toEqual([]);
+      expect(mockCreateDetour).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith("COMMIT");
+    });
+
+    it("returns 500 when acquiring a DB client fails", async () => {
+      const app = buildApp("user-1");
+      db.getClient.mockRejectedValue(new Error("pool exhausted"));
+
+      const res = await request(app).post("/api/trips").send(validBody);
+
+      expect(res.status).toBe(500);
+      // No transaction was started and no create was attempted.
+      expect(mockCreateTrip).not.toHaveBeenCalled();
+    });
+
+    it("preserves a numeric 0 for distance/duration (does not coerce to null)", async () => {
+      const app = buildApp("user-1");
+      mockCreateTrip.mockResolvedValue({ trip_id: "t1" });
+
+      await request(app)
+        .post("/api/trips")
+        .send({ ...validBody, distanceMeters: 0, durationSeconds: 0 });
+
+      expect(mockCreateTrip).toHaveBeenCalledWith(
+        expect.objectContaining({ distanceMeters: 0, durationSeconds: 0 })
+      );
+    });
   });
 });

--- a/backend/app/utils/logger.js
+++ b/backend/app/utils/logger.js
@@ -1,0 +1,30 @@
+/**
+ * Minimal leveled logger for the backend.
+ *
+ * Wraps the console with timestamped, level-prefixed output so application code
+ * has a single place to send logs (and a single place to later swap in a real
+ * logging library such as winston or pino). Levels: info, warn, error.
+ */
+
+/**
+ * Format a log line with an ISO timestamp and uppercase level prefix.
+ *
+ * @param {string} level - Log level label.
+ * @param {string} message - Human-readable message.
+ * @returns {string} The formatted prefix + message.
+ */
+function format(level, message) {
+  return `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}`;
+}
+
+module.exports = {
+  info: function (message, ...meta) {
+    console.log(format("info", message), ...meta);
+  },
+  warn: function (message, ...meta) {
+    console.warn(format("warn", message), ...meta);
+  },
+  error: function (message, ...meta) {
+    console.error(format("error", message), ...meta);
+  },
+};

--- a/backend/config/auth.js
+++ b/backend/config/auth.js
@@ -1,0 +1,101 @@
+/**
+ * Microsoft Entra External ID (CIAM) authentication configuration.
+ *
+ * Builds a single shared MSAL confidential-client application used by the auth
+ * routes to run the OAuth 2.0 authorization-code + PKCE flow. The app registration
+ * platform is "Web" and authenticates with a client secret. Configuration comes
+ * from the ENTRA_* environment variables (see .devcontainer/devcontainer.env.example).
+ *
+ * Exposes:
+ *   - msalClient:  ConfidentialClientApplication for getAuthCodeUrl / acquireTokenByCode.
+ *   - authority:   the tenant authority base URL.
+ *   - redirectUri: the registered callback URL.
+ *   - scopes:      the default OIDC scopes requested at login.
+ *   - cryptoProvider: MSAL CryptoProvider for generating PKCE codes and state.
+ *   - getJwks:     lazily-created remote JWKS for future bearer-token verification.
+ */
+
+const {
+  ConfidentialClientApplication,
+  CryptoProvider,
+} = require("@azure/msal-node");
+const { createRemoteJWKSet } = require("jose");
+const logger = require("../app/utils/logger");
+
+const {
+  ENTRA_TENANT_SUBDOMAIN,
+  ENTRA_TENANT_ID,
+  ENTRA_CLIENT_ID,
+  ENTRA_CLIENT_SECRET,
+  ENTRA_REDIRECT_URI,
+} = process.env;
+
+// Fail fast at startup if the auth environment is not configured. Without these,
+// every login attempt would fail with a less obvious error deep inside MSAL.
+const missing = [
+  ["ENTRA_TENANT_SUBDOMAIN", ENTRA_TENANT_SUBDOMAIN],
+  ["ENTRA_TENANT_ID", ENTRA_TENANT_ID],
+  ["ENTRA_CLIENT_ID", ENTRA_CLIENT_ID],
+  ["ENTRA_CLIENT_SECRET", ENTRA_CLIENT_SECRET],
+  ["ENTRA_REDIRECT_URI", ENTRA_REDIRECT_URI],
+]
+  .filter(([, value]) => !value)
+  .map(([name]) => name);
+
+if (missing.length > 0) {
+  throw new Error(
+    `Missing required Entra environment variables: ${missing.join(", ")}`
+  );
+}
+
+// CIAM (Entra External ID) authority. Accept either the bare subdomain
+// ("jauntdetour") or the full domain ("jauntdetour.onmicrosoft.com") and derive
+// the ciamlogin host from the first label. The tenant ID must be in the
+// authority path: the CIAM discovery document's `issuer` uses the tenant-GUID
+// host, so MSAL's authority-alias validation rejects a tenant-less authority.
+const subdomain = ENTRA_TENANT_SUBDOMAIN.split(".")[0];
+const authorityHost = `${subdomain}.ciamlogin.com`;
+const authority = `https://${authorityHost}/${ENTRA_TENANT_ID}`;
+
+// OIDC scopes: openid for authentication, profile + email to populate the ID
+// token claims (name, email) we persist to the users table.
+const scopes = ["openid", "profile", "email"];
+
+const msalClient = new ConfidentialClientApplication({
+  auth: {
+    clientId: ENTRA_CLIENT_ID,
+    clientSecret: ENTRA_CLIENT_SECRET,
+    authority,
+    knownAuthorities: [authorityHost],
+  },
+  system: {
+    loggerOptions: {
+      loggerCallback(level, message) {
+        logger.info(`MSAL: ${message}`);
+      },
+      piiLoggingEnabled: false,
+      logLevel: 3, // Warning
+    },
+  },
+});
+
+const cryptoProvider = new CryptoProvider();
+
+// Remote JWKS for verifying bearer tokens (e.g. a future API-to-API path).
+// Created lazily so importing this module never triggers a network call.
+let jwks;
+function getJwks() {
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(`${authority}/discovery/v2.0/keys`));
+  }
+  return jwks;
+}
+
+module.exports = {
+  msalClient,
+  authority,
+  redirectUri: ENTRA_REDIRECT_URI,
+  scopes,
+  cryptoProvider,
+  getJwks,
+};

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,5 +1,12 @@
 var config = {
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  db: {
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT || 5432,
+    name: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+  },
 };
 
 module.exports = config;

--- a/backend/index.js
+++ b/backend/index.js
@@ -9,6 +9,7 @@ const placesAPI = require("./app/modules/placesAPI");
 const db = require("./app/db/pool");
 const UserRepository = require("./app/repositories/UserRepository");
 const TripRepository = require("./app/repositories/TripRepository");
+const DetourRepository = require("./app/repositories/DetourRepository");
 const createAuthRouter = require("./app/routes/auth");
 const createTripsRouter = require("./app/routes/trips");
 
@@ -61,9 +62,13 @@ app.use(
 // Compose the data-access layer once and inject it into the routers.
 const userRepository = new UserRepository(db);
 const tripRepository = new TripRepository(db);
+const detourRepository = new DetourRepository(db);
 
 app.use("/auth", createAuthRouter({ userRepository }));
-app.use("/api/trips", createTripsRouter({ tripRepository, db }));
+app.use(
+  "/api/trips",
+  createTripsRouter({ tripRepository, detourRepository, db })
+);
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,23 +6,64 @@ var bodyParser = require("body-parser");
 const routeAPI = require("./app/modules/routeAPI");
 const placesAPI = require("./app/modules/placesAPI");
 
+const db = require("./app/db/pool");
+const UserRepository = require("./app/repositories/UserRepository");
+const TripRepository = require("./app/repositories/TripRepository");
+const createAuthRouter = require("./app/routes/auth");
+const createTripsRouter = require("./app/routes/trips");
+
+const IS_PROD = process.env.NODE_ENV === "production";
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+const SESSION_SECRET = process.env.SESSION_SECRET;
+
+if (!SESSION_SECRET) {
+  throw new Error("SESSION_SECRET environment variable is required");
+}
+
 var app = express();
+
+// Behind a reverse proxy in production (e.g. Azure), trust the first proxy so
+// secure cookies work over the terminated TLS connection.
+if (IS_PROD) {
+  app.set("trust proxy", 1);
+}
+
 app.use(cookieParser());
 
 // This body parser is needed to access the body of a request cleanly
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 
-app.use(cors());
+// Explicit origin + credentials so the browser sends/accepts the session cookie
+// on cross-origin XHR from the frontend dev server. A wildcard origin cannot be
+// combined with credentials.
+app.use(cors({ origin: FRONTEND_URL, credentials: true }));
 
 app.use(
   session({
-    secret: "temporarySecretKey",
+    secret: SESSION_SECRET,
     resave: false,
-    saveUninitialized: true,
-    cookie: { maxAge: 100000000 },
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      // Frontend and backend are cross-site in production (separate
+      // *.azurewebsites.net hosts, which the Public Suffix List treats as
+      // distinct sites), so the cookie must be SameSite=None to be sent on
+      // cross-site XHR. SameSite=None requires Secure. Locally both run on
+      // localhost (same site), where Lax works and avoids needing HTTPS.
+      sameSite: IS_PROD ? "none" : "lax",
+      secure: IS_PROD,
+      maxAge: 1000 * 60 * 60 * 24, // 24 hours
+    },
   })
 );
+
+// Compose the data-access layer once and inject it into the routers.
+const userRepository = new UserRepository(db);
+const tripRepository = new TripRepository(db);
+
+app.use("/auth", createAuthRouter({ userRepository }));
+app.use("/api/trips", createTripsRouter({ tripRepository }));
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/backend/index.js
+++ b/backend/index.js
@@ -63,7 +63,7 @@ const userRepository = new UserRepository(db);
 const tripRepository = new TripRepository(db);
 
 app.use("/auth", createAuthRouter({ userRepository }));
-app.use("/api/trips", createTripsRouter({ tripRepository }));
+app.use("/api/trips", createTripsRouter({ tripRepository, db }));
 
 app.get("/test", function (req, res) {
   res.send({ message: "Hello" });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
+        "@azure/msal-node": "^5.3.1",
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cookie-parser": "1.4.7",
@@ -17,6 +18,7 @@
         "express": "5.1.0",
         "express-session": "1.18.2",
         "https": "1.0.0",
+        "jose": "^6.2.3",
         "pg": "8.13.1",
         "polyline-encoded": "0.0.9"
       },
@@ -28,7 +30,30 @@
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.2.0",
         "nodemon": "3.1.10",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1251,6 +1276,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1287,6 +1325,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2006,6 +2054,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2267,6 +2322,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2602,6 +2663,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2663,6 +2734,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2865,6 +2943,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2910,6 +2999,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3871,6 +3969,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4028,16 +4133,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4062,6 +4167,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4473,9 +4596,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5878,6 +6001,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5952,6 +6084,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6009,11 +6184,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6089,6 +6306,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6101,6 +6328,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -6990,12 +7230,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7390,7 +7631,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7518,14 +7758,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7537,13 +7777,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7913,6 +8153,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "capstone-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capstone-backend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "axios": "1.10.0",
         "body-parser": "2.2.0",
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
+        "dotenv": "16.4.7",
         "express": "5.1.0",
         "express-session": "1.18.2",
         "https": "1.0.0",
+        "pg": "8.13.1",
         "polyline-encoded": "0.0.9"
       },
       "devDependencies": {
@@ -2874,6 +2876,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -6611,6 +6625,95 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
+      "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6725,6 +6828,45 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -7502,6 +7644,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8471,6 +8622,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,10 @@
     "format": "prettier --write \"**/*.{js,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,json,md}\""
   },
+  "lint-staged": {
+    "**/*.{js,json,md}": "prettier --write",
+    "**/*.js": "eslint --fix"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -21,9 +25,11 @@
     "body-parser": "2.2.0",
     "cookie-parser": "1.4.7",
     "cors": "2.8.5",
+    "dotenv": "16.4.7",
     "express": "5.1.0",
     "express-session": "1.18.2",
     "https": "1.0.0",
+    "pg": "8.13.1",
     "polyline-encoded": "0.0.9"
   },
   "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstone-backend",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@azure/msal-node": "^5.3.1",
     "axios": "1.10.0",
     "body-parser": "2.2.0",
     "cookie-parser": "1.4.7",
@@ -29,6 +30,7 @@
     "express": "5.1.0",
     "express-session": "1.18.2",
     "https": "1.0.0",
+    "jose": "^6.2.3",
     "pg": "8.13.1",
     "polyline-encoded": "0.0.9"
   },
@@ -40,6 +42,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.2.0",
     "nodemon": "3.1.10",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "supertest": "^7.2.2"
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,96 @@
+# JauntDetour Documentation
+
+Technical documentation for the JauntDetour road trip planning application.
+
+JauntDetour uses the Google Maps APIs to build routes and find detours along them. The backend persists user accounts and their saved trips and detours so users can save and load their plans.
+
+---
+
+## Architecture Decisions
+
+| Area | Decision |
+|------|----------|
+| **Database** | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS |
+| **Authentication** | Microsoft Entra External ID (email/password + social login) |
+
+---
+
+## 📁 database/
+
+Persistence for users, trips, and detours.
+
+1. **[Selection](database/selection.md)** — recommendation and rationale (why PostgreSQL, options considered, data model, query patterns, backup/DR, cost summary).
+2. **[Schema](database/schema.sql)** — PostgreSQL schema: `users`, `trips`, `detours`. UUID keys, JSONB for Google payloads, plain `DECIMAL` lat/lng, B-tree indexes, timestamp triggers. **No PostGIS.**
+3. **[Cost Comparison](database/cost-comparison.md)** — free-tier and production pricing, 3-year TCO, optimization tips.
+4. **[Implementation Guide](database/implementation-guide.md)** — provisioning, schema deployment, and Node.js integration.
+
+## 📁 authentication/
+
+Managed identity for end users.
+
+1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, user experience, how tokens map to the `users` table, setup overview, security essentials).
+2. **[Implementation Guide](authentication/implementation-guide.md)** — Node.js login/callback flow, token verification, and per-user route scoping.
+
+---
+
+## Key Findings
+
+### Database — Azure Database for PostgreSQL
+- **Right fit:** Google APIs handle all geospatial work, so the data model is plainly relational (`users → trips → detours`) with JSONB for API responses — no spatial extension needed.
+- **Cost-effective:** lowest 3-year TCO of all options (~$5,484 vs ~$21,624 for Cosmos DB). Free for the first 12 months (B1ms, 32 GB).
+- **Future-ready:** `pgvector` + the `azure_ai` extension add semantic search in-place if the AI agent needs it later — no second datastore.
+
+### Authentication — Microsoft Entra External ID
+- **Managed and secure:** Microsoft hosts sign-up/sign-in and handles password storage, MFA, lockout, and reset. We never store credentials.
+- **Flexible login:** email/password **and** Google (plus Apple/Facebook/Microsoft) in one hosted, brandable flow.
+- **Clean DB tie-in:** the token's `sub` claim is stored as `users.external_id` — no `password_hash`. The resolved `user_id` is the authorization boundary for both the API and a future Foundry agent tool.
+
+---
+
+## Data Model
+
+```
+┌──────────────┐
+│    Users     │
+│ - user_id    │──┐
+│ - external_id│  │   (Entra "sub" claim — no password stored)
+│ - email      │  │
+└──────────────┘  │ 1:N
+                  ▼
+┌───────────────────────┐
+│        Trips          │
+│ - trip_id             │──┐
+│ - user_id (FK)        │  │
+│ - origin (JSONB)      │  │
+│ - destination (JSONB) │  │
+│ - route_polyline      │  │
+└───────────────────────┘  │ 1:N
+                           ▼
+┌──────────────────────────────┐
+│         Detours              │
+│ - detour_id                  │
+│ - trip_id (FK)               │
+│ - place_name                 │
+│ - latitude / longitude       │   (plain DECIMAL — no spatial index)
+│ - rating                     │
+└──────────────────────────────┘
+```
+
+---
+
+## Document Status
+
+| Document | Status | Last Updated |
+|----------|--------|--------------|
+| database/selection.md | ✅ | Jun 2, 2026 |
+| database/schema.sql | ✅ | Jun 2, 2026 |
+| database/cost-comparison.md | ✅ | Jun 2, 2026 |
+| database/implementation-guide.md | ✅ | Jun 2, 2026 |
+| authentication/authentication.md | ✅ | Jun 2, 2026 |
+| authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
+
+---
+
+**Document Version:** 2.0
+**Last Updated:** June 2, 2026
+**Maintained by:** JauntDetour Development Team

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,11 @@ Persistence for users, trips, and detours.
 
 Managed identity for end users.
 
-1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, user experience, how tokens map to the `users` table, setup overview, security essentials).
+1. **[Authentication](authentication/authentication.md)** — decision and rationale (why Entra External ID, options compared, cost, user experience, how tokens map to the `users` table, setup overview).
 2. **[Implementation Guide](authentication/implementation-guide.md)** — Node.js login/callback flow, token verification, and per-user route scoping.
+3. **[Security](authentication/security.md)** — token storage, validation, CSRF, CORS, rate limiting, MFA, secrets, logging.
+4. **[Session Management](authentication/session-management.md)** — token lifetimes, logout/revocation, timeouts (lean IdP-managed default, optional Redis store).
+5. **[Compliance](authentication/compliance.md)** — GDPR data-subject rights, retention, cookie policy, data residency.
 
 ---
 
@@ -88,6 +91,9 @@ Managed identity for end users.
 | database/implementation-guide.md | ✅ | Jun 2, 2026 |
 | authentication/authentication.md | ✅ | Jun 2, 2026 |
 | authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
+| authentication/security.md | ✅ | Jun 2, 2026 |
+| authentication/session-management.md | ✅ | Jun 2, 2026 |
+| authentication/compliance.md | ✅ | Jun 2, 2026 |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,11 @@ JauntDetour uses the Google Maps APIs to build routes and find detours along the
 
 ## Architecture Decisions
 
-| Area | Decision |
-|------|----------|
-| **Database** | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS |
-| **Authentication** | Microsoft Entra External ID (email/password + social login) |
+| Area               | Decision                                                                      |
+| ------------------ | ----------------------------------------------------------------------------- |
+| **Database**       | Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS      |
+| **Authentication** | Microsoft Entra External ID (email/password + social login)                   |
+| **Frontend UI**    | Fluent 2 (`@fluentui/react-components`) for new UI (dialogs, drawers, toasts) |
 
 ---
 
@@ -39,11 +40,13 @@ Managed identity for end users.
 ## Key Findings
 
 ### Database — Azure Database for PostgreSQL
+
 - **Right fit:** Google APIs handle all geospatial work, so the data model is plainly relational (`users → trips → detours`) with JSONB for API responses — no spatial extension needed.
 - **Cost-effective:** lowest 3-year TCO of all options (~$5,484 vs ~$21,624 for Cosmos DB). Free for the first 12 months (B1ms, 32 GB).
 - **Future-ready:** `pgvector` + the `azure_ai` extension add semantic search in-place if the AI agent needs it later — no second datastore.
 
 ### Authentication — Microsoft Entra External ID
+
 - **Managed and secure:** Microsoft hosts sign-up/sign-in and handles password storage, MFA, lockout, and reset. We never store credentials.
 - **Flexible login:** email/password **and** Google (plus Apple/Facebook/Microsoft) in one hosted, brandable flow.
 - **Clean DB tie-in:** the token's `sub` claim is stored as `users.external_id` — no `password_hash`. The resolved `user_id` is the authorization boundary for both the API and a future Foundry agent tool.
@@ -83,17 +86,17 @@ Managed identity for end users.
 
 ## Document Status
 
-| Document | Status | Last Updated |
-|----------|--------|--------------|
-| database/selection.md | ✅ | Jun 2, 2026 |
-| database/schema.sql | ✅ | Jun 2, 2026 |
-| database/cost-comparison.md | ✅ | Jun 2, 2026 |
-| database/implementation-guide.md | ✅ | Jun 2, 2026 |
-| authentication/authentication.md | ✅ | Jun 2, 2026 |
-| authentication/implementation-guide.md | ✅ | Jun 2, 2026 |
-| authentication/security.md | ✅ | Jun 2, 2026 |
-| authentication/session-management.md | ✅ | Jun 2, 2026 |
-| authentication/compliance.md | ✅ | Jun 2, 2026 |
+| Document                               | Status | Last Updated |
+| -------------------------------------- | ------ | ------------ |
+| database/selection.md                  | ✅     | Jun 2, 2026  |
+| database/schema.sql                    | ✅     | Jun 2, 2026  |
+| database/cost-comparison.md            | ✅     | Jun 2, 2026  |
+| database/implementation-guide.md       | ✅     | Jun 2, 2026  |
+| authentication/authentication.md       | ✅     | Jun 2, 2026  |
+| authentication/implementation-guide.md | ✅     | Jun 2, 2026  |
+| authentication/security.md             | ✅     | Jun 2, 2026  |
+| authentication/session-management.md   | ✅     | Jun 2, 2026  |
+| authentication/compliance.md           | ✅     | Jun 2, 2026  |
 
 ---
 

--- a/docs/authentication/authentication.md
+++ b/docs/authentication/authentication.md
@@ -12,6 +12,8 @@ Use **Microsoft Entra External ID** as the managed identity provider for JauntDe
 
 We do **not** build our own password authentication, and we do **not** store credentials in our database.
 
+> **Note on naming:** Microsoft Entra External ID is the **successor to Azure AD B2C**. Microsoft stopped onboarding new B2C tenants (May 2025) and B2C is on a retirement path, so new builds use External ID. Earlier spike material that says "Azure AD B2C" refers to the same Azure CIAM platform — the recommendation is unchanged, only the product name and tenant URLs (`*.ciamlogin.com`, not `*.b2clogin.com`).
+
 > Verified against Microsoft Learn (External ID supported features and Google federation, docs updated March 2026).
 
 ---
@@ -26,6 +28,38 @@ Rolling our own username/password auth means owning hashing/salting, reset flows
 | Auth0 / Clerk | Excellent DX and free tiers; viable, but adds a separate vendor outside Azure. |
 | Social OAuth directly (e.g. Google only) | Simple if we only ever want Google; we own more plumbing and no local accounts. |
 | Roll your own password auth | Avoid — high security burden, easy to get wrong. |
+
+### Detailed comparison
+
+| Capability | **Entra External ID** ✅ | Auth0 | Firebase Auth | Custom JWT |
+|------------|:---:|:---:|:---:|:---:|
+| Azure-native | ✅ | ❌ 3rd-party | ❌ Google | ⚠️ self-hosted |
+| Email/password + social in one flow | ✅ | ✅ | ✅ | ❌ build |
+| MFA built in | ✅ | ✅ | ⚠️ limited | ❌ build |
+| GDPR tooling (DPA, residency) | ✅ | ✅ | ⚠️ config | ❌ build |
+| Cost at 50K MAU | ✅ free | ❌ paid | ✅ free | ⚠️ dev/maint |
+| Build effort | ⚠️ moderate | ✅ fast | ✅ fast | ❌ weeks |
+| Maintenance burden | ✅ minimal | ✅ minimal | ✅ minimal | ❌ high |
+
+Firebase is ruled out by the Azure-first preference; Auth0 is a viable non-Azure fallback; custom auth is rejected on security and maintenance grounds.
+
+---
+
+## Cost
+
+External ID bills on **monthly active users (MAU)** — a user counts once no matter how many times they sign in. JauntDetour's expected volume sits comfortably in the free tier.
+
+| MAU | Indicative monthly cost |
+|-----|------------------------|
+| Up to 50,000 | **$0** (free tier) |
+| 50,001 – 100,000 | low per-MAU tiered rate |
+| 100,000+ | progressively lower per-MAU rate |
+
+- The first **50,000 MAU are free**; MFA via the Authenticator app is included.
+- SMS-based MFA and some premium (P1/P2) features carry add-on charges.
+- Figures are **point-in-time** — confirm current rates on the [Azure pricing page](https://azure.microsoft.com/pricing/details/microsoft-entra-external-id/) before a budget decision.
+
+For comparison, Auth0 starts charging well before 50K MAU and a custom build costs roughly $19K+/year in development and maintenance — External ID is both the cheapest and the lowest-effort option.
 
 ---
 
@@ -103,6 +137,8 @@ These matter as much as authentication for a public app:
 - **TLS in transit** — Azure databases enforce SSL by default; keep it on.
 - **Network isolation** — DB behind a VNet/private endpoint in production.
 - **Restrict the Google Maps API key** — scope to specific APIs and referrers.
+
+See [security.md](security.md) for the full hardening detail (token storage, CSRF, CORS, rate limiting, MFA, logging), [session-management.md](session-management.md) for the session lifecycle, and [compliance.md](compliance.md) for GDPR/privacy.
 
 ---
 

--- a/docs/authentication/authentication.md
+++ b/docs/authentication/authentication.md
@@ -1,0 +1,111 @@
+# Authentication for JauntDetour
+
+**Status:** Decided
+**Decision:** Microsoft Entra External ID (customer/external tenant)
+**Last Updated:** June 2, 2026
+
+---
+
+## Decision
+
+Use **Microsoft Entra External ID** as the managed identity provider for JauntDetour's end users. It hosts sign-up and sign-in, supports **email + password local accounts** and **social login (Google, Apple, Facebook, Microsoft)** in the same flow, and handles password storage, hashing, MFA, smart lockout, banned-password checks, and password reset on our behalf.
+
+We do **not** build our own password authentication, and we do **not** store credentials in our database.
+
+> Verified against Microsoft Learn (External ID supported features and Google federation, docs updated March 2026).
+
+---
+
+## Why a managed provider
+
+Rolling our own username/password auth means owning hashing/salting, reset flows, MFA, brute-force protection, breach response, and session security — the most common source of security incidents. A managed provider removes that entire surface area. For a new consumer app, this is the strong default.
+
+| Option | Verdict |
+|--------|---------|
+| **Microsoft Entra External ID** ✅ | Azure-native, one ecosystem, email/password + social in one hosted flow. **Chosen.** |
+| Auth0 / Clerk | Excellent DX and free tiers; viable, but adds a separate vendor outside Azure. |
+| Social OAuth directly (e.g. Google only) | Simple if we only ever want Google; we own more plumbing and no local accounts. |
+| Roll your own password auth | Avoid — high security burden, easy to get wrong. |
+
+---
+
+## What users see
+
+A single hosted **user flow** can present local accounts and social providers together:
+
+```
+┌─────────────────────────────────────┐
+│         Sign in to JauntDetour      │
+│   Email    [____________________]   │
+│   Password [____________________]   │
+│                  [ Sign in ]        │
+│   ──────────  or  ──────────        │
+│   [  🔵  Continue with Google  ]    │
+│   No account?  Sign up              │
+└─────────────────────────────────────┘
+```
+
+The page is **hosted by Microsoft** on `*.ciamlogin.com`, brandable with our logo and colors. The app redirects users there using **OpenID Connect / authorization-code + PKCE**.
+
+---
+
+## How it connects to the database
+
+Whether a user signs in with a password or Google, the backend receives the **same kind of token (JWT)**. From the app's perspective the path is identical:
+
+1. Verify the token.
+2. Read the stable subject (`sub`) claim and email.
+3. Upsert the matching row in `users`, keyed by `external_id` (= the `sub`).
+
+This is why the schema stores **`external_id`, not `password_hash`** (see [../database/schema.sql](../database/schema.sql)). A Google user and an email/password user both become a `users` row identified by their token subject.
+
+### Authorization boundary
+
+Authentication proves *who* the user is; **authorization stays in our app/DB**. Every trip/detour query is scoped:
+
+```sql
+WHERE user_id = <id resolved from the verified token>
+```
+
+The same boundary protects both the REST API and a future Foundry agent tool — the agent calls a parameterized, `user_id`-scoped function, never raw data access.
+
+---
+
+## Setup overview
+
+One-time, in the Microsoft Entra admin center:
+
+1. Create an **external tenant**.
+2. Create a **sign-up and sign-in user flow** (generates the hosted login page).
+3. Enable identity providers:
+   - Email + password is available out of the box.
+   - For Google: create an OAuth client in Google Cloud Console, copy the **Client ID + secret** into Entra (*External Identities → All identity providers → Google*), then add Google to the user flow.
+4. Register the app and point it at the authority `https://<tenant-name>.ciamlogin.com/`.
+
+See [implementation-guide.md](implementation-guide.md) for the Node.js redirect and token-verification code.
+
+---
+
+## Scope notes
+
+- JauntDetour's needs (email/password + Google for consumers) are in the **GA core** of External ID.
+- During the current preview, some premium features are unavailable in external tenants; a few items (Azure Monitor log export, invited-user MFA) are preview/limited.
+- External-tenant auth **log retention is 7 days** on the free side — export to Azure Monitor if longer auth audit history is required.
+
+---
+
+## Security essentials (beyond login)
+
+These matter as much as authentication for a public app:
+
+- **Secrets in Azure Key Vault** — DB password, Google API key, Entra client secret. Not in `.env` for production.
+- **Always parameterized queries** — `$1, $2` placeholders; never concatenate user input into SQL.
+- **TLS in transit** — Azure databases enforce SSL by default; keep it on.
+- **Network isolation** — DB behind a VNet/private endpoint in production.
+- **Restrict the Google Maps API key** — scope to specific APIs and referrers.
+
+---
+
+## Impact on the database decision
+
+**None.** PostgreSQL, Azure SQL, and Cosmos all sit behind the provider identically — they never see credentials, only the resolved user ID. Authentication was decided independently and can change later without touching the data store.

--- a/docs/authentication/compliance.md
+++ b/docs/authentication/compliance.md
@@ -1,0 +1,120 @@
+# GDPR & Privacy Compliance
+
+**Applies to:** Microsoft Entra External ID + JauntDetour backend
+**Last Updated:** June 2, 2026
+
+How JauntDetour meets GDPR obligations. Microsoft is the **data processor** for identity (under its Data Processing Agreement); JauntDetour is the **data controller** for user accounts, trips, and detours.
+
+---
+
+## Data we hold
+
+We deliberately store the **minimum** (see [../database/schema.sql](../database/schema.sql)):
+
+| Field | Purpose |
+|-------|---------|
+| `external_id` (Entra `sub`) | Link the account to the identity provider — **no password is ever stored** |
+| `email` | Account identification and recovery |
+| `display_name` | Personalization |
+| `preferences` (JSONB) | Units, defaults |
+| trips / detours | The user's saved plans |
+
+We do **not** store credentials, payment data, or precise device location.
+
+---
+
+## Data subject rights
+
+| Right | How we satisfy it |
+|-------|-------------------|
+| **Access** | Endpoint returns the user's profile, trips, and detours as JSON |
+| **Portability** | Same data exported as a downloadable JSON file |
+| **Erasure** | Delete the user's rows, then delete the user in Entra |
+| **Rectification** | Profile editing; email changes go through Entra |
+| **Restriction** | Allow disabling optional processing while keeping the account |
+
+```javascript
+// Right to access / portability — scoped to the authenticated user
+router.get('/api/user/export', requireAuth, async (req, res) => {
+  const data = {
+    profile: await User.findById(req.userId),
+    trips: await Trip.findByUserId(req.userId),
+    exportedAt: new Date().toISOString(),
+  };
+  res.setHeader('Content-Disposition', 'attachment; filename=jauntdetour-data.json');
+  res.json(data);
+});
+
+// Right to erasure
+router.delete('/api/user/account', requireAuth, async (req, res) => {
+  await Trip.deleteByUserId(req.userId);   // cascades to detours
+  await User.deleteById(req.userId);
+  await deleteEntraUser(req.userId);       // remove from the identity provider
+  res.json({ message: 'Account deleted' });
+});
+```
+
+Every request is scoped to `req.userId` — the same authorization boundary used everywhere else.
+
+---
+
+## Data minimization & retention
+
+- Collect only what features require; optional fields (e.g. phone) only with explicit consent.
+- **Active accounts:** retained while active.
+- **Inactive accounts:** delete after 2 years of inactivity (with prior warning).
+- **Deleted accounts:** purge within 30 days; remove from backups within 90 days.
+
+---
+
+## Cookie policy
+
+| Category | Consent needed? | Examples |
+|----------|:---:|----------|
+| Essential | No | Auth session cookie (`httpOnly`), CSRF token |
+| Non-essential | Yes | Analytics, UI preference cookies |
+
+Show a consent banner before setting any non-essential cookie; only the essential auth/session cookies load without consent.
+
+---
+
+## Data residency & transfers
+
+- Entra External ID offers **data residency** options; provision the tenant in the region matching the primary user base (EU vs US).
+- Keep the PostgreSQL instance in the same geography as the identity tenant where practical.
+- For transfers outside the EU, rely on Microsoft's Standard Contractual Clauses (covered by the DPA).
+
+Recommended regions: **EU users** → West/North Europe; **US users** → East/West US.
+
+---
+
+## What Microsoft provides vs. what we implement
+
+| Microsoft (Entra) | JauntDetour |
+|-------------------|-------------|
+| DPA, encryption at rest/in transit | Privacy policy & terms of service |
+| Credential storage, MFA, lockout | Cookie consent banner |
+| Identity audit logging | Data export & account-deletion endpoints |
+| Data residency options | Retention enforcement (inactivity cleanup) |
+| SOC 2 / ISO 27001 certifications | Breach-notification process |
+
+---
+
+## Compliance checklist
+
+- [ ] Privacy policy and terms published
+- [ ] Cookie consent banner for non-essential cookies
+- [ ] `/api/user/export` (access + portability) implemented
+- [ ] `/api/user/account` deletion implemented (app rows **and** Entra user)
+- [ ] Retention policy automated (inactive-account cleanup)
+- [ ] Tenant + database provisioned in the appropriate region
+- [ ] Breach-notification procedure documented
+- [ ] Data Protection Officer designated if required
+
+---
+
+## Resources
+
+- [GDPR official text](https://gdpr-info.eu/)
+- [Microsoft data protection & GDPR](https://learn.microsoft.com/compliance/regulatory/gdpr)
+- [Entra External ID data residency](https://learn.microsoft.com/entra/external-id/)

--- a/docs/authentication/implementation-guide.md
+++ b/docs/authentication/implementation-guide.md
@@ -24,30 +24,36 @@ We use **OpenID Connect / authorization-code + PKCE**. Most teams use **MSAL** (
 ## 1. Configuration
 
 `backend/.env.example`:
+
 ```bash
 ENTRA_TENANT_SUBDOMAIN=jauntdetour           # <subdomain>.ciamlogin.com
+ENTRA_TENANT_ID=8edf3fc2-4cde-4c70-9cae-f95870994488  # tenant (directory) GUID
 ENTRA_CLIENT_ID=00001111-aaaa-2222-bbbb-3333cccc4444
 ENTRA_CLIENT_SECRET=                          # from Key Vault in production
 ENTRA_REDIRECT_URI=https://app.jauntdetour.com/auth/callback
 ```
 
 Authority URL format for external tenants:
-`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/`
+`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/<ENTRA_TENANT_ID>`
+
+The tenant ID must be in the authority path. The CIAM discovery document's
+`issuer` uses the tenant-GUID host, so a tenant-less authority fails MSAL's
+authority-alias validation with `endpoints_resolution_error`.
 
 ---
 
 ## 2. MSAL client — `backend/config/auth.js`
 
 ```javascript
-const { ConfidentialClientApplication } = require('@azure/msal-node');
-require('dotenv').config();
+const { ConfidentialClientApplication } = require("@azure/msal-node");
+require("dotenv").config();
 
-const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/`;
+const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/${process.env.ENTRA_TENANT_ID}`;
 
 const msalClient = new ConfidentialClientApplication({
   auth: {
     clientId: process.env.ENTRA_CLIENT_ID,
-    clientSecret: process.env.ENTRA_CLIENT_SECRET,  // from Key Vault in prod
+    clientSecret: process.env.ENTRA_CLIENT_SECRET, // from Key Vault in prod
     authority,
     knownAuthorities: [`${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com`],
   },
@@ -61,15 +67,17 @@ module.exports = { msalClient, authority };
 ## 3. Login + callback routes
 
 ```javascript
-const express = require('express');
-const { msalClient } = require('../config/auth');
-const User = require('../app/models/User');
+const express = require("express");
+const { msalClient } = require("../config/auth");
+const UserRepository = require("../app/repositories/UserRepository");
+const db = require("../app/db/pool");
 
+const userRepository = new UserRepository(db);
 const router = express.Router();
-const SCOPES = ['openid', 'profile', 'email'];
+const SCOPES = ["openid", "profile", "email"];
 
 // (1) Redirect the browser to the hosted Entra login flow.
-router.get('/auth/login', async (req, res) => {
+router.get("/auth/login", async (req, res) => {
   const url = await msalClient.getAuthCodeUrl({
     scopes: SCOPES,
     redirectUri: process.env.ENTRA_REDIRECT_URI,
@@ -78,7 +86,7 @@ router.get('/auth/login', async (req, res) => {
 });
 
 // (3-5) Exchange the code, verify the token, upsert the user.
-router.get('/auth/callback', async (req, res, next) => {
+router.get("/auth/callback", async (req, res, next) => {
   try {
     const result = await msalClient.acquireTokenByCode({
       code: req.query.code,
@@ -89,14 +97,14 @@ router.get('/auth/callback', async (req, res, next) => {
     // MSAL validates the token signature/issuer/audience for us.
     const { sub, email, name } = result.idTokenClaims;
 
-    const user = await User.upsertByExternalId({
-      externalId: sub,       // stable subject claim → users.external_id
+    const user = await userRepository.upsertByExternalId({
+      externalId: sub, // stable subject claim → users.external_id
       email,
       displayName: name,
     });
 
-    req.session.userId = user.user_id;  // or issue your own signed JWT
-    res.redirect('/');
+    req.session.userId = user.user_id; // or issue your own signed JWT
+    res.redirect("/");
   } catch (err) {
     next(err);
   }
@@ -112,30 +120,28 @@ module.exports = router;
 For APIs called with a bearer access token, validate it against the tenant's JWKS. `jose` keeps this small:
 
 ```javascript
-const { createRemoteJWKSet, jwtVerify } = require('jose');
-const { authority } = require('../config/auth');
+const { createRemoteJWKSet, jwtVerify } = require("jose");
+const { authority } = require("../config/auth");
 
-const JWKS = createRemoteJWKSet(
-  new URL(`${authority}discovery/v2.0/keys`)
-);
+const JWKS = createRemoteJWKSet(new URL(`${authority}/discovery/v2.0/keys`));
 
 async function requireAuth(req, res, next) {
   try {
-    const token = (req.headers.authorization || '').replace('Bearer ', '');
+    const token = (req.headers.authorization || "").replace("Bearer ", "");
     const { payload } = await jwtVerify(token, JWKS, {
       audience: process.env.ENTRA_CLIENT_ID,
     });
 
-    const user = await User.upsertByExternalId({
+    const user = await userRepository.upsertByExternalId({
       externalId: payload.sub,
       email: payload.email,
       displayName: payload.name,
     });
 
-    req.userId = user.user_id;  // the authorization boundary
+    req.userId = user.user_id; // the authorization boundary
     next();
   } catch {
-    res.status(401).json({ error: 'Unauthorized' });
+    res.status(401).json({ error: "Unauthorized" });
   }
 }
 
@@ -145,8 +151,8 @@ module.exports = requireAuth;
 Usage — every data route is scoped to `req.userId`:
 
 ```javascript
-router.get('/api/trips', requireAuth, async (req, res) => {
-  const trips = await Trip.findByUserId(req.userId);  // WHERE user_id = $1
+router.get("/api/trips", requireAuth, async (req, res) => {
+  const trips = await tripRepository.getTripsByUserId(req.userId); // WHERE user_id = $1
   res.json(trips);
 });
 ```

--- a/docs/authentication/implementation-guide.md
+++ b/docs/authentication/implementation-guide.md
@@ -1,0 +1,171 @@
+# Entra External ID — Node.js Implementation Guide
+
+**Target:** Microsoft Entra External ID (external tenant) + Express backend
+**Last Updated:** June 2, 2026
+
+How the JauntDetour frontend redirects users to the hosted login flow, and how the backend verifies the returned token and resolves it to a `users` row.
+
+---
+
+## Flow overview
+
+```
+Browser ──(1) redirect──▶ Entra hosted login (*.ciamlogin.com)
+        ◀─(2) auth code──
+Browser ──(3) code──▶ Backend ──(4) exchange for tokens──▶ Entra
+Backend  ─(5) verify JWT, upsert user, issue app session ──▶ Browser
+Browser ──(6) call API with bearer token ──▶ Backend (verify + scope by user_id)
+```
+
+We use **OpenID Connect / authorization-code + PKCE**. Most teams use **MSAL** (`@azure/msal-node`) so they don't hand-roll the OAuth exchange.
+
+---
+
+## 1. Configuration
+
+`backend/.env.example`:
+```bash
+ENTRA_TENANT_SUBDOMAIN=jauntdetour           # <subdomain>.ciamlogin.com
+ENTRA_CLIENT_ID=00001111-aaaa-2222-bbbb-3333cccc4444
+ENTRA_CLIENT_SECRET=                          # from Key Vault in production
+ENTRA_REDIRECT_URI=https://app.jauntdetour.com/auth/callback
+```
+
+Authority URL format for external tenants:
+`https://<ENTRA_TENANT_SUBDOMAIN>.ciamlogin.com/`
+
+---
+
+## 2. MSAL client — `backend/config/auth.js`
+
+```javascript
+const { ConfidentialClientApplication } = require('@azure/msal-node');
+require('dotenv').config();
+
+const authority = `https://${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com/`;
+
+const msalClient = new ConfidentialClientApplication({
+  auth: {
+    clientId: process.env.ENTRA_CLIENT_ID,
+    clientSecret: process.env.ENTRA_CLIENT_SECRET,  // from Key Vault in prod
+    authority,
+    knownAuthorities: [`${process.env.ENTRA_TENANT_SUBDOMAIN}.ciamlogin.com`],
+  },
+});
+
+module.exports = { msalClient, authority };
+```
+
+---
+
+## 3. Login + callback routes
+
+```javascript
+const express = require('express');
+const { msalClient } = require('../config/auth');
+const User = require('../app/models/User');
+
+const router = express.Router();
+const SCOPES = ['openid', 'profile', 'email'];
+
+// (1) Redirect the browser to the hosted Entra login flow.
+router.get('/auth/login', async (req, res) => {
+  const url = await msalClient.getAuthCodeUrl({
+    scopes: SCOPES,
+    redirectUri: process.env.ENTRA_REDIRECT_URI,
+  });
+  res.redirect(url);
+});
+
+// (3-5) Exchange the code, verify the token, upsert the user.
+router.get('/auth/callback', async (req, res, next) => {
+  try {
+    const result = await msalClient.acquireTokenByCode({
+      code: req.query.code,
+      scopes: SCOPES,
+      redirectUri: process.env.ENTRA_REDIRECT_URI,
+    });
+
+    // MSAL validates the token signature/issuer/audience for us.
+    const { sub, email, name } = result.idTokenClaims;
+
+    const user = await User.upsertByExternalId({
+      externalId: sub,       // stable subject claim → users.external_id
+      email,
+      displayName: name,
+    });
+
+    req.session.userId = user.user_id;  // or issue your own signed JWT
+    res.redirect('/');
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;
+```
+
+---
+
+## 4. Protecting API routes
+
+For APIs called with a bearer access token, validate it against the tenant's JWKS. `jose` keeps this small:
+
+```javascript
+const { createRemoteJWKSet, jwtVerify } = require('jose');
+const { authority } = require('../config/auth');
+
+const JWKS = createRemoteJWKSet(
+  new URL(`${authority}discovery/v2.0/keys`)
+);
+
+async function requireAuth(req, res, next) {
+  try {
+    const token = (req.headers.authorization || '').replace('Bearer ', '');
+    const { payload } = await jwtVerify(token, JWKS, {
+      audience: process.env.ENTRA_CLIENT_ID,
+    });
+
+    const user = await User.upsertByExternalId({
+      externalId: payload.sub,
+      email: payload.email,
+      displayName: payload.name,
+    });
+
+    req.userId = user.user_id;  // the authorization boundary
+    next();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}
+
+module.exports = requireAuth;
+```
+
+Usage — every data route is scoped to `req.userId`:
+
+```javascript
+router.get('/api/trips', requireAuth, async (req, res) => {
+  const trips = await Trip.findByUserId(req.userId);  // WHERE user_id = $1
+  res.json(trips);
+});
+```
+
+---
+
+## 5. Production checklist
+
+- [ ] `ENTRA_CLIENT_SECRET` and DB credentials injected from **Azure Key Vault**.
+- [ ] Redirect URIs registered for every environment (dev, staging, prod).
+- [ ] Sessions/cookies set `httpOnly`, `secure`, `sameSite`.
+- [ ] Token `audience` and `issuer` validated on every request.
+- [ ] Brand the hosted user flow (logo, colors) in the Entra admin center.
+- [ ] Export auth logs to Azure Monitor if >7-day retention is needed.
+
+---
+
+## Resources
+
+- [Microsoft Entra External ID](https://learn.microsoft.com/entra/external-id/)
+- [Add Google as an identity provider](https://learn.microsoft.com/entra/external-id/customers/how-to-google-federation-customers)
+- [MSAL for Node.js](https://learn.microsoft.com/entra/identity-platform/msal-node-overview)

--- a/docs/authentication/security.md
+++ b/docs/authentication/security.md
@@ -1,0 +1,166 @@
+# Authentication Security
+
+**Applies to:** Microsoft Entra External ID + Express backend
+**Last Updated:** June 2, 2026
+
+Hardening guidance that sits alongside the [authentication decision](authentication.md) and [implementation guide](implementation-guide.md). Entra hosts sign-in and handles password storage, hashing, MFA, and lockout; everything here covers what **our** app is still responsible for.
+
+---
+
+## Protocol
+
+Use **OAuth 2.0 / OpenID Connect, authorization-code flow with PKCE** — the standard for browser apps. PKCE prevents authorization-code interception, and MSAL implements it for us. We never handle raw passwords.
+
+---
+
+## Token storage
+
+| Token | Where | Lifetime | Why |
+|-------|-------|----------|-----|
+| **Access token** | Browser memory (React state/context) | 15–60 min | Lost on refresh; not readable by injected scripts |
+| **Refresh token** | `httpOnly` + `secure` + `sameSite` cookie, or held by MSAL | 7–30 days | Not reachable from JavaScript (XSS-resistant) |
+
+**Never** store tokens in `localStorage` or `sessionStorage` — both are readable by any script and are a classic XSS exfiltration target.
+
+```javascript
+// Refresh-token cookie (when the backend manages it)
+res.cookie('refreshToken', token, {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict',
+  maxAge: 7 * 24 * 60 * 60 * 1000,
+  path: '/auth',
+});
+```
+
+> With MSAL, Entra issues and rotates refresh tokens for us, so a hand-rolled refresh-token store is optional. See [session-management.md](session-management.md).
+
+---
+
+## Token validation
+
+Every protected request validates the JWT against the tenant's published keys (JWKS). The [implementation guide](implementation-guide.md#4-protecting-api-routes) uses `jose`; always check **signature, expiry, audience, and issuer**, and require `RS256`.
+
+- Issuer/JWKS host is `https://<tenant>.ciamlogin.com/...` (External ID), **not** `b2clogin.com`.
+- Audience must equal our `ENTRA_CLIENT_ID`.
+
+---
+
+## Transport security
+
+- **HTTPS everywhere.** Redirect HTTP→HTTPS; Azure Web Apps terminate TLS.
+- **HSTS** via `helmet.hsts({ maxAge: 31536000, includeSubDomains: true, preload: true })`.
+- TLS 1.2+ only.
+
+```javascript
+const helmet = require('helmet');
+app.use(helmet()); // sets HSTS, CSP defaults, X-Content-Type-Options, etc.
+```
+
+---
+
+## CSRF protection
+
+- **SameSite cookies** are the first line of defense for cookie-based auth.
+- Add **anti-CSRF tokens** for state-changing routes (`POST/PUT/DELETE`) if cookies are used to authenticate them.
+- Validate the `Origin`/`Referer` header on sensitive operations.
+
+---
+
+## CORS
+
+```javascript
+const cors = require('cors');
+app.use(cors({
+  origin: process.env.FRONTEND_URL,   // never '*' with credentials
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'CSRF-Token'],
+}));
+```
+
+Never combine `origin: '*'` with `credentials: true`. Whitelist explicit origins.
+
+---
+
+## Rate limiting
+
+Throttle auth endpoints to blunt brute-force and token-abuse:
+
+```javascript
+const rateLimit = require('express-rate-limit');
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 5,                   // per IP per window
+  message: 'Too many authentication attempts, please try again later',
+});
+
+app.use('/auth', authLimiter);
+```
+
+Back the limiter with Redis (`rate-limit-redis`) when running multiple instances. Note Entra already applies smart lockout on its hosted sign-in pages.
+
+---
+
+## MFA
+
+MFA is configured in the **Entra user flow**, not in our code. Recommended policy:
+
+- Optional for regular users, **required** for any admin/elevated role.
+- Authenticator app (TOTP) is included free; SMS carries per-message cost.
+
+Enforce role-sensitive operations in the app by checking the resolved user's role before allowing the action.
+
+---
+
+## Secrets
+
+- `ENTRA_CLIENT_SECRET`, the DB password, and the Google Maps API key live in **Azure Key Vault** in production — never in committed `.env` files.
+- Restrict the Google Maps API key to specific APIs and HTTP referrers.
+
+---
+
+## Logging & monitoring
+
+Log security-relevant events (without logging tokens or secrets):
+
+- Sign-in success/failure, token refresh, logout
+- Session revocation, role changes
+- Failed authorization (`403`) attempts
+
+```javascript
+securityLogger.info({
+  event: 'login_success',
+  userId: user.user_id,
+  ip: req.ip,
+  userAgent: req.headers['user-agent'],
+  at: new Date().toISOString(),
+});
+```
+
+Export Entra sign-in/audit logs to **Azure Monitor** if you need more than the 7-day external-tenant retention.
+
+---
+
+## Pre-production checklist
+
+- [ ] All traffic over HTTPS; HSTS enabled
+- [ ] `helmet` security headers configured
+- [ ] JWT signature/expiry/audience/issuer validated on every request
+- [ ] Rate limiting on `/auth` routes
+- [ ] CORS locked to known origins; no `*` with credentials
+- [ ] CSRF protection on cookie-authenticated state changes
+- [ ] No tokens in `localStorage`/`sessionStorage`
+- [ ] Secrets sourced from Key Vault
+- [ ] MFA enforced for admin roles
+- [ ] Security event logging in place
+- [ ] Dependencies scanned for known vulnerabilities
+
+---
+
+## Resources
+
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [OAuth 2.0 for Browser-Based Apps](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)
+- [Microsoft Entra External ID](https://learn.microsoft.com/entra/external-id/)

--- a/docs/authentication/session-management.md
+++ b/docs/authentication/session-management.md
@@ -27,11 +27,11 @@ This needs **no Redis** and no hand-rolled refresh logic.
 
 ## Token lifetimes
 
-| Token | Lifetime | Storage |
-|-------|----------|---------|
-| Access token | 15–60 min | Browser memory |
-| Refresh token | 7–30 days (rotated by Entra) | MSAL cache / `httpOnly` cookie |
-| App session | Match refresh window; absolute cap 90 days | `httpOnly` cookie |
+| Token         | Lifetime                                   | Storage                        |
+| ------------- | ------------------------------------------ | ------------------------------ |
+| Access token  | 15–60 min                                  | Browser memory                 |
+| Refresh token | 7–30 days (rotated by Entra)               | MSAL cache / `httpOnly` cookie |
+| App session   | Match refresh window; absolute cap 90 days | `httpOnly` cookie              |
 
 The frontend refreshes the access token shortly before expiry (MSAL `acquireTokenSilent` handles this transparently).
 
@@ -44,9 +44,9 @@ The frontend refreshes the access token shortly before expiry (MSAL `acquireToke
 - **Force sign-out everywhere** — see the optional server-side store below; without it, revocation is bounded by access-token lifetime (keep it short, 15 min).
 
 ```javascript
-router.post('/auth/logout', (req, res) => {
+router.post("/auth/logout", (req, res) => {
   req.session.destroy(() => {
-    res.clearCookie('connect.sid');
+    res.clearCookie("connect.sid");
     const logoutUrl =
       `${authority}oauth2/v2.0/logout` +
       `?post_logout_redirect_uri=${encodeURIComponent(process.env.FRONTEND_URL)}`;
@@ -68,12 +68,27 @@ Short access-token lifetimes (15 min) mean a revoked or expired session is rejec
 
 ## Optional: server-side session store
 
+> **Current build:** sessions use `express-session`'s default in-memory
+> `MemoryStore`. That's fine for local dev and a single instance, but it loses
+> sessions on restart and does not scale across instances. Before running more
+> than one backend instance, switch to a persistent store — `connect-pg-simple`
+> (reuses the existing Postgres pool) is the low-friction option; Redis (below)
+> is the alternative when you also need global revocation.
+
 Adopt this only if you need **immediate, global revocation** or **concurrent-session limits** — e.g. an admin "sign out all devices" feature. It adds a Redis dependency and rotation code.
 
 ```javascript
 // Store session metadata for revocation
-await redis.setex(`session:${userId}:${sessionId}`, 7 * 24 * 60 * 60,
-  JSON.stringify({ userId, createdAt: Date.now(), lastActivity: Date.now(), ip: req.ip }));
+await redis.setex(
+  `session:${userId}:${sessionId}`,
+  7 * 24 * 60 * 60,
+  JSON.stringify({
+    userId,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+    ip: req.ip,
+  })
+);
 
 // Revoke a single session or all of a user's sessions
 async function revokeAllUserSessions(userId) {

--- a/docs/authentication/session-management.md
+++ b/docs/authentication/session-management.md
@@ -1,0 +1,98 @@
+# Session Management
+
+**Applies to:** Microsoft Entra External ID + Express backend
+**Last Updated:** June 2, 2026
+
+How JauntDetour keeps a user signed in after the [hosted login flow](implementation-guide.md), and how sessions end. **Default approach is lean** — let Entra/MSAL own the token lifecycle and keep only a thin app session. A heavier server-side store is described at the end as an optional upgrade.
+
+---
+
+## Default: lean, IdP-managed tokens
+
+Entra (via MSAL) issues, validates, and **rotates** tokens for us. The backend's job is small:
+
+1. After `/auth/callback`, store the resolved `user_id` in a signed, `httpOnly` session cookie (or issue our own short app JWT).
+2. On each API call, verify the bearer/access token and scope every query to `user_id` (see [implementation guide](implementation-guide.md#4-protecting-api-routes)).
+3. On logout, clear the app session and redirect through Entra's logout endpoint.
+
+```
+Browser ──login──▶ Entra hosted UI ──code──▶ Backend
+Backend ──verify, upsert user, set httpOnly session cookie──▶ Browser
+Browser ──API + access token──▶ Backend (verify JWT, scope by user_id)
+```
+
+This needs **no Redis** and no hand-rolled refresh logic.
+
+---
+
+## Token lifetimes
+
+| Token | Lifetime | Storage |
+|-------|----------|---------|
+| Access token | 15–60 min | Browser memory |
+| Refresh token | 7–30 days (rotated by Entra) | MSAL cache / `httpOnly` cookie |
+| App session | Match refresh window; absolute cap 90 days | `httpOnly` cookie |
+
+The frontend refreshes the access token shortly before expiry (MSAL `acquireTokenSilent` handles this transparently).
+
+---
+
+## Logout & revocation
+
+- **User logout** — clear the app session cookie and call Entra's `logout` endpoint to end the IdP session.
+- **Password change / account deletion** — handled in the Entra user flow; our app simply stops accepting the old session on next verification.
+- **Force sign-out everywhere** — see the optional server-side store below; without it, revocation is bounded by access-token lifetime (keep it short, 15 min).
+
+```javascript
+router.post('/auth/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.clearCookie('connect.sid');
+    const logoutUrl =
+      `${authority}oauth2/v2.0/logout` +
+      `?post_logout_redirect_uri=${encodeURIComponent(process.env.FRONTEND_URL)}`;
+    res.redirect(logoutUrl);
+  });
+});
+```
+
+---
+
+## Timeouts
+
+- **Idle timeout:** 30 minutes of inactivity.
+- **Absolute timeout:** 12 hours for sensitive sessions, 90 days hard cap before forced re-authentication.
+
+Short access-token lifetimes (15 min) mean a revoked or expired session is rejected quickly even in the lean model.
+
+---
+
+## Optional: server-side session store
+
+Adopt this only if you need **immediate, global revocation** or **concurrent-session limits** — e.g. an admin "sign out all devices" feature. It adds a Redis dependency and rotation code.
+
+```javascript
+// Store session metadata for revocation
+await redis.setex(`session:${userId}:${sessionId}`, 7 * 24 * 60 * 60,
+  JSON.stringify({ userId, createdAt: Date.now(), lastActivity: Date.now(), ip: req.ip }));
+
+// Revoke a single session or all of a user's sessions
+async function revokeAllUserSessions(userId) {
+  const keys = await redis.keys(`session:${userId}:*`);
+  if (keys.length) await redis.del(...keys);
+}
+```
+
+What it buys you:
+
+- Revoke a refresh token **before** it expires (logout, password change, security incident).
+- Enforce a max number of concurrent sessions per user (evict the oldest).
+- Track last-activity for idle enforcement server-side.
+
+For JauntDetour's MVP this is **not required** — the lean model is the default. Revisit if/when an admin console or strict device management is on the roadmap.
+
+---
+
+## Resources
+
+- [MSAL token lifecycle](https://learn.microsoft.com/entra/identity-platform/msal-acquire-cache-tokens)
+- [Entra External ID sign-out](https://learn.microsoft.com/entra/external-id/customers/how-to-user-flow-sign-up-sign-in-customers)

--- a/docs/database/cost-comparison.md
+++ b/docs/database/cost-comparison.md
@@ -1,0 +1,77 @@
+# Azure Database Cost Comparison
+
+**Purpose:** Pricing reference behind the PostgreSQL decision.
+**Last Updated:** June 2, 2026
+
+> Prices are approximate and change over time. Verify with the
+> [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/) before committing.
+
+---
+
+## Summary
+
+| Database | Free tier | Small | Medium | Large |
+|----------|-----------|-------|--------|-------|
+| **Azure PostgreSQL** ✅ | 12 mo free (B1ms, 32 GB) | $50–75/mo | $150–200/mo | $350–450/mo |
+| Azure Cosmos DB | 1000 RU/s + 25 GB | $100–200/mo | $400–600/mo | $1000–1500/mo |
+| Azure SQL Database | Serverless (auto-pause) | $75–100/mo | $200–350/mo | $500–750/mo |
+| MongoDB Atlas | M0 forever (512 MB) | $60–90/mo | $150–220/mo | $350–500/mo |
+
+PostgreSQL has the best cost-to-performance ratio at every tier.
+
+---
+
+## PostgreSQL configurations
+
+| Environment | Config | Monthly |
+|-------------|--------|---------|
+| Development | Burstable B1ms, 32 GB, 7-day backups, no HA | **$0** (12-mo free tier) |
+| Small (1–10K users) | D2s_v3, 128 GB, zone-redundant HA, geo backups | ~$152 |
+| Medium (10–50K users) | D4s_v3, 256 GB, zone-redundant HA, geo backups | ~$305 |
+| Large (50–200K users) | D8s_v3, 512 GB, zone-redundant HA, geo backups | ~$610 |
+
+**Cost drivers:** compute tier, HA (~2x compute), backup retention/geo-redundancy, optional read replicas.
+
+---
+
+## 3-year TCO
+
+Assumptions: Y1 = 1K users/1 GB (dev → small); Y2 = 10K users/10 GB; Y3 = 50K users/50 GB.
+
+| Database | Year 1 | Year 2 | Year 3 | **3-Year Total** |
+|----------|--------|--------|--------|------------------|
+| **Azure PostgreSQL** ✅ | $0 | $1,824 | $3,660 | **$5,484** |
+| MongoDB Atlas | $720 | $1,800 | $4,200 | $6,720 |
+| Azure SQL Database | $900 | $3,600 | $7,080 | $11,580 |
+| Azure Cosmos DB | $648 | $4,896 | $16,080 | $21,624 |
+
+**PostgreSQL saves ~$1,236–$16,140 over 3 years** versus the alternatives.
+
+---
+
+## Cost optimization
+
+- Use the 12-month **free tier** (B1ms) for development.
+- Enable **HA only in production** (saves ~50% in dev/staging).
+- Keep **7-day backups** in non-prod; 14–35 days in prod.
+- Add **read replicas** only when read load demands it.
+- Archive old data to **Azure Blob Storage**.
+
+**Potential savings:** 40–60% in non-production environments.
+
+---
+
+## Hidden costs
+
+| Category | Estimated impact |
+|----------|------------------|
+| Networking (private endpoints, egress) | $5–50/mo |
+| Monitoring (Azure Monitor logs/alerts) | $10–50/mo |
+| Long-term backup retention | varies |
+
+---
+
+## Verify current pricing
+
+- [Azure PostgreSQL pricing](https://azure.microsoft.com/pricing/details/postgresql/)
+- [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/)

--- a/docs/database/implementation-guide.md
+++ b/docs/database/implementation-guide.md
@@ -9,14 +9,52 @@ A concise, step-by-step path from provisioning to a working Node.js integration.
 
 ## Prerequisites
 
-- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 16+
+- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 18+
+- Terraform 1.5+ (for the Infrastructure-as-Code path below)
 - An active Azure subscription with Contributor/Owner on the target resource group
 
 ---
 
 ## 1. Provision the server
 
-### Development (free tier)
+Two paths are documented: the **Terraform path (recommended)** for repeatable
+Infrastructure-as-Code, and the **manual Azure CLI path** as a fallback or for
+one-off experimentation.
+
+### Option A — Terraform (recommended)
+
+The Terraform configuration lives in [`/infra`](../../infra/README.md) and
+references an existing resource group and provisions the Flexible Server (dev
+free tier), the database, firewall rules, and enforced TLS.
+
+> **The resource group must already exist.** Terraform reads it via a
+> `data "azurerm_resource_group"` source (read-only) and will **error** if it is
+> not found — it does not create the resource group.
+
+```pwsh
+az login
+az account set --subscription "<your-subscription-id>"
+
+cd infra
+Copy-Item terraform.tfvars.example terraform.tfvars   # then edit values
+$env:TF_VAR_admin_password = "<strong-password>"      # keep secrets out of files
+
+terraform init
+terraform validate
+terraform plan
+terraform apply        # type "yes" to confirm
+```
+
+Read the connection details back out:
+
+```pwsh
+terraform output server_fqdn      # -> DB_HOST
+terraform output database_name    # -> DB_NAME
+```
+
+### Option B — Manual Azure CLI
+
+#### Development (free tier)
 ```bash
 az group create --name jauntdetour-rg --location eastus
 
@@ -32,7 +70,7 @@ az postgres flexible-server create \
   --tags Environment=Development Project=JauntDetour
 ```
 
-### Production
+#### Production
 ```bash
 az postgres flexible-server create \
   --resource-group jauntdetour-rg \
@@ -76,28 +114,33 @@ psql "...dbname=jauntdetour..." -c "\dt"
 ### Install the driver
 ```bash
 cd backend
-npm install pg dotenv
+npm install   # pg and dotenv are declared in package.json
 ```
 
-### Connection module — `backend/config/database.js`
+### Connection pool — `backend/app/db/pool.js`
+
+A single shared `pg` Pool is created from environment variables. Pooling keeps a
+set of open connections ready so each request reuses one instead of paying a fresh
+TCP + TLS + auth handshake. Azure requires SSL.
+
 ```javascript
-const { Pool } = require('pg');
-require('dotenv').config();
+const { Pool } = require("pg");
+const logger = require("../utils/logger");
 
 const pool = new Pool({
   host: process.env.DB_HOST,
   port: process.env.DB_PORT || 5432,
   database: process.env.DB_NAME,
   user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,        // from Key Vault in production
-  ssl: { rejectUnauthorized: true },        // Azure requires SSL
+  password: process.env.DB_PASSWORD, // from Key Vault in production
+  ssl: process.env.DB_SSL === "false" ? false : { rejectUnauthorized: true },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
 });
 
-pool.on('error', (err) => {
-  console.error('Unexpected idle client error', err);
+pool.on("error", (err) => {
+  logger.error("Unexpected error on idle PostgreSQL client", err);
   process.exit(-1);
 });
 
@@ -108,151 +151,107 @@ module.exports = {
 };
 ```
 
-### Environment variables — `backend/.env.example`
+### Environment variables — root `.env`
+
+Copy `.env.example` to `.env` and fill in the values from the Terraform outputs:
+
 ```bash
 DB_HOST=jauntdetour-db-dev.postgres.database.azure.com
 DB_PORT=5432
 DB_NAME=jauntdetour
 DB_USER=jauntdetour_app
 DB_PASSWORD=            # local dev only; use Key Vault in production
-GOOGLE_API_KEY=
-NODE_ENV=development
 ```
 
-Add `.env` to `.gitignore`. In production, inject secrets from **Azure Key Vault**, not files.
+`.env` is gitignored. In production, inject secrets from **Azure Key Vault**, not files.
 
 ---
 
 ## 4. Data access layer
 
-User records key off the Entra `external_id` (the token `sub` claim) — there is no password column. See [../authentication/authentication.md](../authentication/authentication.md).
+User records key off the Entra `external_id` (the token `sub` claim) — there is no
+password column. See [../authentication/authentication.md](../authentication/authentication.md).
 
-### `backend/app/models/User.js`
+Repositories are ES classes with a **constructor-injected pool**, which keeps them
+trivial to unit test (pass a mock pool). All queries use parameterized placeholders
+(`$1, $2, ...`) to prevent SQL injection.
+
+### `backend/app/repositories/UserRepository.js`
 ```javascript
-const db = require('../../config/database');
+const logger = require("../utils/logger");
 
-class User {
-  // Create or fetch the user that matches a verified token's subject claim.
-  static async upsertByExternalId({ externalId, email, displayName }) {
-    const query = `
-      INSERT INTO users (external_id, email, display_name)
-      VALUES ($1, $2, $3)
-      ON CONFLICT (external_id) DO UPDATE
-        SET email = EXCLUDED.email,
-            last_login = CURRENT_TIMESTAMP
-      RETURNING user_id, external_id, email, display_name, preferences
+class UserRepository {
+  constructor(pool) {
+    if (!pool || typeof pool.query !== "function") {
+      throw new Error("UserRepository requires a database pool with a query method");
+    }
+    this.pool = pool;
+  }
+
+  async createUser({ externalId, email, displayName = null, preferences = {} }) {
+    const text = `
+      INSERT INTO users (external_id, email, display_name, preferences)
+      VALUES ($1, $2, $3, $4)
+      RETURNING user_id, external_id, email, display_name, preferences,
+                is_active, created_at, updated_at, last_login
     `;
-    const result = await db.query(query, [externalId, email, displayName]);
+    const result = await this.pool.query(text, [externalId, email, displayName, preferences]);
     return result.rows[0];
   }
 
-  static async findById(userId) {
-    const result = await db.query(
-      'SELECT * FROM users WHERE user_id = $1 AND is_active = true',
-      [userId]
+  async getUserByExternalId(externalId) {
+    const result = await this.pool.query(
+      "SELECT * FROM users WHERE external_id = $1",
+      [externalId]
     );
     return result.rows[0] || null;
   }
+
+  // getUserById, getUserByEmail, updateUser,
+  // deleteUser (soft: is_active = false), hardDeleteUser (cascade) ...
 }
 
-module.exports = User;
+module.exports = UserRepository;
 ```
 
-### `backend/app/models/Trip.js`
+Wire it up with the shared pool:
+
 ```javascript
-const db = require('../../config/database');
-
-class Trip {
-  static async create({ userId, tripName, origin, destination, routePolyline, distanceMeters, durationSeconds, departureTime }) {
-    const query = `
-      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, departure_time)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING trip_id, trip_name, origin, destination, distance_meters, duration_seconds, status, created_at
-    `;
-    const values = [userId, tripName, JSON.stringify(origin), JSON.stringify(destination),
-                    routePolyline, distanceMeters, durationSeconds, departureTime];
-    const result = await db.query(query, values);
-    return result.rows[0];
-  }
-
-  // Always scope by user_id — the authorization boundary.
-  static async findByUserId(userId) {
-    const result = await db.query(
-      `SELECT trip_id, trip_name, origin, destination, distance_meters,
-              duration_seconds, status, created_at
-       FROM trips WHERE user_id = $1 ORDER BY created_at DESC`,
-      [userId]
-    );
-    return result.rows;
-  }
-
-  static async findByIdWithDetours(tripId, userId) {
-    const query = `
-      SELECT t.*,
-        COALESCE(json_agg(
-          json_build_object(
-            'detour_id', d.detour_id, 'place_name', d.place_name,
-            'place_type', d.place_type, 'latitude', d.latitude,
-            'longitude', d.longitude, 'rating', d.rating,
-            'position_on_route', d.position_on_route, 'notes', d.notes
-          ) ORDER BY d.position_on_route
-        ) FILTER (WHERE d.detour_id IS NOT NULL), '[]') AS detours
-      FROM trips t
-      LEFT JOIN detours d ON t.trip_id = d.trip_id
-      WHERE t.trip_id = $1 AND t.user_id = $2
-      GROUP BY t.trip_id
-    `;
-    const result = await db.query(query, [tripId, userId]);
-    return result.rows[0] || null;
-  }
-}
-
-module.exports = Trip;
+const pool = require("../db/pool");
+const UserRepository = require("../repositories/UserRepository");
+const users = new UserRepository(pool);
 ```
 
-### `backend/app/models/Detour.js`
-```javascript
-const db = require('../../config/database');
-
-class Detour {
-  static async create({ tripId, placeId, placeName, placeType, latitude, longitude, address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes }) {
-    const query = `
-      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude,
-                           address, position_on_route, rating, price_level, stop_duration_minutes, notes)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-      RETURNING detour_id, place_name, place_type, latitude, longitude, rating, created_at
-    `;
-    const values = [tripId, placeId, placeName, placeType, latitude, longitude,
-                    address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes];
-    const result = await db.query(query, values);
-    return result.rows[0];
-  }
-}
-
-module.exports = Detour;
-```
-
-> Note: there is no `findNearby` / `ST_DWithin` method. Proximity search is performed by the Google Places API in `placesAPI.js`; the database only stores the chosen results.
+`deleteUser` performs a **soft delete** (`is_active = false`) for routine
+deactivation; `hardDeleteUser` performs a permanent `DELETE` that cascades to the
+user's trips and detours, intended for GDPR account erasure. Trip and detour
+repositories follow the same pattern and are always scoped by `user_id` — the
+authorization boundary.
 
 ---
 
 ## 5. Testing
 
-```javascript
-// backend/app/models/__tests__/Trip.test.js
-const db = require('../../../config/database');
-jest.mock('../../../config/database');
-const Trip = require('../Trip');
+Unit tests inject a mock pool, so no live database is needed. Assert on the SQL
+text and parameter array captured in `pool.query.mock.calls`.
 
-test('findByUserId scopes by user and orders by created_at', async () => {
-  db.query.mockResolvedValue({ rows: [{ trip_id: 't1' }] });
-  const trips = await Trip.findByUserId('u1');
-  expect(trips).toHaveLength(1);
-  expect(db.query.mock.calls[0][1]).toEqual(['u1']);
+```javascript
+// backend/app/repositories/UserRepository.test.js
+const UserRepository = require("./UserRepository");
+
+test("createUser inserts with parameterized values", async () => {
+  const pool = { query: jest.fn().mockResolvedValue({ rows: [{ user_id: "u1" }] }) };
+  const repo = new UserRepository(pool);
+
+  await repo.createUser({ externalId: "x", email: "a@example.com" });
+
+  const [sql, params] = pool.query.mock.calls[0];
+  expect(sql).toContain("INSERT INTO users");
+  expect(params).toEqual(["x", "a@example.com", null, {}]);
 });
 ```
 
-Run with `npm test`.
+Run with `npm test` (from `backend/`).
 
 ---
 

--- a/docs/database/implementation-guide.md
+++ b/docs/database/implementation-guide.md
@@ -1,0 +1,275 @@
+# PostgreSQL Implementation Guide
+
+**Target:** Azure Database for PostgreSQL (Flexible Server), PostgreSQL 14+
+**Last Updated:** June 2, 2026
+
+A concise, step-by-step path from provisioning to a working Node.js integration. No PostGIS — all geospatial work stays in the Google Maps APIs.
+
+---
+
+## Prerequisites
+
+- Azure CLI 2.30+, `psql` (PostgreSQL 14+), Node.js 16+
+- An active Azure subscription with Contributor/Owner on the target resource group
+
+---
+
+## 1. Provision the server
+
+### Development (free tier)
+```bash
+az group create --name jauntdetour-rg --location eastus
+
+az postgres flexible-server create \
+  --resource-group jauntdetour-rg \
+  --name jauntdetour-db-dev \
+  --location eastus \
+  --admin-user dbadmin \
+  --admin-password "$DB_ADMIN_PASSWORD" \
+  --sku-name Standard_B1ms --tier Burstable \
+  --storage-size 32 --version 14 \
+  --backup-retention 7 --high-availability Disabled \
+  --tags Environment=Development Project=JauntDetour
+```
+
+### Production
+```bash
+az postgres flexible-server create \
+  --resource-group jauntdetour-rg \
+  --name jauntdetour-db-prod \
+  --location eastus \
+  --admin-user dbadmin \
+  --admin-password "$DB_ADMIN_PASSWORD" \
+  --sku-name Standard_D2s_v3 --tier GeneralPurpose \
+  --storage-size 128 --version 14 \
+  --public-access None \
+  --backup-retention 14 --geo-redundant-backup Enabled \
+  --high-availability ZoneRedundant \
+  --tags Environment=Production Project=JauntDetour
+```
+
+> Pass `--admin-password` from an environment variable or Azure Key Vault — never hard-code it.
+
+For production, prefer **VNet integration** (`--public-access None` + a delegated subnet) over public firewall rules.
+
+---
+
+## 2. Apply the schema
+
+```bash
+# Create the database, then apply the schema (no PostGIS extension required)
+psql "host=jauntdetour-db-dev.postgres.database.azure.com port=5432 \
+      dbname=jauntdetour user=dbadmin sslmode=require" \
+  < docs/database/schema.sql
+```
+
+The schema enables only `pgcrypto` (for `gen_random_uuid()`). Verify tables:
+
+```bash
+psql "...dbname=jauntdetour..." -c "\dt"
+```
+
+---
+
+## 3. Node.js integration
+
+### Install the driver
+```bash
+cd backend
+npm install pg dotenv
+```
+
+### Connection module — `backend/config/database.js`
+```javascript
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT || 5432,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,        // from Key Vault in production
+  ssl: { rejectUnauthorized: true },        // Azure requires SSL
+  max: 20,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000,
+});
+
+pool.on('error', (err) => {
+  console.error('Unexpected idle client error', err);
+  process.exit(-1);
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  getClient: () => pool.connect(),
+  pool,
+};
+```
+
+### Environment variables — `backend/.env.example`
+```bash
+DB_HOST=jauntdetour-db-dev.postgres.database.azure.com
+DB_PORT=5432
+DB_NAME=jauntdetour
+DB_USER=jauntdetour_app
+DB_PASSWORD=            # local dev only; use Key Vault in production
+GOOGLE_API_KEY=
+NODE_ENV=development
+```
+
+Add `.env` to `.gitignore`. In production, inject secrets from **Azure Key Vault**, not files.
+
+---
+
+## 4. Data access layer
+
+User records key off the Entra `external_id` (the token `sub` claim) — there is no password column. See [../authentication/authentication.md](../authentication/authentication.md).
+
+### `backend/app/models/User.js`
+```javascript
+const db = require('../../config/database');
+
+class User {
+  // Create or fetch the user that matches a verified token's subject claim.
+  static async upsertByExternalId({ externalId, email, displayName }) {
+    const query = `
+      INSERT INTO users (external_id, email, display_name)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (external_id) DO UPDATE
+        SET email = EXCLUDED.email,
+            last_login = CURRENT_TIMESTAMP
+      RETURNING user_id, external_id, email, display_name, preferences
+    `;
+    const result = await db.query(query, [externalId, email, displayName]);
+    return result.rows[0];
+  }
+
+  static async findById(userId) {
+    const result = await db.query(
+      'SELECT * FROM users WHERE user_id = $1 AND is_active = true',
+      [userId]
+    );
+    return result.rows[0] || null;
+  }
+}
+
+module.exports = User;
+```
+
+### `backend/app/models/Trip.js`
+```javascript
+const db = require('../../config/database');
+
+class Trip {
+  static async create({ userId, tripName, origin, destination, routePolyline, distanceMeters, durationSeconds, departureTime }) {
+    const query = `
+      INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, departure_time)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING trip_id, trip_name, origin, destination, distance_meters, duration_seconds, status, created_at
+    `;
+    const values = [userId, tripName, JSON.stringify(origin), JSON.stringify(destination),
+                    routePolyline, distanceMeters, durationSeconds, departureTime];
+    const result = await db.query(query, values);
+    return result.rows[0];
+  }
+
+  // Always scope by user_id — the authorization boundary.
+  static async findByUserId(userId) {
+    const result = await db.query(
+      `SELECT trip_id, trip_name, origin, destination, distance_meters,
+              duration_seconds, status, created_at
+       FROM trips WHERE user_id = $1 ORDER BY created_at DESC`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  static async findByIdWithDetours(tripId, userId) {
+    const query = `
+      SELECT t.*,
+        COALESCE(json_agg(
+          json_build_object(
+            'detour_id', d.detour_id, 'place_name', d.place_name,
+            'place_type', d.place_type, 'latitude', d.latitude,
+            'longitude', d.longitude, 'rating', d.rating,
+            'position_on_route', d.position_on_route, 'notes', d.notes
+          ) ORDER BY d.position_on_route
+        ) FILTER (WHERE d.detour_id IS NOT NULL), '[]') AS detours
+      FROM trips t
+      LEFT JOIN detours d ON t.trip_id = d.trip_id
+      WHERE t.trip_id = $1 AND t.user_id = $2
+      GROUP BY t.trip_id
+    `;
+    const result = await db.query(query, [tripId, userId]);
+    return result.rows[0] || null;
+  }
+}
+
+module.exports = Trip;
+```
+
+### `backend/app/models/Detour.js`
+```javascript
+const db = require('../../config/database');
+
+class Detour {
+  static async create({ tripId, placeId, placeName, placeType, latitude, longitude, address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes }) {
+    const query = `
+      INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude,
+                           address, position_on_route, rating, price_level, stop_duration_minutes, notes)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+      RETURNING detour_id, place_name, place_type, latitude, longitude, rating, created_at
+    `;
+    const values = [tripId, placeId, placeName, placeType, latitude, longitude,
+                    address, positionOnRoute, rating, priceLevel, stopDurationMinutes, notes];
+    const result = await db.query(query, values);
+    return result.rows[0];
+  }
+}
+
+module.exports = Detour;
+```
+
+> Note: there is no `findNearby` / `ST_DWithin` method. Proximity search is performed by the Google Places API in `placesAPI.js`; the database only stores the chosen results.
+
+---
+
+## 5. Testing
+
+```javascript
+// backend/app/models/__tests__/Trip.test.js
+const db = require('../../../config/database');
+jest.mock('../../../config/database');
+const Trip = require('../Trip');
+
+test('findByUserId scopes by user and orders by created_at', async () => {
+  db.query.mockResolvedValue({ rows: [{ trip_id: 't1' }] });
+  const trips = await Trip.findByUserId('u1');
+  expect(trips).toHaveLength(1);
+  expect(db.query.mock.calls[0][1]).toEqual(['u1']);
+});
+```
+
+Run with `npm test`.
+
+---
+
+## 6. Production checklist
+
+- [ ] Provision General Purpose tier with zone-redundant HA and geo-redundant backups.
+- [ ] VNet integration / private endpoint — no public access.
+- [ ] Secrets in **Azure Key Vault**, injected at runtime.
+- [ ] Least-privilege `jauntdetour_app` DB user (not `dbadmin`).
+- [ ] Parameterized queries everywhere ( `$1, $2` ) — never string concatenation.
+- [ ] Azure Monitor alerts on CPU, storage, and connection limits.
+- [ ] Quarterly point-in-time restore drill.
+
+---
+
+## Resources
+
+- [Azure PostgreSQL docs](https://docs.microsoft.com/azure/postgresql/)
+- [node-postgres (pg)](https://node-postgres.com/)
+- [PostgreSQL JSONB](https://www.postgresql.org/docs/current/datatype-json.html)

--- a/docs/database/schema.sql
+++ b/docs/database/schema.sql
@@ -1,0 +1,145 @@
+-- ============================================================================
+-- JauntDetour Database Schema
+-- Database: Azure Database for PostgreSQL (Flexible Server), PostgreSQL 14+
+-- No PostGIS / spatial extensions: Google Maps APIs handle all geospatial work.
+-- Authentication: Microsoft Entra External ID (credentials are NOT stored here).
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Extensions
+-- ----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";  -- gen_random_uuid()
+
+-- ----------------------------------------------------------------------------
+-- Users
+-- Profile only. Authentication is delegated to Microsoft Entra External ID;
+-- we store the provider's stable subject ("sub") claim as external_id.
+-- ----------------------------------------------------------------------------
+CREATE TABLE users (
+    user_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id  VARCHAR(255) UNIQUE NOT NULL,        -- Entra "sub" claim
+    email        VARCHAR(255) UNIQUE NOT NULL,
+    display_name VARCHAR(150),
+    created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    last_login   TIMESTAMPTZ,
+    is_active    BOOLEAN DEFAULT true,
+    preferences  JSONB DEFAULT '{}'::jsonb,           -- theme, notifications, etc.
+    CONSTRAINT email_format CHECK (email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+);
+
+-- ----------------------------------------------------------------------------
+-- Trips
+-- Saved road trips. Google API responses stored as JSONB.
+-- ----------------------------------------------------------------------------
+CREATE TABLE trips (
+    trip_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id          UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    trip_name        VARCHAR(255) NOT NULL,
+    origin           JSONB NOT NULL,                  -- {lat, lng, address}
+    destination      JSONB NOT NULL,                  -- {lat, lng, address}
+    route_polyline   TEXT,                            -- Google encoded polyline
+    distance_meters  INTEGER,                         -- cached from Directions API
+    duration_seconds INTEGER,                         -- cached from Directions API
+    departure_time   TIMESTAMPTZ,
+    status           VARCHAR(50) DEFAULT 'planned',
+    created_at       TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    metadata         JSONB DEFAULT '{}'::jsonb,
+    CONSTRAINT valid_status   CHECK (status IN ('planned','active','completed','cancelled')),
+    CONSTRAINT valid_distance CHECK (distance_meters IS NULL OR distance_meters > 0),
+    CONSTRAINT valid_duration CHECK (duration_seconds IS NULL OR duration_seconds > 0)
+);
+
+-- ----------------------------------------------------------------------------
+-- Detours
+-- Points of interest saved along a trip. Plain lat/lng (no spatial index):
+-- proximity search is performed by Google Places, not the database.
+-- ----------------------------------------------------------------------------
+CREATE TABLE detours (
+    detour_id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id                           UUID NOT NULL REFERENCES trips(trip_id) ON DELETE CASCADE,
+    place_id                          VARCHAR(255),     -- Google Places ID
+    place_name                        VARCHAR(255) NOT NULL,
+    place_type                        VARCHAR(100),     -- restaurant, park, etc.
+    latitude                          DECIMAL(10, 8) NOT NULL,
+    longitude                         DECIMAL(11, 8) NOT NULL,
+    address                           VARCHAR(500),
+    position_on_route                 FLOAT,            -- normalized 0.0-1.0
+    estimated_detour_duration_seconds INTEGER,
+    estimated_detour_distance_meters  INTEGER,
+    rating                            DECIMAL(2,1),     -- Google rating 0.0-5.0
+    price_level                       INTEGER,          -- 1-4
+    stop_duration_minutes             INTEGER DEFAULT 30,
+    visit_time                        TIMESTAMPTZ,
+    notes                             TEXT,
+    created_at                        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at                        TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    metadata                          JSONB DEFAULT '{}'::jsonb,
+    CONSTRAINT valid_latitude    CHECK (latitude BETWEEN -90 AND 90),
+    CONSTRAINT valid_longitude   CHECK (longitude BETWEEN -180 AND 180),
+    CONSTRAINT valid_position    CHECK (position_on_route IS NULL OR (position_on_route >= 0.0 AND position_on_route <= 1.0)),
+    CONSTRAINT valid_rating      CHECK (rating IS NULL OR (rating >= 0.0 AND rating <= 5.0)),
+    CONSTRAINT valid_price_level CHECK (price_level IS NULL OR (price_level BETWEEN 1 AND 4))
+);
+
+-- ----------------------------------------------------------------------------
+-- Indexes (B-tree only; no spatial/GiST indexes needed)
+-- ----------------------------------------------------------------------------
+CREATE INDEX idx_users_external_id  ON users(external_id);
+CREATE INDEX idx_trips_user_id      ON trips(user_id);
+CREATE INDEX idx_trips_status       ON trips(status);
+CREATE INDEX idx_trips_created_at   ON trips(created_at DESC);
+CREATE INDEX idx_trips_user_status  ON trips(user_id, status) INCLUDE (trip_name, created_at);
+CREATE INDEX idx_detours_trip_id    ON detours(trip_id);
+CREATE INDEX idx_detours_place_type ON detours(place_type);
+
+-- ----------------------------------------------------------------------------
+-- Auto-update updated_at
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_users_updated_at   BEFORE UPDATE ON users   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_trips_updated_at   BEFORE UPDATE ON trips   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_detours_updated_at BEFORE UPDATE ON detours FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ----------------------------------------------------------------------------
+-- Sample data (testing)
+-- ----------------------------------------------------------------------------
+INSERT INTO users (external_id, email, display_name, preferences)
+VALUES ('entra-sub-demo-0001', 'demo@jauntdetour.com', 'Demo User',
+        '{"theme": "light", "notifications": true}'::jsonb);
+
+INSERT INTO trips (user_id, trip_name, origin, destination, route_polyline, distance_meters, duration_seconds, status)
+SELECT user_id,
+       'San Francisco to Yosemite',
+       '{"lat": 37.7749, "lng": -122.4194, "address": "San Francisco, CA"}'::jsonb,
+       '{"lat": 37.8651, "lng": -119.5383, "address": "Yosemite National Park, CA"}'::jsonb,
+       'encoded_polyline_placeholder', 280000, 12600, 'planned'
+FROM users WHERE email = 'demo@jauntdetour.com';
+
+INSERT INTO detours (trip_id, place_id, place_name, place_type, latitude, longitude, address, position_on_route, rating, stop_duration_minutes, notes)
+SELECT trip_id, 'ChIJabcdefg123456789', 'Yosemite Falls Trailhead', 'park',
+       37.74550000, -119.59670000, 'Yosemite Valley, CA', 0.85, 4.8, 120,
+       'Popular waterfall hike - bring water and sunscreen!'
+FROM trips WHERE trip_name = 'San Francisco to Yosemite';
+
+-- ----------------------------------------------------------------------------
+-- Application user (least privilege) — set a real secret from Key Vault
+-- ----------------------------------------------------------------------------
+-- CREATE USER jauntdetour_app WITH PASSWORD '<from Key Vault>';
+-- GRANT CONNECT ON DATABASE jauntdetour TO jauntdetour_app;
+-- GRANT USAGE ON SCHEMA public TO jauntdetour_app;
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO jauntdetour_app;
+-- ALTER DEFAULT PRIVILEGES IN SCHEMA public
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO jauntdetour_app;
+
+-- ============================================================================
+-- End of Schema
+-- ============================================================================

--- a/docs/database/selection.md
+++ b/docs/database/selection.md
@@ -1,0 +1,115 @@
+# Database Selection for JauntDetour
+
+**Status:** Decided
+**Decision:** Azure Database for PostgreSQL (Flexible Server) — relational, no PostGIS
+**Last Updated:** June 2, 2026
+
+---
+
+## Decision
+
+Use **Azure Database for PostgreSQL (Flexible Server)** as the system of record for users, trips, and detours. Start on the free/Burstable tier for development and scale to General Purpose with zone-redundant HA for production.
+
+We deliberately **do not** use PostGIS or any spatial extension. Google Maps APIs perform all routing and place-search work at request time; the database only saves and loads the results.
+
+---
+
+## Why this fits JauntDetour
+
+JauntDetour is fundamentally a **"Google Maps API wrapper + save/load"** application:
+
+- `placesAPI.js` calls Google Places for nearby detours (lat/lng + radius).
+- `routeAPI.js` calls Google Directions for routes and distances.
+- The database persists user accounts, saved trips, and chosen detours — nothing more.
+
+This makes the data model a straightforward relational one (`users → trips → detours`), with JSON storage for the Google API payloads.
+
+| Requirement | Why PostgreSQL fits |
+|-------------|---------------------|
+| Store Google API JSON (origin, destination, polyline, places) | `JSONB` is a first-class, indexable binary JSON type |
+| "Get my trips" / "get my detours" queries | Simple, indexed foreign-key lookups by `user_id` / `trip_id` |
+| Node.js backend | Mature `pg` driver; no .NET dependency to justify Azure SQL |
+| Cost | Cheapest option at every tier in our analysis (see cost-comparison.md) |
+| Future semantic search for the AI agent | `pgvector` + the `azure_ai` extension add vector search in-place, no second datastore |
+| Map rendering | Plain `DECIMAL` lat/lng columns — no spatial index needed |
+
+---
+
+## Options considered
+
+| Option | Verdict |
+|--------|---------|
+| **Azure PostgreSQL** ✅ | Relational fit, cheapest, best JSON support, clean path to `pgvector` for the agent. **Chosen.** |
+| Azure SQL Database | Defensible, but its main edge (deep .NET integration) is unused, and JSON handling is more bolted-on. JSONB and cost favor PostgreSQL. |
+| Azure Cosmos DB | Capable but NoSQL — fights our relational shape, loses foreign keys/cascades, and is the most expensive and hardest to cost-predict (RU model). |
+| MongoDB Atlas | Third-party, document model mismatch, weaker Azure integration. |
+
+We do **not** choose a database to be a Foundry "knowledge source." Foundry agents reach app data through a **function/OpenAPI tool** doing parameterized, `user_id`-scoped queries — which works identically against any of these databases. PostgreSQL wins on data-shape fit, cost, and the in-place vector path.
+
+---
+
+## Data model
+
+Three entities with simple 1:N relationships:
+
+```
+Users (1) ──< (N) Trips (1) ──< (N) Detours
+```
+
+Key design points:
+
+- **UUID primary keys** — prevent enumeration, safe for distributed generation.
+- **`external_id` instead of `password_hash`** — authentication is delegated to Microsoft Entra External ID (see ../authentication/authentication.md). We store the provider's `sub` claim, not credentials.
+- **`JSONB` for Google payloads** — `origin`, `destination`, `metadata`, user `preferences`.
+- **Plain `DECIMAL` lat/lng** on detours — sufficient for map display; no spatial index.
+- **Cached Google values** — `route_polyline`, `distance_meters`, `duration_seconds` to reduce API calls.
+- **B-tree indexes** on foreign keys, status, and created date. No GiST/spatial indexes.
+
+See [schema.sql](schema.sql) for the full definition.
+
+---
+
+## Query patterns
+
+| Pattern | Query | Notes |
+|---------|-------|-------|
+| User's trip list | `WHERE user_id = $1 ORDER BY created_at DESC` | Most frequent; covered by composite index |
+| Trip with detours | `WHERE trip_id = $1` + `json_agg` of detours | Foreign-key lookup |
+| Find a user (post-auth) | `WHERE external_id = $1` | Resolves token subject to a row |
+| Find nearby places | ❌ Not a DB query | Google Places API handles this |
+
+---
+
+## Backup & disaster recovery
+
+PostgreSQL Flexible Server provides:
+
+- Automated backups, 7–35 day retention, point-in-time restore.
+- Optional geo-redundant backup storage for cross-region recovery.
+- Zone-redundant HA (automatic failover) in production.
+
+| Tier | Use | RPO / RTO |
+|------|-----|-----------|
+| Dev (Burstable, 7-day backups, no HA) | development | ~minutes / ~1–2 h |
+| Prod (General Purpose, geo-redundant, zone-redundant HA) | production | <5 min / <1 min failover |
+
+---
+
+## Cost summary
+
+| Year | Scale | Monthly | Annual |
+|------|-------|---------|--------|
+| Year 1 | Dev → small | $0 (free tier) | $0 |
+| Year 2 | 10K users, 10 GB | ~$152 | ~$1,824 |
+| Year 3 | 50K users, 50 GB | ~$305 | ~$3,660 |
+
+**3-year TCO: ~$5,484** — the lowest of all options evaluated. Full breakdown in [cost-comparison.md](cost-comparison.md).
+
+---
+
+## Next steps
+
+1. Provision free-tier PostgreSQL and apply [schema.sql](schema.sql).
+2. Integrate with the Node.js backend (see [implementation-guide.md](implementation-guide.md)).
+3. Wire authentication via Entra External ID (see [../authentication/authentication.md](../authentication/authentication.md)).
+4. Revisit `pgvector` if/when we add semantic agent features.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.5",
       "dependencies": {
         "@fluentui/react-components": "^9.74.3",
+        "@fluentui/react-icons": "^2.0.331",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@vis.gl/react-google-maps": "1.5.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "1.1.5",
       "dependencies": {
+        "@fluentui/react-components": "^9.74.3",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@vis.gl/react-google-maps": "1.5.4",
@@ -2077,6 +2078,21 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "license": "MIT",
@@ -2142,6 +2158,1586 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.4.0.tgz",
+      "integrity": "sha512-NwhNNwCTbXYdLYwa6Ha484qCLHgRFo5vOv7BGaq0REcY2rkgwcDHVlbchwsGV7D3XgTZCjzDu54SSPmk5NOxXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
+      "integrity": "sha512-F7xVaP0OR7JMCxrBwI3ryNhKof9Yi2c6RhYPsQy7rh2+KMGLGgYLsrDJyHmSejjxp4Bs11plXGdU38SN5j1hgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.142",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.142.tgz",
+      "integrity": "sha512-YrbMX1wF7huOByxP2J+2aUWatpODd1MXhqam95oeLUnoJUViBK6ZZuBYba7m0OTsRMUA4pB1WfjvuIGsnSQKtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.17.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
+      "integrity": "sha512-f5qSP5aD2ZbYgQn4hCjQzqh8mHJNeN/vsC9Nwth5uJlGNdIAPbPO+dXVC18DkYqNU8O9A5Ae/uJPRbxoH23zbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.11.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.3.tgz",
+      "integrity": "sha512-O8PoDUf1OUXDviECFvxdxo88kCEJLlP4TtCXyE58PKuAywrVeqmOA7eNy6/xhaGVuyDO8l9YJh05sYkyLiNLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
+      "integrity": "sha512-jxS6H6+KCk62MeueCf7cT2fRbdnN6h/lCOIyXWJLpPf9Mx+LWWP3KAfKik3BuDY28oy1pDYIuvFucDL+OMAb/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.4.tgz",
+      "integrity": "sha512-KcxyQAC+xTO/n2BMBj2lLKgQL2/eyTlkUhElHv9SKqP29Ks8EPYSovYpDtSfbtx8Dle+8NSUnhAvnO1kE/+fMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.10.1.tgz",
+      "integrity": "sha512-8Ow/ck9a/RLh3cJ6ZPF4asmGnNfqXr/Kengk+zTkMuppk+pFL3X6WEMrJLSOUKKZtx0Tp1UBuUPA6RL6Ive5WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.1.tgz",
+      "integrity": "sha512-4t65Y9pRW9W7kf/Yyc7S796le2WFKfXFTCuzfkFS+AHUM7JlrmMUOnQLA0i24WDNS6ArA0vo6EbMDnUcjgV9Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.9.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.10.tgz",
+      "integrity": "sha512-Ml3Vqi9KNA+mRG1FUiIjk/HCYqEjRZKSE8jQviMSQDLe4Rb6EO16FhtuFuIOz/ls47y/Sx6zTnb1t+HiFatpJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
+      "integrity": "sha512-VzePhN5Nz3D69Fu7SnPUCrMfkrbhfqGpNJDis85+W7dvOo9cyUou6yRreHsSzxVkRyE9swcA1LnsKJS6oVn9ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.18.tgz",
+      "integrity": "sha512-zbsQ+hVJeGwXVTjneA42i4UuHRACfcTnBs3BUcDT22lBDQjJxhYYZzmj5ksM92M2ZU0fMHV8K5OfSyCnZU5mqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.17.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.3.tgz",
+      "integrity": "sha512-QuWcM6fvqnfUzpkJApQbXfbIQ6iQkMGgrsdwmJHkB4Q/E6zT0aLZoEjEx2P5QkMz9m5D7LzeZWmFIOEFq8SzFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.74.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.3.tgz",
+      "integrity": "sha512-HdcLR4V9KZnduui0v4UfBIyJrO4G8eZf3W4iu8hssykl0hN1uneNNJmsVZExT8G8ybFen85ucqMOxCXQ3L7raw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.12.1",
+        "@fluentui/react-alert": "9.0.0-beta.142",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-breadcrumb": "^9.4.4",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-card": "^9.7.1",
+        "@fluentui/react-carousel": "^9.9.10",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-color-picker": "^9.2.18",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-image": "^9.4.3",
+        "@fluentui/react-infobutton": "9.0.0-beta.117",
+        "@fluentui/react-infolabel": "^9.4.22",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-list": "^9.6.16",
+        "@fluentui/react-menu": "^9.25.1",
+        "@fluentui/react-message-bar": "^9.7.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-nav": "^9.4.2",
+        "@fluentui/react-overflow": "^9.9.0",
+        "@fluentui/react-persona": "^9.7.5",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-progress": "^9.5.3",
+        "@fluentui/react-provider": "^9.22.18",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-rating": "^9.4.3",
+        "@fluentui/react-search": "^9.4.4",
+        "@fluentui/react-select": "^9.5.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-skeleton": "^9.7.4",
+        "@fluentui/react-slider": "^9.6.4",
+        "@fluentui/react-spinbutton": "^9.6.4",
+        "@fluentui/react-spinner": "^9.8.4",
+        "@fluentui/react-swatch-picker": "^9.5.4",
+        "@fluentui/react-switch": "^9.7.4",
+        "@fluentui/react-table": "^9.19.17",
+        "@fluentui/react-tabs": "^9.12.3",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tag-picker": "^9.9.0",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-teaching-popover": "^9.7.2",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-textarea": "^9.7.4",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-toast": "^9.8.1",
+        "@fluentui/react-toolbar": "^9.8.3",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-tree": "^9.16.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.114",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
+      "integrity": "sha512-A9YdkKonDlNSTnD8SCcSMhj0O6mAyMtXMERWH5mA1UqdtVxzJ4Y/muNd3Nk5rwAaLPUZ5HWMabtt2Ewa/BxARA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0",
+        "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.18.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
+      "integrity": "sha512-acW70/CxibJC19bQVbrJyxYiuIP9nX593O/Tya4x9wMEEcnTHZ6RW8liS6kbYYEL/AERYRuOYkLJ++TNniTxSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
+      "integrity": "sha512-uhqpu+JfSaLEqFNtDQFYFo/gM1QoRV2I1iUYTMsO2iqEis4zZmMsQETti7lTv29SITWIky3e8pkRoC6xyQBLsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
+      "integrity": "sha512-nZBWG0290IcCshpt2wjORDD8fLOsccSPdp0EW45CxK09/JR+4hkGbbIj8x14GW7GYu4RsGzk18OYga0kY+4j2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.3.tgz",
+      "integrity": "sha512-5PJXFTGS9W4CBJW6Nh2Tqe5p8RxMMCPbsIyIcYUXIxCZTXDGrx1jZ+af8lWKJFlcfWOlFxyK+QE14UXl+lqzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.331",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.331.tgz",
+      "integrity": "sha512-SY3Js+SW20T0qqt8uo1pWwi1njWisOzblIFqVoACql+ZrcSkXeifI+CQMCVdf5BZTAk0NnsUGb0pV9048SKpZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.3.tgz",
+      "integrity": "sha512-BQSsT3kVdpR3s02Zq9zpqj0NjaijWOVKPLBchp9XqWlygO15dkykNt2LRoHAkZRgpnlh2D8zBCw9qQ4ubzYNaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.117",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.117.tgz",
+      "integrity": "sha512-h01PQzH736I/7mhjNcYi8cFjspCqgSmQukXbzCsESzB1VnAkx8djqy5A8f/mV1HmHw7vBAIX8VdH+ddtx8WyXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.22.tgz",
+      "integrity": "sha512-K5W+g+HfGu5ltl5BGekZJB2z0ACLidIW7KFQ5Qj+UG1kpoB3G4q10HTm5gY74VjXP/GrM5RVx8IcnHRqyAfR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.4.tgz",
+      "integrity": "sha512-Lpdu0TBBSbv3VasaCz3blNeEgQS7XhtLTmiYXZj5g8Hrk7gNDJORDPYRrXcRjOUPGkV/InB4JY+GeXy2cYfOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
+      "integrity": "sha512-npqPWSJ2qciCRB4B/cyWyrTbf8V8Z2Kfr9HnZqrUBDgEvq72rRGb+gml6naxGNzhaT4NBLQLZmdPZqt+1wZ4ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.3.tgz",
+      "integrity": "sha512-/tYFciaorFym7Q2yDCdRYeP3JzLtw5eYt2yCvRlmBsugtKmn2f/kOu+b2cB37kWizbXjSdOGhCrTL8J1EUlIZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.3.tgz",
+      "integrity": "sha512-3Cd+UWgLpP6E6/NZaomCqZd965gruWXz2+gqUDfP7nBTLaCgOIuFQe0HAgSYi0ys4xli3cDtKeytqZJ7ReA6gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.6.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.16.tgz",
+      "integrity": "sha512-ZWsLxr1ZDe6hmvGLGlHQIPt1E70xsWHaHn+QGxB0XUxjq64SnxCDm4HCSPZ40MS3Hqgd4eQdnmPUS9d6odcYUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.1.tgz",
+      "integrity": "sha512-nP2bUB0Blrz5cqG6JnaHKznD2zGv134vuiCStk0op1/IErIPoU6wJj6H+unYVhFwyHCReyPZcp/pQZWkSWErJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.3.tgz",
+      "integrity": "sha512-LxcoTatsPPYj8Y5fx9QeJYOlXs6C4HIgmXTUaqNTCnFquNrcBHU4RtzUEq/6ssJ8jP/dy8Z03Bk4dE31RCV5MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
+      "integrity": "sha512-sbrNuauwI5uw20XOAqPjXBfgBqPreHc5AxU7bJ6yoLUHL2gDKo7KGAIvLEd216GX37mgPkb3dx9rarIVGx3uvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
+      "integrity": "sha512-9aNzHAHNdfbH/8/mYGy5YVrUOGnpiru3YrqQ7KhCRWXvlce7yV3WF5CzN1g/uNh3MFmKGwQeW4ui6xJOfEaI4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@fluentui/react-utilities": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.2.tgz",
+      "integrity": "sha512-1nZgZwZHgJ1P73E0Aw4UrTqri9BMSShI7otuktdATB5iHolDHE+9JtQjr3OQJ0QR+YyXgD8bMWiKvSa6p/Pdlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.9.0.tgz",
+      "integrity": "sha512-u8M7yqlzmvdYezlvVjGJUH38ik5fb59aSSGOsJyepnXM5HwnyFb9ecBwqAFAGi23lw+wz07V0aeYMEzK7q+slw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.4.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.5.tgz",
+      "integrity": "sha512-5MlVpl3+l+UW7vTf/d1qKP6EANBkxoXjmxmbNZpiuXjIE2QJFcVRBplWXwEPgt3GAOGnix1wPVkUgHElUJOCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.4.tgz",
+      "integrity": "sha512-Ofn4kh+WfC647n9ap0mtoN47eP0FsP/ZIjoZf1GfW6Co+A3zAZN+V7z6AayCPvbvdv8vKFQ0diHeUBrIu9Pz3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.8.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
+      "integrity": "sha512-od8RN6dny6N/qGFm2uv5UV+ugGOKupFeCIF+R0rU5SimSvix6o+wv5rPrH9JHRHFqjDIi5kRh9hk/rZfgsnuaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.3.tgz",
+      "integrity": "sha512-2j2k87k7yVX8LYd9q3SniXYVGqED6JFRdTNeyamDf4DTk9/ECxTl2nKTmKedkDodddR5RRXpAtJXv874Mi9eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "^0.2.3",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
+      "integrity": "sha512-GVrZzo9QCBOyMZC/K8Q4VTbD76hgG/Xuvhr8gyqOxnuHS9lTfnPJyEZ+T+F36LmpDb6d/XmDcwKjIcyg359ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.18.tgz",
+      "integrity": "sha512-kLtBaw6WIzyJJCmzeublw1ifidVPnpzGS39lYjzWdO6vHwuizs5ARCgwlGXxkB+kAlG2Mma/cPFUdYOa0J2f2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.4.tgz",
+      "integrity": "sha512-punC09igeQT+3Fc67lteh4ibzi8kIAQyKJSh8gdYj9mA4WlAIAcdUIQ4cnqT57hRoz0zuUtZGXpP1y2Kbr8M+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
+      "integrity": "sha512-kolMzzTl9/fg54jY1iy8w54BktkKFKGLaEeiESXAbtSZiUyNIj1BADMbIG3kysbVnhkYK8Q5h0kxZPsblrL/ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.4.tgz",
+      "integrity": "sha512-mLDqzL00XkSfJrtIZN34tQO2eBrjlPr33HuD9m3zUUQTq5g7wvA0LomT7m3RQPCJfV6FcOcMDmVfotqDUmttzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.3.tgz",
+      "integrity": "sha512-Qt4ovfXQRx11ou7OaoD0O1CNawfIzTS+Q39fX+wwLwL2yfn15oWnQGGVuQD3hWh0dh7k9cmOErRIrOKeI2wmXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
+      "integrity": "sha512-lIDvfFDldqOkmiwQU0ZEdnKnj/xxnNOGeuciuPz7ao+RyvDYf87Uo1RvTpMTveRCmpPC9z5rOX0EZZK+PhX7Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
+      "integrity": "sha512-hPpbAe6pT00FG717A7wV6QCx4+WizhvT9AI/IbEifjKTQ9uxKhodDQNk8WqEXA1ziFoSifDHGAKbcOn/kdr4Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
+      "integrity": "sha512-+t4B6anAWSXFJgmnNXOvC7S/ZWU23MOCDWrvRXKz3fki9fENN85HiRmlnx4fR8akYItVDscqQacRQRxAL8F0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
+      "integrity": "sha512-vgfsJosM6hMixFCR7mP856xKx0xXa5Vz4Y95t37Xne2yzJ47bTfqQ62kof7U1AyvaSEeDIp76cwKMyv3lQUD3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.4.tgz",
+      "integrity": "sha512-UwrtK3vP2Ruo2nAI+bbu56XhtpEIwi1XvHFXpVyRWGNQI9362lMS3F4CjwDlyPR24GeF+kEgZeF7QaruTVmagQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.4.tgz",
+      "integrity": "sha512-P4Xh+zrEOXO7mUmHDPo2G/yfQYwXWArrBOBKCLKOw6qI7KjuzBJxmy1Zqm94/drRr1EKVpBaZckSiT8X8N0TNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.19.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.17.tgz",
+      "integrity": "sha512-SPhAlS6yQ/53GB/1XUzCum63ktzmNaZVWswshr6SCo7oUERxdszr6xHJ5bSvgNczlApuLzZVz6Vnxe2s7+bsCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
+      "integrity": "sha512-CkQmrErImxvGDgrNIh+v0GbXzTKx1YSiBXYuFIhjdFaTnTk5CE79xwZp3mIkZK4SUns0HcH5wchjuO1L5LfcRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
+      "integrity": "sha512-napGx7dGdLoKoUpKlzc2Til43UMUTtr9J1GWrOFvCT6aZLTox5GjtoxQM/IPhcZ09jJOOUMbVF8ScA5u3/uyTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.14.1",
+        "tabster": "^8.8.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.9.0.tgz",
+      "integrity": "sha512-DYe0p4eFkCTi0HbKFWgr+MmaVhvggGnnUG4vTsgZ9zGADXPAkcVebjSGoF3LeYvRwp73t+qQRe8dT0lvBofTpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.2.tgz",
+      "integrity": "sha512-yJmUrx3b1m4OYoXGt1+hUgZzghoTuHGGHkXyTwmCUCKX7BKAXQBbOu0VHyxmG+VDkPhpO3773ObQCFXCdTavrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.2.tgz",
+      "integrity": "sha512-984lSUplfBiLTKpNSGvzPaBMmQ8pSM0u/Ucv4QoB2QB9U771pu8NtuNvtiuhQe5f6yC3wblIFHnTVrlZW66TWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.18.tgz",
+      "integrity": "sha512-iED0KJPtU44M5kByfg93n/Zwwky0BhyRHaWFcIeB6jsCVAeCf8kUSS2Nr+7zQocf60DFHgMF7y4XEl0rRe+PHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.4.tgz",
+      "integrity": "sha512-Zq2D8u2ssneLVY4OuvMWYT5Er3yAo3OKmTWmPNsJ6F9dISIc7UullDwuBoKYES943EBzSfNyKZQwCY7Bo1BGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.23",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
+      "integrity": "sha512-J9nKVwbwmBxDNrArgJ9GHypWH43WW0XJhNWvC6ED4dGrvgc8Rnw7bKxI7swG46OTMJNCkwrOnGNEu5YGkMigfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
+      "integrity": "sha512-/R12jBM1cllfvim9x+NxL4/5ObDdih42yHsswecVGhwK/rituz37UEWWr1MkapMCDnr/gVRVb4QEsbFXX3lpNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.3.tgz",
+      "integrity": "sha512-QDc5XQyODm0BIQ5VCbM59n0pEXNCMk2a9OQ7B5eDWoqnvTxj++ul1XQb6EF0libbkjFl7zTsaaHnhIOzsVEq0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.16.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.3.tgz",
+      "integrity": "sha512-Uf4ero9GhHoe8B6ZONKTIriPnd8cuyPFGXbPo+AG4t4vB5QO8qSZmwrR89btd2Xbr1zWQoMmJJFDn83S+3Te8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.26.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
+      "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.114",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
+      "integrity": "sha512-hD44CrZh84P1Rsd+ACPdmre3j20OevkoMKxMRzMXWlSIYKbT+m5I5yM3XxxSvKb1Qr77LeBPTTJs6apvMcfRiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.7.2",
       "license": "MIT",
@@ -2179,6 +3775,42 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.3.tgz",
+      "integrity": "sha512-FMnlwhtmCRWvXEg2j/6W90wzvW+PFqdrsWFslfmxwS6l9X73gO0dnndKphht9ZOsJODvmLdqlnU1Lh8igg2mKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.4.2",
+        "csstype": "^3.2.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.5.tgz",
+      "integrity": "sha512-7otiHiIqhdOdoSgNJdZenUR8hRljS5e2CecBVPrA3U9hLgRQzRjEMo3pPF/HJoHHo6cvdpHdqQH1HaFTJWgKeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/core": "^1.21.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "integrity": "sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3025,6 +4657,15 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3241,6 +4882,26 @@
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -5403,6 +7064,12 @@
       "version": "0.3.8",
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "license": "BSD-2-Clause"
@@ -5779,6 +7446,30 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.187",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -9414,6 +11105,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keyborg": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
+      "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "license": "MIT",
@@ -12328,6 +14025,15 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "funding": [
@@ -13281,6 +14987,12 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "license": "MIT",
@@ -13528,6 +15240,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tabster": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
+      "integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "^2.14.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fluentui/react-components": "^9.74.3",
+    "@fluentui/react-icons": "^2.0.331",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@vis.gl/react-google-maps": "1.5.4",
@@ -17,8 +18,8 @@
     "redux": "5.0.1"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "start": "GENERATE_SOURCEMAP=false PORT=3001 react-scripts --openssl-legacy-provider start",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --watchAll=false",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,10 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,json,css,md}\"",
     "eject": "react-scripts eject"
   },
+  "lint-staged": {
+    "src/**/*.{js,jsx,json,css,md}": "prettier --write",
+    "src/**/*.{js,jsx}": "eslint --fix"
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.5",
   "private": true,
   "dependencies": {
+    "@fluentui/react-components": "^9.74.3",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@vis.gl/react-google-maps": "1.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@fluentui/react-components": "^9.74.3",

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Header from "./header/Header";
 import AuthButton from "./header/AuthButton";
+import MyTrips from "./sidebar/MyTrips";
 import FooterMenu from "./footer-menu/FooterMenu";
 import MapContainer from "./MapContainer";
 import Sidebar from "./sidebar/Sidebar";
@@ -10,11 +11,14 @@ class Main extends React.Component {
   render() {
     return (
       <div className="app-container">
-        <AuthButton
-          user={this.props.user}
-          setUser={this.props.setUser}
-          clearUser={this.props.clearUser}
-        ></AuthButton>
+        <div className="app-toolbar">
+          <MyTrips></MyTrips>
+          <AuthButton
+            user={this.props.user}
+            setUser={this.props.setUser}
+            clearUser={this.props.clearUser}
+          ></AuthButton>
+        </div>
         <Header
           origin={this.props.origin}
           destination={this.props.destination}

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Header from "./header/Header";
+import AuthButton from "./header/AuthButton";
 import FooterMenu from "./footer-menu/FooterMenu";
 import MapContainer from "./MapContainer";
 import Sidebar from "./sidebar/Sidebar";
@@ -9,6 +10,11 @@ class Main extends React.Component {
   render() {
     return (
       <div className="app-container">
+        <AuthButton
+          user={this.props.user}
+          setUser={this.props.setUser}
+          clearUser={this.props.clearUser}
+        ></AuthButton>
         <Header
           origin={this.props.origin}
           destination={this.props.destination}
@@ -17,6 +23,9 @@ class Main extends React.Component {
           setRoute={this.props.setRoute}
           setTripSummary={this.props.setTripSummary}
           clearAll={this.props.clearAll}
+          user={this.props.user}
+          setUser={this.props.setUser}
+          clearUser={this.props.clearUser}
         ></Header>
         <Sidebar
           origin={this.props.origin}
@@ -124,6 +133,9 @@ Main.propTypes = {
   getDetourForm: PropTypes.func,
   clearAll: PropTypes.func,
   clearDetourOptions: PropTypes.func,
+  user: PropTypes.object,
+  setUser: PropTypes.func,
+  clearUser: PropTypes.func,
 };
 
 export default Main;

--- a/frontend/src/components/header/AuthButton.jsx
+++ b/frontend/src/components/header/AuthButton.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import PropTypes from "prop-types";
+import AuthRequester from "../../scripts/AuthRequester";
+
+/**
+ * AuthButton — sign-in / sign-out control.
+ *
+ * On mount it asks the backend who the current user is (via the session cookie)
+ * and stores the result in Redux. When signed out it shows "Sign in"; when
+ * signed in it shows the display name and "Sign out".
+ */
+class AuthButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.auth = new AuthRequester();
+    this.handleLogin = this.handleLogin.bind(this);
+    this.handleLogout = this.handleLogout.bind(this);
+  }
+
+  componentDidMount() {
+    // Resolve login state from the backend session on first render, syncing
+    // Redux to the backend's truth: set the user when signed in, clear it
+    // otherwise (getCurrentUser resolves to null on a 401 or any error).
+    this.auth.getCurrentUser().then((user) => {
+      if (user) {
+        this.props.setUser(user);
+      } else {
+        this.props.clearUser();
+      }
+    });
+  }
+
+  handleLogin() {
+    this.auth.login();
+  }
+
+  handleLogout() {
+    this.props.clearUser();
+    this.auth.logout();
+  }
+
+  render() {
+    const user = this.props.user;
+
+    if (user) {
+      const name = user.display_name || user.email;
+      return (
+        <div className="auth-button auth-button--signed-in">
+          <span className="auth-button__name">{name}</span>
+          <button type="button" onClick={this.handleLogout}>
+            Sign out
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="auth-button auth-button--signed-out">
+        <button type="button" onClick={this.handleLogin}>
+          Sign in
+        </button>
+      </div>
+    );
+  }
+}
+
+AuthButton.propTypes = {
+  user: PropTypes.object,
+  setUser: PropTypes.func.isRequired,
+  clearUser: PropTypes.func.isRequired,
+};
+
+export default AuthButton;

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,0 +1,150 @@
+import React, { useState, useCallback } from "react";
+import { useSelector } from "react-redux";
+import {
+  Button,
+  OverlayDrawer,
+  DrawerHeader,
+  DrawerHeaderTitle,
+  DrawerBody,
+  Card,
+  Text,
+  Spinner,
+} from "@fluentui/react-components";
+import TripRequester from "../../scripts/TripRequester";
+
+const PAGE_SIZE = 10;
+
+// origin/destination are stored as JSONB { address, lat, lng }; show the address.
+function formatEndpoint(point) {
+  if (!point) {
+    return "Unknown";
+  }
+  if (point.address) {
+    return point.address;
+  }
+  if (point.lat != null && point.lng != null) {
+    return `${point.lat}, ${point.lng}`;
+  }
+  return "Unknown";
+}
+
+/**
+ * MyTrips — a "My Trips" button (shown only when signed in) that opens a
+ * non-modal Fluent drawer listing the user's saved trips. The drawer overlays
+ * the map without a backdrop, so the map stays visible behind it. List-only for
+ * now; loading a trip onto the map is a later story.
+ */
+export default function MyTrips() {
+  const user = useSelector((state) => state.user);
+
+  const [open, setOpen] = useState(false);
+  const [trips, setTrips] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const load = useCallback((nextPage) => {
+    setLoading(true);
+    setError(false);
+    new TripRequester()
+      .listTrips(nextPage, PAGE_SIZE)
+      .then((data) => {
+        setTrips(data.trips || []);
+        setTotal(data.total || 0);
+        setPage(data.page || nextPage);
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleOpen = () => {
+    setOpen(true);
+    load(1);
+  };
+
+  if (!user) {
+    return null;
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <>
+      <Button appearance="secondary" id="my-trips-button" onClick={handleOpen}>
+        My Trips
+      </Button>
+
+      <OverlayDrawer
+        as="aside"
+        position="end"
+        modalType="non-modal"
+        open={open}
+        onOpenChange={(event, data) => setOpen(data.open)}
+      >
+        <DrawerHeader>
+          <DrawerHeaderTitle
+            action={
+              <Button
+                appearance="subtle"
+                aria-label="Close"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </Button>
+            }
+          >
+            My Trips
+          </DrawerHeaderTitle>
+        </DrawerHeader>
+
+        <DrawerBody>
+          {loading ? (
+            <Spinner label="Loading trips..." />
+          ) : error ? (
+            <Text>Could not load your trips. Please try again.</Text>
+          ) : total === 0 ? (
+            <Text>You haven&apos;t saved any trips yet.</Text>
+          ) : (
+            <>
+              <div className="my-trips-list">
+                {trips.map((trip) => (
+                  <Card key={trip.trip_id} className="my-trips-card">
+                    <Text weight="semibold">{trip.trip_name}</Text>
+                    <Text size={200}>
+                      {formatEndpoint(trip.origin)} &rarr;{" "}
+                      {formatEndpoint(trip.destination)}
+                    </Text>
+                    <Text size={200}>
+                      Saved {new Date(trip.created_at).toLocaleDateString()}
+                    </Text>
+                  </Card>
+                ))}
+              </div>
+
+              <div className="my-trips-pager">
+                <Button
+                  appearance="secondary"
+                  disabled={page <= 1}
+                  onClick={() => load(page - 1)}
+                >
+                  Previous
+                </Button>
+                <Text>
+                  Page {page} of {totalPages}
+                </Text>
+                <Button
+                  appearance="secondary"
+                  disabled={page >= totalPages}
+                  onClick={() => load(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </>
+          )}
+        </DrawerBody>
+      </OverlayDrawer>
+    </>
+  );
+}

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useCallback } from "react";
-import { useSelector } from "react-redux";
+import React, { useState, useCallback, useRef } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
   OverlayDrawer,
@@ -9,8 +9,14 @@ import {
   Card,
   Text,
   Spinner,
+  Toaster,
+  Toast,
+  ToastTitle,
+  useToastController,
+  useId,
 } from "@fluentui/react-components";
 import TripRequester from "../../scripts/TripRequester";
+import log from "../../utils/logger";
 
 const PAGE_SIZE = 10;
 
@@ -28,14 +34,38 @@ function formatEndpoint(point) {
   return "Unknown";
 }
 
+// Rebuild the planning state from a loaded trip view. clearAll first so a loaded
+// trip never merges with an in-progress one; SET_ROUTE also flips showRoute /
+// showDetourButton so the map and sidebar render.
+function applyTripView(dispatch, { trip, route, detours }) {
+  dispatch({ type: "CLEAR_ALL" });
+  dispatch({
+    type: "SET_ORIGIN",
+    data: { origin: (trip.origin && trip.origin.address) || "" },
+  });
+  dispatch({
+    type: "SET_DESTINATION",
+    data: { destination: (trip.destination && trip.destination.address) || "" },
+  });
+  if (route) {
+    dispatch({ type: "SET_ROUTE", data: { route } });
+    dispatch({
+      type: "SET_TRIP_SUMMARY",
+      data: { tripSummary: route.summary },
+    });
+  }
+  dispatch({ type: "SET_DETOUR_LIST", data: { detourList: detours || [] } });
+}
+
 /**
  * MyTrips — a "My Trips" button (shown only when signed in) that opens a
  * non-modal Fluent drawer listing the user's saved trips. The drawer overlays
- * the map without a backdrop, so the map stays visible behind it. List-only for
- * now; loading a trip onto the map is a later story.
+ * the map without a backdrop, so the map stays visible behind it. Clicking a
+ * trip loads it onto the map and into the sidebar; the drawer stays open.
  */
 export default function MyTrips() {
   const user = useSelector((state) => state.user);
+  const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
   const [trips, setTrips] = useState([]);
@@ -43,6 +73,15 @@ export default function MyTrips() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const [loadingTripId, setLoadingTripId] = useState(null);
+
+  // Monotonic token for load requests. Only the most recent click's response is
+  // applied, so quick successive clicks can't resolve out of order and load the
+  // wrong trip (or let an earlier request clear the later one's loading state).
+  const latestRequestRef = useRef(0);
+
+  const toasterId = useId("my-trips-toaster");
+  const { dispatchToast } = useToastController(toasterId);
 
   const load = useCallback((nextPage) => {
     setLoading(true);
@@ -63,6 +102,56 @@ export default function MyTrips() {
     load(1);
   };
 
+  // Fetch a saved trip and rebuild the planning state from it. clearAll first so
+  // a loaded trip never merges with an in-progress one. The drawer stays open.
+  // Only show the spinner if the load is slow (>250ms); fast loads render
+  // instantly, so a momentary spinner would just be a distracting flash.
+  const loadTrip = useCallback(
+    (tripId) => {
+      const requestId = latestRequestRef.current + 1;
+      latestRequestRef.current = requestId;
+      const isLatest = () => latestRequestRef.current === requestId;
+
+      let settled = false;
+      const spinnerTimer = setTimeout(() => {
+        if (!settled && isLatest()) {
+          setLoadingTripId(tripId);
+        }
+      }, 250);
+      new TripRequester()
+        .getTrip(tripId)
+        .then((view) => {
+          // Ignore a stale response from a superseded click.
+          if (isLatest()) {
+            applyTripView(dispatch, view);
+          }
+        })
+        .catch((err) => {
+          log.error("Failed to load trip:", err);
+          if (!isLatest()) {
+            return;
+          }
+          dispatchToast(
+            <Toast>
+              <ToastTitle>
+                Could not load that trip. Please try again.
+              </ToastTitle>
+            </Toast>,
+            { intent: "error" }
+          );
+        })
+        .finally(() => {
+          settled = true;
+          clearTimeout(spinnerTimer);
+          // Only the latest request owns the loading indicator.
+          if (isLatest()) {
+            setLoadingTripId(null);
+          }
+        });
+    },
+    [dispatch, dispatchToast]
+  );
+
   if (!user) {
     return null;
   }
@@ -71,6 +160,7 @@ export default function MyTrips() {
 
   return (
     <>
+      <Toaster toasterId={toasterId} />
       <Button appearance="secondary" id="my-trips-button" onClick={handleOpen}>
         My Trips
       </Button>
@@ -109,7 +199,29 @@ export default function MyTrips() {
             <>
               <div className="my-trips-list">
                 {trips.map((trip) => (
-                  <Card key={trip.trip_id} className="my-trips-card">
+                  <Card
+                    key={trip.trip_id}
+                    className="my-trips-card"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Load trip ${trip.trip_name}`}
+                    aria-busy={loadingTripId === trip.trip_id}
+                    onClick={() => loadTrip(trip.trip_id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        loadTrip(trip.trip_id);
+                      }
+                    }}
+                  >
+                    {loadingTripId === trip.trip_id && (
+                      <div
+                        className="my-trips-card__spinner"
+                        aria-hidden="true"
+                      >
+                        <Spinner size="tiny" />
+                      </div>
+                    )}
                     <Text weight="semibold">{trip.trip_name}</Text>
                     <Text size={200}>
                       {formatEndpoint(trip.origin)} &rarr;{" "}

--- a/frontend/src/components/sidebar/MyTrips.jsx
+++ b/frontend/src/components/sidebar/MyTrips.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
@@ -9,12 +9,28 @@ import {
   Card,
   Text,
   Spinner,
+  Menu,
+  MenuTrigger,
+  MenuPopover,
+  MenuList,
+  MenuItem,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
   Toaster,
   Toast,
   ToastTitle,
   useToastController,
   useId,
 } from "@fluentui/react-components";
+import {
+  MoreHorizontalRegular,
+  CopyRegular,
+  DeleteRegular,
+} from "@fluentui/react-icons";
 import TripRequester from "../../scripts/TripRequester";
 import log from "../../utils/logger";
 
@@ -36,7 +52,8 @@ function formatEndpoint(point) {
 
 // Rebuild the planning state from a loaded trip view. clearAll first so a loaded
 // trip never merges with an in-progress one; SET_ROUTE also flips showRoute /
-// showDetourButton so the map and sidebar render.
+// showDetourButton so the map and sidebar render. Record which saved trip is
+// loaded (currentTrip) and its name so the sidebar can offer "Update Trip".
 function applyTripView(dispatch, { trip, route, detours }) {
   dispatch({ type: "CLEAR_ALL" });
   dispatch({
@@ -55,6 +72,29 @@ function applyTripView(dispatch, { trip, route, detours }) {
     });
   }
   dispatch({ type: "SET_DETOUR_LIST", data: { detourList: detours || [] } });
+  dispatch({ type: "SET_TRIP_NAME", data: { tripName: trip.tripName || "" } });
+  dispatch({
+    type: "SET_CURRENT_TRIP",
+    data: {
+      currentTrip: {
+        tripId: trip.tripId,
+        tripName: trip.tripName,
+        updatedAt: trip.updatedAt,
+        // Snapshot of the saved values so a later update that hasn't re-routed
+        // (e.g. a rename) preserves distance/duration/coords/polyline instead
+        // of wiping them (the loaded route has no legs to recompute from).
+        origin: trip.origin,
+        destination: trip.destination,
+        routePolyline:
+          (route &&
+            route.overview_polyline &&
+            route.overview_polyline.points) ||
+          null,
+        distanceMeters: trip.distanceMeters,
+        durationSeconds: trip.durationSeconds,
+      },
+    },
+  });
 }
 
 /**
@@ -65,6 +105,9 @@ function applyTripView(dispatch, { trip, route, detours }) {
  */
 export default function MyTrips() {
   const user = useSelector((state) => state.user);
+  // Bumped whenever a trip is saved/updated elsewhere (e.g. the Save Trip
+  // button) so the open list can refresh instead of showing stale data.
+  const tripsRevision = useSelector((state) => state.tripsRevision);
   const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
@@ -74,11 +117,19 @@ export default function MyTrips() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [loadingTripId, setLoadingTripId] = useState(null);
+  // Trip pending delete confirmation (null when the dialog is closed).
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  // Trip currently being duplicated (drives the per-card spinner).
+  const [duplicatingTripId, setDuplicatingTripId] = useState(null);
 
   // Monotonic token for load requests. Only the most recent click's response is
   // applied, so quick successive clicks can't resolve out of order and load the
   // wrong trip (or let an earlier request clear the later one's loading state).
   const latestRequestRef = useRef(0);
+  // Tracks the last trips-revision we reacted to, so we only reload when a trip
+  // actually changed (not on the initial render).
+  const prevRevisionRef = useRef(tripsRevision);
 
   const toasterId = useId("my-trips-toaster");
   const { dispatchToast } = useToastController(toasterId);
@@ -101,6 +152,18 @@ export default function MyTrips() {
     setOpen(true);
     load(1);
   };
+
+  // Refresh the open list when a trip is saved/updated elsewhere so it never
+  // shows stale data (previously required closing and reopening the drawer).
+  useEffect(() => {
+    if (tripsRevision === prevRevisionRef.current) {
+      return;
+    }
+    prevRevisionRef.current = tripsRevision;
+    if (open) {
+      load(page);
+    }
+  }, [tripsRevision, open, page, load]);
 
   // Fetch a saved trip and rebuild the planning state from it. clearAll first so
   // a loaded trip never merges with an in-progress one. The drawer stays open.
@@ -151,6 +214,79 @@ export default function MyTrips() {
     },
     [dispatch, dispatchToast]
   );
+
+  // Duplicate a trip, then refresh the list so the new "Copy of ..." appears
+  // (it sorts to the top by created_at). The copy is created server-side.
+  const handleDuplicate = useCallback(
+    (trip) => {
+      setDuplicatingTripId(trip.trip_id);
+      new TripRequester()
+        .duplicateTrip(trip.trip_id)
+        .then(() => {
+          load(page);
+          dispatchToast(
+            <Toast>
+              <ToastTitle>Trip duplicated</ToastTitle>
+            </Toast>,
+            { intent: "success" }
+          );
+        })
+        .catch((err) => {
+          log.error("Failed to duplicate trip:", err);
+          dispatchToast(
+            <Toast>
+              <ToastTitle>
+                Could not duplicate that trip. Please try again.
+              </ToastTitle>
+            </Toast>,
+            { intent: "error" }
+          );
+        })
+        .finally(() => setDuplicatingTripId(null));
+    },
+    [load, page, dispatchToast]
+  );
+
+  // Delete the trip awaiting confirmation, then update the list in place. If the
+  // last trip on a page beyond the first is removed, step back a page so the
+  // user isn't left on an empty page.
+  const handleConfirmDelete = useCallback(() => {
+    const trip = deleteTarget;
+    if (!trip) {
+      return;
+    }
+    setDeleting(true);
+    new TripRequester()
+      .deleteTrip(trip.trip_id)
+      .then(() => {
+        setDeleteTarget(null);
+        const remaining = trips.filter((t) => t.trip_id !== trip.trip_id);
+        if (remaining.length === 0 && page > 1) {
+          load(page - 1);
+        } else {
+          setTrips(remaining);
+          setTotal((prev) => Math.max(0, prev - 1));
+        }
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Trip deleted</ToastTitle>
+          </Toast>,
+          { intent: "success" }
+        );
+      })
+      .catch((err) => {
+        log.error("Failed to delete trip:", err);
+        dispatchToast(
+          <Toast>
+            <ToastTitle>
+              Could not delete that trip. Please try again.
+            </ToastTitle>
+          </Toast>,
+          { intent: "error" }
+        );
+      })
+      .finally(() => setDeleting(false));
+  }, [deleteTarget, trips, page, load, dispatchToast]);
 
   if (!user) {
     return null;
@@ -205,7 +341,10 @@ export default function MyTrips() {
                     role="button"
                     tabIndex={0}
                     aria-label={`Load trip ${trip.trip_name}`}
-                    aria-busy={loadingTripId === trip.trip_id}
+                    aria-busy={
+                      loadingTripId === trip.trip_id ||
+                      duplicatingTripId === trip.trip_id
+                    }
                     onClick={() => loadTrip(trip.trip_id)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
@@ -214,7 +353,8 @@ export default function MyTrips() {
                       }
                     }}
                   >
-                    {loadingTripId === trip.trip_id && (
+                    {(loadingTripId === trip.trip_id ||
+                      duplicatingTripId === trip.trip_id) && (
                       <div
                         className="my-trips-card__spinner"
                         aria-hidden="true"
@@ -222,6 +362,39 @@ export default function MyTrips() {
                         <Spinner size="tiny" />
                       </div>
                     )}
+                    {/* Options menu — stop propagation so opening it (or picking
+                        an item) never triggers the card's load-trip click. */}
+                    <div
+                      className="my-trips-card__menu"
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <Menu>
+                        <MenuTrigger disableButtonEnhancement>
+                          <Button
+                            appearance="subtle"
+                            icon={<MoreHorizontalRegular />}
+                            aria-label={`Options for ${trip.trip_name}`}
+                          />
+                        </MenuTrigger>
+                        <MenuPopover>
+                          <MenuList>
+                            <MenuItem
+                              icon={<CopyRegular />}
+                              onClick={() => handleDuplicate(trip)}
+                            >
+                              Duplicate
+                            </MenuItem>
+                            <MenuItem
+                              icon={<DeleteRegular />}
+                              onClick={() => setDeleteTarget(trip)}
+                            >
+                              Delete
+                            </MenuItem>
+                          </MenuList>
+                        </MenuPopover>
+                      </Menu>
+                    </div>
                     <Text weight="semibold">{trip.trip_name}</Text>
                     <Text size={200}>
                       {formatEndpoint(trip.origin)} &rarr;{" "}
@@ -257,6 +430,44 @@ export default function MyTrips() {
           )}
         </DrawerBody>
       </OverlayDrawer>
+
+      {/* Delete confirmation — driven by deleteTarget so a single dialog serves
+          every card. */}
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(event, data) => {
+          if (!data.open) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Delete trip?</DialogTitle>
+            <DialogContent>
+              This permanently deletes
+              {deleteTarget ? ` "${deleteTarget.trip_name}"` : " this trip"} and
+              its detours. This can&apos;t be undone.
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                disabled={deleting}
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="primary"
+                disabled={deleting}
+                onClick={handleConfirmDelete}
+              >
+                {deleting ? "Deleting..." : "Delete"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
     </>
   );
 }

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import React, { useState, useEffect, useCallback } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import {
   Button,
   Dialog,
@@ -20,54 +20,187 @@ import TripRequester, { buildTripPayload } from "../../scripts/TripRequester";
 import AuthRequester from "../../scripts/AuthRequester";
 
 // sessionStorage flag: set when a signed-out user opts to sign in from the save
-// prompt, so the name dialog reopens automatically after the login redirect.
+// prompt, so the save resumes automatically after the login redirect.
 const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
 
 /**
- * SaveTrip — "Save Trip" button plus its Fluent dialogs and toast.
+ * SaveTrip — the "Save Trip" control and its dialogs.
  *
- * Reads the current trip straight from Redux, so it can drop into TripSummary
- * with no prop threading. Signed-out users get a prompt to sign in; signed-in
- * users get a name dialog, and the result is reported via a Fluent toast.
+ * Reads the current trip straight from Redux. The trip name is edited in the
+ * separate TripNameField component (Redux `tripName`); SaveTrip only renders the
+ * Save button plus its dialogs. The button always reads "Save Trip"; under the
+ * hood it updates the loaded trip in place when one is loaded (`currentTrip`),
+ * otherwise creates a new trip. If the loaded trip no longer exists (e.g. deleted
+ * elsewhere), the update falls back to creating a new trip. Signed-out users are
+ * prompted to sign in.
  */
 export default function SaveTrip() {
-  const { user, origin, destination, route, detourList } = useSelector(
-    (state) => ({
-      user: state.user,
-      origin: state.origin,
-      destination: state.destination,
-      route: state.route,
-      detourList: state.detourList,
-    })
-  );
+  const {
+    user,
+    origin,
+    destination,
+    route,
+    detourList,
+    tripName,
+    currentTrip,
+  } = useSelector((state) => ({
+    user: state.user,
+    origin: state.origin,
+    destination: state.destination,
+    route: state.route,
+    detourList: state.detourList,
+    tripName: state.tripName,
+    currentTrip: state.currentTrip,
+  }));
+  const dispatch = useDispatch();
 
   const [nameDialogOpen, setNameDialogOpen] = useState(false);
   const [signInDialogOpen, setSignInDialogOpen] = useState(false);
-  const [tripName, setTripName] = useState("");
+  // Local buffer for the fallback "name required" dialog input.
+  const [dialogName, setDialogName] = useState("");
   const [saving, setSaving] = useState(false);
 
   const toasterId = useId("save-trip-toaster");
   const { dispatchToast } = useToastController(toasterId);
   const auth = new AuthRequester();
 
+  const setTripName = useCallback(
+    (name) => dispatch({ type: "SET_TRIP_NAME", data: { tripName: name } }),
+    [dispatch]
+  );
+
+  const showToast = useCallback(
+    (message, intent) =>
+      dispatchToast(
+        <Toast>
+          <ToastTitle>{message}</ToastTitle>
+        </Toast>,
+        { intent }
+      ),
+    [dispatchToast]
+  );
+
+  // Persist the current plan under `name`: update the loaded trip in place, or
+  // create a new one. A 404 on update means the loaded trip is gone (deleted),
+  // so fall back to creating it as a new trip. On success, bump the revision so
+  // an open "My Trips" list refreshes.
+  const persist = useCallback(
+    (name) => {
+      setSaving(true);
+      const payload = buildTripPayload(
+        { origin, destination, route, detourList },
+        name,
+        currentTrip
+      );
+      const requester = new TripRequester();
+
+      const create = () =>
+        requester.saveTrip(payload).then((data) => {
+          const trip = data.trip || {};
+          setTripName(name);
+          dispatch({
+            type: "SET_CURRENT_TRIP",
+            data: {
+              currentTrip: {
+                tripId: trip.trip_id,
+                tripName: name,
+                updatedAt: trip.updated_at,
+                origin: trip.origin,
+                destination: trip.destination,
+                routePolyline: trip.route_polyline,
+                distanceMeters: trip.distance_meters,
+                durationSeconds: trip.duration_seconds,
+              },
+            },
+          });
+        });
+
+      const save = currentTrip
+        ? requester
+            .updateTrip(currentTrip.tripId, payload)
+            .then((data) => {
+              const trip = data.trip || {};
+              const updatedRoute = data.route || {};
+              setTripName(trip.tripName || name);
+              dispatch({
+                type: "SET_CURRENT_TRIP",
+                data: {
+                  currentTrip: {
+                    tripId: trip.tripId || currentTrip.tripId,
+                    tripName: trip.tripName || name,
+                    updatedAt: trip.updatedAt,
+                    origin: trip.origin,
+                    destination: trip.destination,
+                    routePolyline:
+                      (updatedRoute.overview_polyline &&
+                        updatedRoute.overview_polyline.points) ||
+                      currentTrip.routePolyline ||
+                      null,
+                    distanceMeters: trip.distanceMeters,
+                    durationSeconds: trip.durationSeconds,
+                  },
+                },
+              });
+            })
+            .catch((err) => {
+              // The loaded trip no longer exists — save it as a new trip.
+              if (err && err.response && err.response.status === 404) {
+                return create();
+              }
+              throw err;
+            })
+        : create();
+
+      return save
+        .then(() => {
+          setNameDialogOpen(false);
+          dispatch({ type: "BUMP_TRIPS_REVISION" });
+          showToast("Trip saved", "success");
+        })
+        .catch(() => {
+          showToast("Could not save trip. Please try again.", "error");
+        })
+        .finally(() => setSaving(false));
+    },
+    [
+      origin,
+      destination,
+      route,
+      detourList,
+      currentTrip,
+      dispatch,
+      setTripName,
+      showToast,
+    ]
+  );
+
+  // Start a save: save directly when a name is present, else prompt for one.
+  const requestSave = useCallback(() => {
+    const name = (tripName || "").trim();
+    if (name) {
+      persist(name);
+    } else {
+      setDialogName("");
+      setNameDialogOpen(true);
+    }
+  }, [tripName, persist]);
+
   // Clicking "Sign in" from the save prompt is an intent to save. We stash a
-  // one-shot flag before the login redirect; once the user is authenticated on
-  // return, reopen the name dialog automatically.
+  // one-shot flag before the login redirect; once authenticated on return,
+  // resume the save automatically.
   useEffect(() => {
     if (user && sessionStorage.getItem(RESUME_SAVE_KEY)) {
       sessionStorage.removeItem(RESUME_SAVE_KEY);
-      setTripName("");
-      setNameDialogOpen(true);
+      requestSave();
     }
-  }, [user]);
+  }, [user, requestSave]);
 
-  const handleClick = () => {
+  const handlePrimaryClick = () => {
     if (!user) {
       setSignInDialogOpen(true);
-    } else {
-      setTripName("");
-      setNameDialogOpen(true);
+      return;
     }
+    requestSave();
   };
 
   const handleSignIn = () => {
@@ -76,54 +209,23 @@ export default function SaveTrip() {
     auth.login();
   };
 
-  const handleSave = () => {
-    const name = tripName.trim();
-    if (!name) {
-      return;
-    }
-    setSaving(true);
-    const payload = buildTripPayload(
-      { origin, destination, route, detourList },
-      name
-    );
-    new TripRequester()
-      .saveTrip(payload)
-      .then(() => {
-        setNameDialogOpen(false);
-        dispatchToast(
-          <Toast>
-            <ToastTitle>Trip saved</ToastTitle>
-          </Toast>,
-          { intent: "success" }
-        );
-      })
-      .catch(() => {
-        dispatchToast(
-          <Toast>
-            <ToastTitle>Could not save trip. Please try again.</ToastTitle>
-          </Toast>,
-          { intent: "error" }
-        );
-      })
-      .finally(() => {
-        setSaving(false);
-      });
-  };
-
   return (
     <>
       <Toaster toasterId={toasterId} />
 
-      <Button
-        appearance="primary"
-        className="save-trip-btn mt-2"
-        id="save-trip-button"
-        onClick={handleClick}
-      >
-        Save Trip
-      </Button>
+      <div className="save-trip-section">
+        <Button
+          appearance="primary"
+          className="save-trip-btn"
+          id="save-trip-button"
+          disabled={saving}
+          onClick={handlePrimaryClick}
+        >
+          {saving ? "Saving..." : "Save Trip"}
+        </Button>
+      </div>
 
-      {/* Signed-in: prompt for a trip name. */}
+      {/* Fallback: prompt for a name when saving without one. */}
       <Dialog
         open={nameDialogOpen}
         onOpenChange={(event, data) => setNameDialogOpen(data.open)}
@@ -134,9 +236,9 @@ export default function SaveTrip() {
             <DialogContent>
               <Field label="Trip name" required>
                 <Input
-                  value={tripName}
+                  value={dialogName}
                   placeholder="e.g. Coastal weekend"
-                  onChange={(event) => setTripName(event.target.value)}
+                  onChange={(event) => setDialogName(event.target.value)}
                 />
               </Field>
             </DialogContent>
@@ -150,8 +252,8 @@ export default function SaveTrip() {
               </Button>
               <Button
                 appearance="primary"
-                disabled={saving || !tripName.trim()}
-                onClick={handleSave}
+                disabled={saving || !dialogName.trim()}
+                onClick={() => persist(dialogName.trim())}
               >
                 {saving ? "Saving..." : "Save"}
               </Button>

--- a/frontend/src/components/sidebar/SaveTrip.jsx
+++ b/frontend/src/components/sidebar/SaveTrip.jsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import {
+  Button,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Field,
+  Input,
+  Toaster,
+  Toast,
+  ToastTitle,
+  useToastController,
+  useId,
+} from "@fluentui/react-components";
+import TripRequester, { buildTripPayload } from "../../scripts/TripRequester";
+import AuthRequester from "../../scripts/AuthRequester";
+
+// sessionStorage flag: set when a signed-out user opts to sign in from the save
+// prompt, so the name dialog reopens automatically after the login redirect.
+const RESUME_SAVE_KEY = "jaunt.resumeSaveTrip";
+
+/**
+ * SaveTrip — "Save Trip" button plus its Fluent dialogs and toast.
+ *
+ * Reads the current trip straight from Redux, so it can drop into TripSummary
+ * with no prop threading. Signed-out users get a prompt to sign in; signed-in
+ * users get a name dialog, and the result is reported via a Fluent toast.
+ */
+export default function SaveTrip() {
+  const { user, origin, destination, route, detourList } = useSelector(
+    (state) => ({
+      user: state.user,
+      origin: state.origin,
+      destination: state.destination,
+      route: state.route,
+      detourList: state.detourList,
+    })
+  );
+
+  const [nameDialogOpen, setNameDialogOpen] = useState(false);
+  const [signInDialogOpen, setSignInDialogOpen] = useState(false);
+  const [tripName, setTripName] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const toasterId = useId("save-trip-toaster");
+  const { dispatchToast } = useToastController(toasterId);
+  const auth = new AuthRequester();
+
+  // Clicking "Sign in" from the save prompt is an intent to save. We stash a
+  // one-shot flag before the login redirect; once the user is authenticated on
+  // return, reopen the name dialog automatically.
+  useEffect(() => {
+    if (user && sessionStorage.getItem(RESUME_SAVE_KEY)) {
+      sessionStorage.removeItem(RESUME_SAVE_KEY);
+      setTripName("");
+      setNameDialogOpen(true);
+    }
+  }, [user]);
+
+  const handleClick = () => {
+    if (!user) {
+      setSignInDialogOpen(true);
+    } else {
+      setTripName("");
+      setNameDialogOpen(true);
+    }
+  };
+
+  const handleSignIn = () => {
+    // Survive the full-page login redirect so we can resume on return.
+    sessionStorage.setItem(RESUME_SAVE_KEY, "1");
+    auth.login();
+  };
+
+  const handleSave = () => {
+    const name = tripName.trim();
+    if (!name) {
+      return;
+    }
+    setSaving(true);
+    const payload = buildTripPayload(
+      { origin, destination, route, detourList },
+      name
+    );
+    new TripRequester()
+      .saveTrip(payload)
+      .then(() => {
+        setNameDialogOpen(false);
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Trip saved</ToastTitle>
+          </Toast>,
+          { intent: "success" }
+        );
+      })
+      .catch(() => {
+        dispatchToast(
+          <Toast>
+            <ToastTitle>Could not save trip. Please try again.</ToastTitle>
+          </Toast>,
+          { intent: "error" }
+        );
+      })
+      .finally(() => {
+        setSaving(false);
+      });
+  };
+
+  return (
+    <>
+      <Toaster toasterId={toasterId} />
+
+      <Button
+        appearance="primary"
+        className="save-trip-btn mt-2"
+        id="save-trip-button"
+        onClick={handleClick}
+      >
+        Save Trip
+      </Button>
+
+      {/* Signed-in: prompt for a trip name. */}
+      <Dialog
+        open={nameDialogOpen}
+        onOpenChange={(event, data) => setNameDialogOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Save your trip</DialogTitle>
+            <DialogContent>
+              <Field label="Trip name" required>
+                <Input
+                  value={tripName}
+                  placeholder="e.g. Coastal weekend"
+                  onChange={(event) => setTripName(event.target.value)}
+                />
+              </Field>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                disabled={saving}
+                onClick={() => setNameDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                appearance="primary"
+                disabled={saving || !tripName.trim()}
+                onClick={handleSave}
+              >
+                {saving ? "Saving..." : "Save"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* Signed-out: prompt to sign in. */}
+      <Dialog
+        open={signInDialogOpen}
+        onOpenChange={(event, data) => setSignInDialogOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Sign in to save your trip</DialogTitle>
+            <DialogContent>
+              Create an account or sign in to save this trip and access it
+              later.
+            </DialogContent>
+            <DialogActions>
+              <Button
+                appearance="secondary"
+                onClick={() => setSignInDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button appearance="primary" onClick={handleSignIn}>
+                Sign in
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/sidebar/TripNameField.jsx
+++ b/frontend/src/components/sidebar/TripNameField.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Field, Input } from "@fluentui/react-components";
+
+/**
+ * TripNameField — the editable trip name, shown above the trip timeline.
+ *
+ * Reads/writes Redux `tripName` directly so it can sit anywhere in the sidebar
+ * without prop threading. When a saved trip is loaded its name populates here;
+ * the value is picked up by SaveTrip when saving/updating.
+ */
+export default function TripNameField() {
+  const tripName = useSelector((state) => state.tripName);
+  const dispatch = useDispatch();
+
+  return (
+    <div className="trip-name-section">
+      <Field className="trip-name-field" label="Trip name">
+        <Input
+          size="large"
+          className="trip-name-input"
+          value={tripName || ""}
+          placeholder="e.g. Coastal weekend"
+          onChange={(event) =>
+            dispatch({
+              type: "SET_TRIP_NAME",
+              data: { tripName: event.target.value },
+            })
+          }
+        />
+      </Field>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/TripSummary.jsx
+++ b/frontend/src/components/sidebar/TripSummary.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import TripTimeline from "./TripTimeline";
+import TripNameField from "./TripNameField";
 import SaveTrip from "./SaveTrip";
 import { exportToGoogleMaps } from "../../utils/googleMapsExport";
 
@@ -52,10 +53,10 @@ class TripSummary extends React.Component {
                     id="export-route-button"
                     text="Open in Google Maps"
                   ></Button>
-                  <SaveTrip></SaveTrip>
                 </div>
               </div>
             </div>
+            <TripNameField></TripNameField>
             <TripTimeline
               origin={this.props.origin}
               destination={this.props.destination}
@@ -65,6 +66,7 @@ class TripSummary extends React.Component {
               setTripSummary={this.props.setTripSummary}
               setDetourList={this.props.setDetourList}
             ></TripTimeline>
+            <SaveTrip></SaveTrip>
           </div>
         ) : (
           <div></div>

--- a/frontend/src/components/sidebar/TripSummary.jsx
+++ b/frontend/src/components/sidebar/TripSummary.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import TripTimeline from "./TripTimeline";
+import SaveTrip from "./SaveTrip";
 import { exportToGoogleMaps } from "../../utils/googleMapsExport";
 
 class TripSummary extends React.Component {
@@ -51,6 +52,7 @@ class TripSummary extends React.Component {
                     id="export-route-button"
                     text="Open in Google Maps"
                   ></Button>
+                  <SaveTrip></SaveTrip>
                 </div>
               </div>
             </div>

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -1,6 +1,11 @@
 var config = {
   NODE_ENV: process.env.NODE_ENV,
   GOOGLE_API_KEY: process.env.REACT_APP_GOOGLE_API_KEY,
+  BACKEND_URL:
+    process.env.REACT_APP_BACKEND_URL ||
+    (process.env.NODE_ENV === "development"
+      ? "http://localhost:3000"
+      : "https://jauntdetour-backend.azurewebsites.net"),
 };
 
 module.exports = config;

--- a/frontend/src/containers/MainContainer.js
+++ b/frontend/src/containers/MainContainer.js
@@ -103,6 +103,17 @@ let matchDispatchToProps = (dispatch) => {
       dispatch({
         type: "CLEAR_ALL",
       }),
+    setUser: (user) =>
+      dispatch({
+        type: "SET_USER",
+        data: {
+          user: user,
+        },
+      }),
+    clearUser: () =>
+      dispatch({
+        type: "CLEAR_USER",
+      }),
   };
 };
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,15 +6,45 @@ import * as serviceWorker from "./serviceWorker";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
 import mainReducer from "./reducers/main-reducer";
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 
-let store = createStore(mainReducer);
+// Persist the planning state to sessionStorage so an in-progress trip survives
+// full-page navigations — most importantly the sign-in redirect (backend →
+// Entra → back), which would otherwise wipe the in-memory Redux state. Scoped
+// to sessionStorage so it's per-tab and cleared when the tab closes. `user` is
+// deliberately not persisted: auth state is always re-resolved from /auth/me.
+const PERSIST_KEY = "jaunt.tripState";
+
+function loadState() {
+  try {
+    const saved = sessionStorage.getItem(PERSIST_KEY);
+    return saved ? JSON.parse(saved) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function saveState(state) {
+  try {
+    // eslint-disable-next-line no-unused-vars
+    const { user, ...planning } = state;
+    sessionStorage.setItem(PERSIST_KEY, JSON.stringify(planning));
+  } catch {
+    // Ignore write failures (e.g. storage disabled or full).
+  }
+}
+
+let store = createStore(mainReducer, loadState());
+store.subscribe(() => saveState(store.getState()));
 
 const container = document.getElementById("root");
 const root = createRoot(container);
 
 root.render(
   <Provider store={store}>
-    <App />
+    <FluentProvider theme={webLightTheme}>
+      <App />
+    </FluentProvider>
   </Provider>
 );
 

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -2,6 +2,15 @@ let initialState = {
   user: null,
   origin: "",
   destination: "",
+  // The name the user has given the in-progress trip (bound to the sidebar
+  // name field). currentTrip identifies which saved trip, if any, is loaded —
+  // null means an unsaved/new trip. Both persist to sessionStorage (see
+  // index.js) so they survive the sign-in redirect.
+  tripName: "",
+  currentTrip: null,
+  // Bumped whenever a trip is created/updated/deleted/duplicated so an open
+  // "My Trips" list can refresh itself without being closed and reopened.
+  tripsRevision: 0,
   detourType: "Hike",
   detourList: [],
   tripSummary: {},
@@ -39,6 +48,21 @@ const mainReducer = (state = initialState, action) => {
       return {
         ...state,
         destination: action.data.destination,
+      };
+    case "SET_TRIP_NAME":
+      return {
+        ...state,
+        tripName: action.data.tripName,
+      };
+    case "SET_CURRENT_TRIP":
+      return {
+        ...state,
+        currentTrip: action.data.currentTrip,
+      };
+    case "BUMP_TRIPS_REVISION":
+      return {
+        ...state,
+        tripsRevision: (state.tripsRevision || 0) + 1,
       };
     case "SET_ROUTE":
       return {
@@ -117,6 +141,11 @@ const mainReducer = (state = initialState, action) => {
         user: state.user,
         origin: "",
         destination: "",
+        tripName: "",
+        currentTrip: null,
+        // Preserve the revision counter so clearing the planner doesn't look
+        // like a trip mutation to an open list.
+        tripsRevision: state.tripsRevision,
         detourType: "Hike",
         detourList: [],
         tripSummary: {},

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -1,4 +1,5 @@
 let initialState = {
+  user: null,
   origin: "",
   destination: "",
   detourType: "Hike",
@@ -19,6 +20,16 @@ let initialState = {
 
 const mainReducer = (state = initialState, action) => {
   switch (action.type) {
+    case "SET_USER":
+      return {
+        ...state,
+        user: action.data.user,
+      };
+    case "CLEAR_USER":
+      return {
+        ...state,
+        user: null,
+      };
     case "SET_ORIGIN":
       return {
         ...state,
@@ -103,6 +114,7 @@ const mainReducer = (state = initialState, action) => {
       };
     case "CLEAR_ALL":
       return {
+        user: state.user,
         origin: "",
         destination: "",
         detourType: "Hike",

--- a/frontend/src/reducers/main-reducer.test.js
+++ b/frontend/src/reducers/main-reducer.test.js
@@ -1,0 +1,65 @@
+import mainReducer from "./main-reducer";
+
+describe("mainReducer — trip name and current trip", () => {
+  it("defaults tripName to an empty string and currentTrip to null", () => {
+    const state = mainReducer(undefined, { type: "@@INIT" });
+    expect(state.tripName).toBe("");
+    expect(state.currentTrip).toBeNull();
+  });
+
+  it("SET_TRIP_NAME updates the trip name", () => {
+    const state = mainReducer(undefined, {
+      type: "SET_TRIP_NAME",
+      data: { tripName: "Coastal weekend" },
+    });
+    expect(state.tripName).toBe("Coastal weekend");
+  });
+
+  it("SET_CURRENT_TRIP records the loaded trip", () => {
+    const currentTrip = {
+      tripId: "t1",
+      tripName: "Coastal weekend",
+      updatedAt: "2026-07-07T12:00:00.000Z",
+    };
+    const state = mainReducer(undefined, {
+      type: "SET_CURRENT_TRIP",
+      data: { currentTrip },
+    });
+    expect(state.currentTrip).toEqual(currentTrip);
+  });
+
+  it("CLEAR_ALL resets tripName and currentTrip but preserves the user", () => {
+    const loaded = mainReducer(
+      { user: { id: "u1" } },
+      {
+        type: "SET_CURRENT_TRIP",
+        data: {
+          currentTrip: { tripId: "t1", tripName: "X", updatedAt: "now" },
+        },
+      }
+    );
+    const withName = mainReducer(loaded, {
+      type: "SET_TRIP_NAME",
+      data: { tripName: "X" },
+    });
+
+    const cleared = mainReducer(withName, { type: "CLEAR_ALL" });
+
+    expect(cleared.tripName).toBe("");
+    expect(cleared.currentTrip).toBeNull();
+    expect(cleared.user).toEqual({ id: "u1" });
+  });
+
+  it("BUMP_TRIPS_REVISION increments the revision counter", () => {
+    const first = mainReducer(undefined, { type: "BUMP_TRIPS_REVISION" });
+    expect(first.tripsRevision).toBe(1);
+    const second = mainReducer(first, { type: "BUMP_TRIPS_REVISION" });
+    expect(second.tripsRevision).toBe(2);
+  });
+
+  it("CLEAR_ALL preserves the trips revision counter", () => {
+    const bumped = mainReducer(undefined, { type: "BUMP_TRIPS_REVISION" });
+    const cleared = mainReducer(bumped, { type: "CLEAR_ALL" });
+    expect(cleared.tripsRevision).toBe(1);
+  });
+});

--- a/frontend/src/scripts/AuthRequester.js
+++ b/frontend/src/scripts/AuthRequester.js
@@ -1,0 +1,65 @@
+import axios from "axios";
+import config from "../config/config.js";
+import log from "../utils/logger";
+
+/**
+ * AuthRequester — talks to the backend auth endpoints.
+ *
+ * The backend owns the OAuth flow and issues an http-only session cookie, so
+ * every call must send credentials. Login is a full-page redirect (not XHR)
+ * because it navigates to the Entra hosted pages.
+ */
+export default class AuthRequester {
+  getUrlBase() {
+    return config.BACKEND_URL;
+  }
+
+  /**
+   * Start sign-in by navigating the browser to the backend login endpoint,
+   * which redirects on to Entra.
+   */
+  login() {
+    window.location.assign(this.getUrlBase() + "/auth/login");
+  }
+
+  /**
+   * Fetch the currently authenticated user. Resolves to the user object, or
+   * null when not signed in (the backend returns 401).
+   *
+   * @returns {Promise<object|null>}
+   */
+  getCurrentUser() {
+    return axios
+      .get(this.getUrlBase() + "/auth/me", { withCredentials: true })
+      .then((response) => response.data.user)
+      .catch((error) => {
+        if (error.response && error.response.status === 401) {
+          return null;
+        }
+        log.error("Unable to fetch current user:", error);
+        return null;
+      });
+  }
+
+  /**
+   * Sign out: clear the backend session, then navigate to the Entra logout URL
+   * returned by the server to end the IdP SSO session.
+   *
+   * @returns {Promise<void>}
+   */
+  logout() {
+    return axios
+      .post(this.getUrlBase() + "/auth/logout", {}, { withCredentials: true })
+      .then((response) => {
+        const logoutUrl = response.data && response.data.logoutUrl;
+        if (logoutUrl) {
+          window.location.assign(logoutUrl);
+        } else {
+          window.location.reload();
+        }
+      })
+      .catch((error) => {
+        log.error("Logout failed:", error);
+      });
+  }
+}

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -111,4 +111,22 @@ export default class TripRequester {
         throw error;
       });
   }
+
+  /**
+   * Load a single saved trip, reconstructed for rendering.
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @returns {Promise<object>} { trip, route, detours }
+   */
+  getTrip(tripId) {
+    return axios
+      .get(this.getUrlBase() + "/api/trips/" + tripId, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to load trip:", error);
+        throw error;
+      });
+  }
 }

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -10,11 +10,18 @@ import log from "../utils/logger";
  * no extra API calls. `origin`/`destination` in state are the address strings
  * the user typed; we pair them with the resolved leg coordinates.
  *
+ * When there are no route legs (e.g. a loaded trip that hasn't been re-routed,
+ * such as a plain rename), the live route can't supply distance/duration/coords,
+ * so we fall back to `fallback` — the saved values captured when the trip was
+ * loaded — to avoid wiping them on update.
+ *
  * @param {object} state - Redux state ({ origin, destination, route, detourList }).
  * @param {string} tripName - The name the user entered for the trip.
- * @returns {object} The request body for POST /api/trips.
+ * @param {object} [fallback] - Saved trip values ({ origin, destination,
+ *   routePolyline, distanceMeters, durationSeconds }) used when no live legs.
+ * @returns {object} The request body for POST/PUT /api/trips.
  */
-export function buildTripPayload(state, tripName) {
+export function buildTripPayload(state, tripName, fallback = null) {
   const { origin, destination, route, detourList } = state;
   const legs = (route && route.legs) || [];
   const firstLeg = legs[0] || {};
@@ -32,25 +39,31 @@ export function buildTripPayload(state, tripName) {
   );
   // Only report distance/duration when there is a route; preserve a genuine 0.
   const hasLegs = legs.length > 0;
+  const fb = fallback || {};
   const routePolyline =
     (route && route.overview_polyline && route.overview_polyline.points) ||
+    fb.routePolyline ||
     null;
 
   return {
     tripName,
-    origin: {
-      address: origin || "",
-      lat: startLocation.lat ?? null,
-      lng: startLocation.lng ?? null,
-    },
-    destination: {
-      address: destination || "",
-      lat: endLocation.lat ?? null,
-      lng: endLocation.lng ?? null,
-    },
+    origin: hasLegs
+      ? {
+          address: origin || "",
+          lat: startLocation.lat ?? null,
+          lng: startLocation.lng ?? null,
+        }
+      : fb.origin || { address: origin || "", lat: null, lng: null },
+    destination: hasLegs
+      ? {
+          address: destination || "",
+          lat: endLocation.lat ?? null,
+          lng: endLocation.lng ?? null,
+        }
+      : fb.destination || { address: destination || "", lat: null, lng: null },
     routePolyline,
-    distanceMeters: hasLegs ? distanceMeters : null,
-    durationSeconds: hasLegs ? durationSeconds : null,
+    distanceMeters: hasLegs ? distanceMeters : (fb.distanceMeters ?? null),
+    durationSeconds: hasLegs ? durationSeconds : (fb.durationSeconds ?? null),
     detours: (detourList || []).map((detour) => ({
       placeName: detour.name,
       placeType: detour.type || null,
@@ -126,6 +139,64 @@ export default class TripRequester {
       .then((response) => response.data)
       .catch((error) => {
         log.error("Failed to load trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * Update an existing saved trip (and replace its detours). Resolves to the
+   * reconstructed trip view on success.
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @param {object} payload - Body from buildTripPayload.
+   * @returns {Promise<object>} { trip, route, detours }
+   */
+  updateTrip(tripId, payload) {
+    return axios
+      .put(this.getUrlBase() + "/api/trips/" + tripId, payload, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to update trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * Duplicate a saved trip (and all of its detours). Resolves to the new trip.
+   *
+   * @param {string} tripId - The source trip's UUID.
+   * @returns {Promise<object>} { trip, detours }
+   */
+  duplicateTrip(tripId) {
+    return axios
+      .post(
+        this.getUrlBase() + "/api/trips/" + tripId + "/duplicate",
+        {},
+        { withCredentials: true }
+      )
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to duplicate trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * Delete a saved trip (and its detours, via ON DELETE CASCADE).
+   *
+   * @param {string} tripId - The trip's UUID.
+   * @returns {Promise<object>} { message }
+   */
+  deleteTrip(tripId) {
+    return axios
+      .delete(this.getUrlBase() + "/api/trips/" + tripId, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to delete trip:", error);
         throw error;
       });
   }

--- a/frontend/src/scripts/TripRequester.js
+++ b/frontend/src/scripts/TripRequester.js
@@ -1,0 +1,114 @@
+import axios from "axios";
+import config from "../config/config.js";
+import log from "../utils/logger";
+
+/**
+ * Build the POST /api/trips payload from the current Redux state.
+ *
+ * The full Google route object is kept in `state.route`, so we can pull exact
+ * coordinates, distance, duration, and the encoded polyline straight from it —
+ * no extra API calls. `origin`/`destination` in state are the address strings
+ * the user typed; we pair them with the resolved leg coordinates.
+ *
+ * @param {object} state - Redux state ({ origin, destination, route, detourList }).
+ * @param {string} tripName - The name the user entered for the trip.
+ * @returns {object} The request body for POST /api/trips.
+ */
+export function buildTripPayload(state, tripName) {
+  const { origin, destination, route, detourList } = state;
+  const legs = (route && route.legs) || [];
+  const firstLeg = legs[0] || {};
+  const lastLeg = legs[legs.length - 1] || {};
+  const startLocation = firstLeg.start_location || {};
+  const endLocation = lastLeg.end_location || {};
+
+  const distanceMeters = legs.reduce(
+    (sum, leg) => sum + ((leg.distance && leg.distance.value) || 0),
+    0
+  );
+  const durationSeconds = legs.reduce(
+    (sum, leg) => sum + ((leg.duration && leg.duration.value) || 0),
+    0
+  );
+  // Only report distance/duration when there is a route; preserve a genuine 0.
+  const hasLegs = legs.length > 0;
+  const routePolyline =
+    (route && route.overview_polyline && route.overview_polyline.points) ||
+    null;
+
+  return {
+    tripName,
+    origin: {
+      address: origin || "",
+      lat: startLocation.lat ?? null,
+      lng: startLocation.lng ?? null,
+    },
+    destination: {
+      address: destination || "",
+      lat: endLocation.lat ?? null,
+      lng: endLocation.lng ?? null,
+    },
+    routePolyline,
+    distanceMeters: hasLegs ? distanceMeters : null,
+    durationSeconds: hasLegs ? durationSeconds : null,
+    detours: (detourList || []).map((detour) => ({
+      placeName: detour.name,
+      placeType: detour.type || null,
+      latitude: detour.lat,
+      longitude: detour.lng,
+      placeId: detour.placeId || detour.id || null,
+      rating: detour.rating || null,
+      metadata: { addedTime: detour.addedTime },
+    })),
+  };
+}
+
+/**
+ * TripRequester — persists a trip to the backend.
+ *
+ * The backend scopes the trip to the signed-in user via the session cookie, so
+ * every call must send credentials.
+ */
+export default class TripRequester {
+  getUrlBase() {
+    return config.BACKEND_URL;
+  }
+
+  /**
+   * Save a trip (with its detours). Resolves to the created trip on success.
+   *
+   * @param {object} payload - Body from buildTripPayload.
+   * @returns {Promise<object>} { trip, detours }
+   */
+  saveTrip(payload) {
+    return axios
+      .post(this.getUrlBase() + "/api/trips", payload, {
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to save trip:", error);
+        throw error;
+      });
+  }
+
+  /**
+   * List the signed-in user's saved trips, newest first, paginated.
+   *
+   * @param {number} [page=1] - 1-based page number.
+   * @param {number} [limit=10] - Page size.
+   * @returns {Promise<object>} { trips, total, page, limit }
+   */
+  listTrips(page = 1, limit = 10) {
+    return axios
+      .get(this.getUrlBase() + "/api/trips", {
+        params: { page, limit },
+        withCredentials: true,
+      })
+      .then((response) => response.data)
+      .catch((error) => {
+        log.error("Failed to load trips:", error);
+        throw error;
+      });
+  }
+}

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -1,0 +1,160 @@
+import axios from "axios";
+import TripRequester, { buildTripPayload } from "./TripRequester";
+
+jest.mock("axios");
+
+jest.mock("../utils/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+describe("buildTripPayload", () => {
+  const state = {
+    origin: "San Francisco, CA",
+    destination: "Los Angeles, CA",
+    route: {
+      overview_polyline: { points: "encoded_polyline_string" },
+      legs: [
+        {
+          start_location: { lat: 37.77, lng: -122.42 },
+          end_location: { lat: 36.0, lng: -120.0 },
+          distance: { value: 300000 },
+          duration: { value: 18000 },
+        },
+        {
+          start_location: { lat: 36.0, lng: -120.0 },
+          end_location: { lat: 34.05, lng: -118.24 },
+          distance: { value: 316000 },
+          duration: { value: 14400 },
+        },
+      ],
+    },
+    detourList: [
+      {
+        name: "Big Sur",
+        type: "Landmark",
+        lat: 36.27,
+        lng: -121.8,
+        id: "place-1",
+        placeId: "gplace-1",
+        rating: 4.8,
+        addedTime: 45,
+      },
+    ],
+  };
+
+  it("pairs the typed addresses with the resolved leg coordinates", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.tripName).toBe("Coastal drive");
+    expect(payload.origin).toEqual({
+      address: "San Francisco, CA",
+      lat: 37.77,
+      lng: -122.42,
+    });
+    expect(payload.destination).toEqual({
+      address: "Los Angeles, CA",
+      lat: 34.05,
+      lng: -118.24,
+    });
+  });
+
+  it("sums distance and duration across all legs and takes the encoded polyline", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.distanceMeters).toBe(616000);
+    expect(payload.durationSeconds).toBe(32400);
+    expect(payload.routePolyline).toBe("encoded_polyline_string");
+  });
+
+  it("maps detours to the backend shape", () => {
+    const payload = buildTripPayload(state, "Coastal drive");
+
+    expect(payload.detours).toEqual([
+      {
+        placeName: "Big Sur",
+        placeType: "Landmark",
+        latitude: 36.27,
+        longitude: -121.8,
+        placeId: "gplace-1",
+        rating: 4.8,
+        metadata: { addedTime: 45 },
+      },
+    ]);
+  });
+
+  it("degrades gracefully when route data is missing", () => {
+    const payload = buildTripPayload(
+      { origin: "A", destination: "B", route: {}, detourList: [] },
+      "Empty"
+    );
+
+    expect(payload.origin).toEqual({ address: "A", lat: null, lng: null });
+    expect(payload.destination).toEqual({ address: "B", lat: null, lng: null });
+    expect(payload.distanceMeters).toBeNull();
+    expect(payload.durationSeconds).toBeNull();
+    expect(payload.routePolyline).toBeNull();
+    expect(payload.detours).toEqual([]);
+  });
+
+  it("preserves a computed 0 distance/duration when a route (legs) exists", () => {
+    const payload = buildTripPayload(
+      {
+        origin: "A",
+        destination: "A",
+        route: {
+          legs: [
+            {
+              start_location: { lat: 1, lng: 2 },
+              end_location: { lat: 1, lng: 2 },
+              distance: { value: 0 },
+              duration: { value: 0 },
+            },
+          ],
+        },
+        detourList: [],
+      },
+      "Zero"
+    );
+
+    expect(payload.distanceMeters).toBe(0);
+    expect(payload.durationSeconds).toBe(0);
+  });
+});
+
+describe("TripRequester.listTrips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests the given page/limit with credentials and returns the data", async () => {
+    const data = { trips: [{ trip_id: "t1" }], total: 1, page: 2, limit: 5 };
+    axios.get.mockResolvedValue({ data });
+
+    const result = await new TripRequester().listTrips(2, 5);
+
+    const [url, options] = axios.get.mock.calls[0];
+    expect(url).toContain("/api/trips");
+    expect(options).toMatchObject({
+      params: { page: 2, limit: 5 },
+      withCredentials: true,
+    });
+    expect(result).toBe(data);
+  });
+
+  it("defaults to page 1 and limit 10", async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    await new TripRequester().listTrips();
+
+    const [, options] = axios.get.mock.calls[0];
+    expect(options.params).toEqual({ page: 1, limit: 10 });
+  });
+
+  it("propagates errors", async () => {
+    axios.get.mockRejectedValue(new Error("network"));
+
+    await expect(new TripRequester().listTrips()).rejects.toThrow("network");
+  });
+});

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -158,3 +158,29 @@ describe("TripRequester.listTrips", () => {
     await expect(new TripRequester().listTrips()).rejects.toThrow("network");
   });
 });
+
+describe("TripRequester.getTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests the trip by id with credentials and returns the data", async () => {
+    const data = { trip: { tripId: "t1" }, route: {}, detours: [] };
+    axios.get.mockResolvedValue({ data });
+
+    const result = await new TripRequester().getTrip("t1");
+
+    const [url, options] = axios.get.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.get.mockRejectedValue(new Error("not found"));
+
+    await expect(new TripRequester().getTrip("bad")).rejects.toThrow(
+      "not found"
+    );
+  });
+});

--- a/frontend/src/scripts/TripRequester.test.js
+++ b/frontend/src/scripts/TripRequester.test.js
@@ -121,6 +121,69 @@ describe("buildTripPayload", () => {
     expect(payload.distanceMeters).toBe(0);
     expect(payload.durationSeconds).toBe(0);
   });
+
+  it("falls back to saved values when there are no route legs (rename)", () => {
+    // A loaded trip's route has an encoded polyline but no legs, so the payload
+    // must preserve the saved distance/duration/coords instead of nulling them.
+    const fallback = {
+      origin: { address: "San Francisco, CA", lat: 37.77, lng: -122.42 },
+      destination: { address: "Los Angeles, CA", lat: 34.05, lng: -118.24 },
+      routePolyline: "saved_polyline",
+      distanceMeters: 616000,
+      durationSeconds: 32400,
+    };
+    const payload = buildTripPayload(
+      {
+        origin: "San Francisco, CA",
+        destination: "Los Angeles, CA",
+        route: { overview_polyline: { points: "saved_polyline" } },
+        detourList: [],
+      },
+      "Renamed trip",
+      fallback
+    );
+
+    expect(payload.distanceMeters).toBe(616000);
+    expect(payload.durationSeconds).toBe(32400);
+    expect(payload.origin).toEqual(fallback.origin);
+    expect(payload.destination).toEqual(fallback.destination);
+    expect(payload.routePolyline).toBe("saved_polyline");
+  });
+
+  it("prefers live route legs over the fallback when the trip was re-routed", () => {
+    const fallback = {
+      origin: { address: "Old", lat: 1, lng: 1 },
+      destination: { address: "Old", lat: 2, lng: 2 },
+      routePolyline: "old",
+      distanceMeters: 100,
+      durationSeconds: 100,
+    };
+    const payload = buildTripPayload(
+      {
+        origin: "New A",
+        destination: "New B",
+        route: {
+          overview_polyline: { points: "new" },
+          legs: [
+            {
+              start_location: { lat: 10, lng: 20 },
+              end_location: { lat: 30, lng: 40 },
+              distance: { value: 5000 },
+              duration: { value: 600 },
+            },
+          ],
+        },
+        detourList: [],
+      },
+      "Re-routed",
+      fallback
+    );
+
+    expect(payload.distanceMeters).toBe(5000);
+    expect(payload.durationSeconds).toBe(600);
+    expect(payload.origin).toEqual({ address: "New A", lat: 10, lng: 20 });
+    expect(payload.routePolyline).toBe("new");
+  });
 });
 
 describe("TripRequester.listTrips", () => {
@@ -182,5 +245,84 @@ describe("TripRequester.getTrip", () => {
     await expect(new TripRequester().getTrip("bad")).rejects.toThrow(
       "not found"
     );
+  });
+});
+
+describe("TripRequester.updateTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("PUTs the payload to the trip id with credentials and returns the data", async () => {
+    const payload = { tripName: "Updated" };
+    const data = { trip: { tripId: "t1", tripName: "Updated" } };
+    axios.put.mockResolvedValue({ data });
+
+    const result = await new TripRequester().updateTrip("t1", payload);
+
+    const [url, body, options] = axios.put.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(body).toBe(payload);
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.put.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().updateTrip("t1", {})).rejects.toThrow(
+      "boom"
+    );
+  });
+});
+
+describe("TripRequester.duplicateTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("POSTs to the duplicate endpoint with credentials and returns the data", async () => {
+    const data = { trip: { trip_id: "copy-1" } };
+    axios.post.mockResolvedValue({ data });
+
+    const result = await new TripRequester().duplicateTrip("t1");
+
+    const [url, body, options] = axios.post.mock.calls[0];
+    expect(url).toContain("/api/trips/t1/duplicate");
+    expect(body).toEqual({});
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.post.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().duplicateTrip("t1")).rejects.toThrow(
+      "boom"
+    );
+  });
+});
+
+describe("TripRequester.deleteTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("DELETEs the trip by id with credentials and returns the data", async () => {
+    const data = { message: "Trip deleted" };
+    axios.delete.mockResolvedValue({ data });
+
+    const result = await new TripRequester().deleteTrip("t1");
+
+    const [url, options] = axios.delete.mock.calls[0];
+    expect(url).toContain("/api/trips/t1");
+    expect(options).toMatchObject({ withCredentials: true });
+    expect(result).toBe(data);
+  });
+
+  it("propagates errors", async () => {
+    axios.delete.mockRejectedValue(new Error("boom"));
+
+    await expect(new TripRequester().deleteTrip("t1")).rejects.toThrow("boom");
   });
 });

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -28,6 +28,42 @@
   flex-direction: column;
 }
 
+/* Sign in / sign out control, pinned top-right above all layouts. */
+.auth-button {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-button button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #1a73e8;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.auth-button button:hover {
+  background-color: #1666c9;
+}
+
+.auth-button__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  background: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+}
+
 /* Desktop: sidebar is visible, so add left margin to avoid overlap */
 @media only screen and (min-width: 1025px) {
   .app-container {

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -83,13 +83,23 @@
   flex-direction: column;
   gap: 4px;
   position: relative;
+  /* Leave room in the top-right corner for the options (ellipsis) menu. */
+  padding-right: 40px;
 }
 
-/* Overlay the load spinner in the corner so it never resizes the card. */
+/* Overlay the load spinner in the corner so it never resizes the card. Sits to
+   the left of the options menu so the two never overlap. */
 .my-trips-card__spinner {
   position: absolute;
   top: 8px;
-  right: 8px;
+  right: 44px;
+}
+
+/* Options (ellipsis) menu pinned to the card's top-right corner. */
+.my-trips-card__menu {
+  position: absolute;
+  top: 4px;
+  right: 4px;
 }
 
 .my-trips-pager {
@@ -283,6 +293,55 @@
 .save-trip-btn:active {
   background-color: #146c2e !important;
   color: #ffffff !important;
+}
+
+/* Save Trip section — sits at the bottom of the trip timeline. Left-aligned to
+   override the app-wide centered text, with sidebar-matching side padding. */
+.save-trip-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 15px 20px;
+  text-align: left;
+}
+
+/* Trip name — sits above the trip timeline, sidebar-matching side padding. */
+.trip-name-section {
+  padding: 10px 15px 4px;
+  text-align: left;
+}
+
+/* Trip name — full width, left-aligned, with a bit of polish over the plain
+   default input. */
+.trip-name-field {
+  width: 100%;
+}
+
+.trip-name-field label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: #1f3d2b;
+  margin-bottom: 4px;
+}
+
+.trip-name-input {
+  width: 100%;
+  border-radius: 8px;
+  background-color: #f4f9f5;
+  border-color: #cfe3d5;
+  transition:
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
+}
+
+.trip-name-input:hover {
+  background-color: #eef6f0;
+}
+
+.trip-name-input:focus-within {
+  background-color: #ffffff;
+  border-color: #188038;
 }
 
 /* Apply rounded pill-like styling to all buttons */

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -28,12 +28,19 @@
   flex-direction: column;
 }
 
-/* Sign in / sign out control, pinned top-right above all layouts. */
-.auth-button {
+/* Top-right toolbar holding the My Trips + sign-in/out controls. */
+.app-toolbar {
   position: fixed;
   top: 12px;
   right: 12px;
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Sign in / sign out control. */
+.auth-button {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -62,6 +69,27 @@
   padding: 6px 10px;
   border-radius: 4px;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* My Trips drawer list. */
+.my-trips-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.my-trips-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.my-trips-pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
 }
 
 /* Desktop: sidebar is visible, so add left margin to avoid overlap */
@@ -230,6 +258,23 @@
   cursor: not-allowed;
   background-color: transparent;
   color: #6c757d;
+}
+
+/* Save Trip — pill shape to match the detour/route buttons; green to signal a
+   positive "save/commit" action, distinct from the blue Add Detour button. */
+.save-trip-btn {
+  width: 100%;
+  border-radius: 1.5rem !important;
+  background-color: #188038 !important;
+  color: #ffffff !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.save-trip-btn:hover,
+.save-trip-btn:active {
+  background-color: #146c2e !important;
+  color: #ffffff !important;
 }
 
 /* Apply rounded pill-like styling to all buttons */

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -82,6 +82,14 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  position: relative;
+}
+
+/* Overlay the load spinner in the corner so it never resizes the card. */
+.my-trips-card__spinner {
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 .my-trips-pager {

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,62 @@
+# JauntDetour Infrastructure (Terraform)
+
+Infrastructure-as-Code for the JauntDetour Azure resources. Currently provisions the
+**Azure Database for PostgreSQL — Flexible Server** (dev free tier) plus its database and
+firewall rules.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) >= 2.30, authenticated:
+  ```pwsh
+  az login
+  az account set --subscription "<your-subscription-id>"
+  ```
+
+## Usage
+
+```pwsh
+cd infra
+Copy-Item terraform.tfvars.example terraform.tfvars   # then edit values
+
+# Provide the admin password without committing it:
+$env:TF_VAR_admin_password = "<strong-password>"
+
+terraform init
+terraform validate
+terraform plan
+terraform apply        # type "yes" to confirm
+```
+
+After apply, read the connection details:
+
+```pwsh
+terraform output server_fqdn
+terraform output database_name
+```
+
+Use those values to populate the backend `.env` (`DB_HOST`, `DB_NAME`) and apply the schema —
+see [../docs/database/implementation-guide.md](../docs/database/implementation-guide.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `providers.tf` | Terraform + azurerm provider versions |
+| `variables.tf` | Input variables (names, SKU, storage, credentials) |
+| `main.tf` | PostgreSQL server, database, firewall, TLS config (deployed into an existing resource group) |
+| `outputs.tf` | Server FQDN, database name, admin login, resource group |
+| `terraform.tfvars.example` | Template for your local variable values |
+
+## Notes
+
+- The `resource_group_name` must be an **existing** resource group. Terraform references it as a
+  data source — it does not create, modify, or delete the resource group or anything else already
+  in it. Only the database server, database, firewall rules, and TLS setting are created. The server 
+  is deployed to `var.location` (default `centralus`), which may differ from the resource group's region.
+- `admin_password` is **sensitive** — pass it via `TF_VAR_admin_password` or a gitignored
+  `terraform.tfvars`. Never commit it.
+- `terraform.tfvars`, `*.tfstate`, and `.terraform/` are gitignored.
+- The dev tier uses Burstable `B_Standard_B1ms`, 32 GB, 7-day backups, no HA — covered by the
+  Azure 12-month free tier. Production hardening (HA, geo-redundant backups, private endpoint)
+  is documented in the implementation guide and is intentionally out of scope here.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,70 @@
+# Reference an existing resource group; Terraform does not create or modify it.
+data "azurerm_resource_group" "main" {
+  name = var.resource_group_name
+}
+
+# Azure Database for PostgreSQL - Flexible Server.
+# Dev defaults (B1ms / Burstable / 32 GB) are covered by the 12-month free tier.
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = var.server_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+
+  version  = var.postgres_version
+  sku_name = var.sku_name
+
+  storage_mb            = var.storage_mb
+  backup_retention_days = var.backup_retention_days
+
+  administrator_login    = var.admin_login
+  administrator_password = var.admin_password
+
+  # No high availability or geo-redundant backups on the free dev tier.
+  zone = "1"
+
+  tags = {
+    Project     = "JauntDetour"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    # Azure may assign/adjust the availability zone; ignore drift to avoid noisy plans.
+    ignore_changes = [zone]
+  }
+}
+
+# Application database.
+resource "azurerm_postgresql_flexible_server_database" "main" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Allow other Azure services (e.g. the App Service / container) to reach the server.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  name             = "AllowAzureServices"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+# Optional: allow a single developer machine through the firewall for local testing.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "dev_client" {
+  count            = var.dev_client_ip == "" ? 0 : 1
+  name             = "AllowDevClient"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = var.dev_client_ip
+  end_ip_address   = var.dev_client_ip
+}
+
+# Enforce TLS for all connections (Azure default, set explicitly for clarity).
+resource "azurerm_postgresql_flexible_server_configuration" "require_ssl" {
+  name      = "require_secure_transport"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "ON"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "server_fqdn" {
+  description = "Fully qualified domain name of the PostgreSQL server (use as DB_HOST)."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "database_name" {
+  description = "Name of the application database (use as DB_NAME)."
+  value       = azurerm_postgresql_flexible_server_database.main.name
+}
+
+output "admin_login" {
+  description = "Administrator login (use as DB_USER for the initial schema load)."
+  value       = azurerm_postgresql_flexible_server.main.administrator_login
+}
+
+output "resource_group_name" {
+  description = "Resource group containing the database."
+  value       = data.azurerm_resource_group.main.name
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  # The subscription already has resources, so its resource providers are
+  # registered. Skip automatic registration, which requires subscription-level
+  # permissions and otherwise stalls the plan.
+  resource_provider_registrations = "none"
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit real credentials.
+
+# Must be an EXISTING resource group. The database is created inside it;
+# The server's region is controlled by the `location` variable (default: centralus).
+resource_group_name   = "jauntdetour-rg"
+environment           = "development"
+server_name           = "jauntdetour-db-dev"
+database_name         = "jauntdetour"
+postgres_version      = "14"
+sku_name              = "B_Standard_B1ms"
+storage_mb            = 32768
+backup_retention_days = 7
+admin_login           = ""
+
+# Provide the admin password securely instead of storing it here, e.g.:
+#   $env:TF_VAR_admin_password = "<strong-password>"   (PowerShell)
+# admin_password = "set-via-TF_VAR_admin_password"
+
+# Your current public IP, to allow local psql access (optional).
+# dev_client_ip = ""

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,71 @@
+variable "resource_group_name" {
+  description = "Name of the existing Azure resource group to deploy the database into."
+  type        = string
+  default     = "jauntdetour-rg"
+}
+
+variable "environment" {
+  description = "Deployment environment tag (e.g. development, production)."
+  type        = string
+  default     = "production"
+}
+
+variable "location" {
+  description = "Azure region for the PostgreSQL server. May differ from the resource group's region."
+  type        = string
+  default     = "centralus"
+}
+
+variable "server_name" {
+  description = "Globally unique name of the PostgreSQL Flexible Server."
+  type        = string
+  default     = "jauntdetour-db-prod"
+}
+
+variable "database_name" {
+  description = "Name of the application database created on the server."
+  type        = string
+  default     = "jauntdetour"
+}
+
+variable "postgres_version" {
+  description = "Major PostgreSQL version."
+  type        = string
+  default     = "14"
+}
+
+variable "sku_name" {
+  description = "Compute SKU. Burstable B1ms is covered by the 12-month free tier."
+  type        = string
+  default     = "B_Standard_B1ms"
+}
+
+variable "storage_mb" {
+  description = "Provisioned storage in MB (32 GB = 32768)."
+  type        = number
+  default     = 32768
+}
+
+variable "backup_retention_days" {
+  description = "Automated backup retention window in days."
+  type        = number
+  default     = 7
+}
+
+variable "admin_login" {
+  description = "Administrator login for the PostgreSQL server."
+  type        = string
+  default     = "dbadmin"
+}
+
+variable "admin_password" {
+  description = "Administrator password. Provide via TF_VAR_admin_password or a .tfvars file — never commit it."
+  type        = string
+  sensitive   = true
+}
+
+variable "dev_client_ip" {
+  description = "Public IP allowed through the server firewall for local development. Leave empty to skip the rule."
+  type        = string
+  default     = ""
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "devDependencies": {
         "concurrently": "^8.2.0",
         "dotenv": "^16.3.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.5.2",
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -24,6 +26,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -165,6 +183,93 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -200,6 +305,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -233,6 +355,21 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/date-fns": {
@@ -290,6 +427,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -298,6 +448,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -338,6 +519,32 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -359,6 +566,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore-by-default": {
@@ -424,12 +657,374 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -513,6 +1108,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -524,6 +1174,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.1.tgz",
+      "integrity": "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pstree.remy": {
@@ -556,6 +1219,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -579,6 +1282,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -590,6 +1316,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -605,11 +1344,64 @@
         "node": ">=10"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -637,6 +1429,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -702,6 +1507,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -728,6 +1549,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -2,20 +2,25 @@
   "name": "jauntdetour",
   "version": "1.0.0",
   "description": "Road trip planning app with detours",
-  "private": true,  "scripts": {
+  "private": true,
+  "scripts": {
     "dev": "concurrently \"npm run backend:dev\" \"npm run frontend:dev\"",
     "backend:dev": "cd backend && node -r dotenv/config index.js",
     "frontend:dev": "cd frontend && npm start",
     "backend:start": "cd backend && node index.js",
     "frontend:start": "cd frontend && npm start",
     "install:all": "npm install --prefix ./backend && npm install --prefix ./frontend",
-    "build:frontend": "cd frontend && npm run build"
-  },"devDependencies": {
+    "build:frontend": "cd frontend && npm run build",
+    "prepare": "husky"
+  },
+  "devDependencies": {
     "concurrently": "^8.2.0",
     "dotenv": "^16.3.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.5.2",
     "nodemon": "^3.0.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jauntdetour",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Road trip planning app with detours",
   "private": true,
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,20 @@ export NODE_ENV="development"
 export NODE_ENV="production"
 ```
 
+Database connection (backend)
+```
+DB_HOST=<host>
+DB_PORT=5432
+DB_NAME=<database>
+DB_USER=<user>
+DB_PASSWORD=<password>
+DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
+```
+When using the DevContainer, the `DB_*` values are provided automatically from
+`.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
+For the schema, data-access layer, and Azure/production setup, see
+[docs/database/implementation-guide.md](docs/database/implementation-guide.md).
+
 ### Installing
 
 A step by step series of examples that tell you how to get a development env running
@@ -59,11 +73,19 @@ npm install
 For the best development experience, use the provided DevContainer or the convenience scripts:
 
 ### Option 1: DevContainer (VS Code)
-1. Open the project in VS Code
-2. Install the "Dev Containers" extension
-3. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
-4. The container will automatically install all dependencies
-5. Use `Ctrl+Shift+P` → "Tasks: Run Task" → "Start Full Stack Development"
+1. Copy the environment template and add your Google Maps API key:
+   ```bash
+   cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+   ```
+2. Open the project in VS Code
+3. Install the "Dev Containers" extension
+4. Press `Ctrl+Shift+P` → "Dev Containers: Reopen in Container"
+5. The container installs all dependencies and starts a local PostgreSQL 14 database (created and seeded automatically)
+6. Run `npm run dev` to start the frontend and backend
+
+The DevContainer includes a PostgreSQL sidecar, so the app runs against a local
+database with no cloud setup required. See [DEV-SETUP.md](DEV-SETUP.md) for details,
+connection info, and how to reset the database.
 
 ### Option 2: Local Development with Scripts
 Install root-level dependencies first:
@@ -88,6 +110,13 @@ npm run backend:dev
 # Frontend only  
 npm run frontend:dev
 ```
+
+### Database
+Local development uses a PostgreSQL database that runs automatically inside the
+DevContainer (see Option 1 above) — no manual database install needed. The backend
+connects through the `DB_*` environment variables. For the schema, the data-access
+layer, resetting local data, and Azure/production provisioning (Terraform), see
+[DEV-SETUP.md](DEV-SETUP.md) and [docs/database/implementation-guide.md](docs/database/implementation-guide.md).
 
 ## Original Manual Setup
 
@@ -209,8 +238,9 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 ## Built With
 
-* [Node v10.15.3](https://nodejs.org/en/download/) - Runtime environment
+* [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
 * [Express](https://expressjs.com/) - Web framework used for backend
+* [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
 * [React](https://reactjs.org/) - Library used to build the frontend
 * [Redux](https://redux.js.org/) - State management library
 * [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API

--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,13 @@ Often during a road trip, you want to stop at a nice place for lunch an hour dow
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
-Jauntdetour consists of a lightweight frontend that is built in React that interfaces with a NodeJS backend deployed on an Ubuntu server. 
+Jauntdetour consists of a lightweight frontend that is built in React that interfaces with a NodeJS backend deployed on an Ubuntu server.
 
 ### Prerequisites
 
-This project was built with NodeJS (v10.15.3). You can obtain the latest version from the URL below.
+This project requires **Node.js >= 20** (`@azure/msal-node`, used for
+authentication, requires Node 20+). The dev container already provides Node 20.
+For a local install, get the latest LTS from the URL below.
 
 ```
 https://nodejs.org/en/download/
@@ -21,11 +23,13 @@ https://nodejs.org/en/download/
 Both the frontend and backend use environment variables in their configuration. These are used to set the Google API key and to determine if this is a development or production environment
 
 Google API key
+
 ```
 export GOOGLE_API_KEY=<key>
 ```
 
 Node environment
+
 ```
 // If this is going on a development environment such as a laptop
 export NODE_ENV="development"
@@ -35,6 +39,7 @@ export NODE_ENV="production"
 ```
 
 Database connection (backend)
+
 ```
 DB_HOST=<host>
 DB_PORT=5432
@@ -43,10 +48,32 @@ DB_USER=<user>
 DB_PASSWORD=<password>
 DB_SSL=false   # local Postgres; leave unset for Azure (SSL required)
 ```
+
+Authentication & session (backend) — Microsoft Entra External ID
+
+```
+ENTRA_TENANT_SUBDOMAIN=<subdomain>        # the <sub> in <sub>.ciamlogin.com
+ENTRA_TENANT_ID=<tenant directory GUID>   # required in the CIAM authority path
+ENTRA_CLIENT_ID=<app registration client id>
+ENTRA_CLIENT_SECRET=<app registration client secret>
+ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
+SESSION_SECRET=<long random string>       # e.g. openssl rand -base64 32
+FRONTEND_URL=http://localhost:3001        # CORS origin + post-login redirect
+```
+
+Frontend
+
+```
+REACT_APP_GOOGLE_API_KEY=<key>
+REACT_APP_BACKEND_URL=<backend base URL>   # optional; defaults by NODE_ENV
+```
+
 When using the DevContainer, the `DB_*` values are provided automatically from
 `.devcontainer/devcontainer.env` and point at the bundled local PostgreSQL database.
 For the schema, data-access layer, and Azure/production setup, see
 [docs/database/implementation-guide.md](docs/database/implementation-guide.md).
+For authentication setup, see
+[docs/authentication/implementation-guide.md](docs/authentication/implementation-guide.md).
 
 ### Installing
 
@@ -73,6 +100,7 @@ npm install
 For the best development experience, use the provided DevContainer or the convenience scripts:
 
 ### Option 1: DevContainer (VS Code)
+
 1. Copy the environment template and add your Google Maps API key:
    ```bash
    cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
@@ -88,30 +116,36 @@ database with no cloud setup required. See [DEV-SETUP.md](DEV-SETUP.md) for deta
 connection info, and how to reset the database.
 
 ### Option 2: Local Development with Scripts
+
 Install root-level dependencies first:
+
 ```bash
 npm install
 ```
 
 Then start both services:
+
 ```bash
 npm run dev
 ```
 
 This will start:
+
 - Backend on http://localhost:3000
 - Frontend on http://localhost:3001
 
 ### Individual Services
+
 ```bash
 # Backend only (with auto-restart)
 npm run backend:dev
 
-# Frontend only  
+# Frontend only
 npm run frontend:dev
 ```
 
 ### Database
+
 Local development uses a PostgreSQL database that runs automatically inside the
 DevContainer (see Option 1 above) — no manual database install needed. The backend
 connects through the `DB_*` environment variables. For the schema, the data-access
@@ -143,12 +177,14 @@ npm install
 To run in a development environment, follow the following steps
 
 Start the backend
+
 ```
 cd /<repo-root-dir>/backend
 node index.js
 ```
 
 Start the frontend
+
 ```
 cd ../frontend
 npm start
@@ -163,6 +199,7 @@ This project includes comprehensive unit tests and linting to ensure code qualit
 ### Running Tests Locally
 
 #### Frontend Tests
+
 ```bash
 cd frontend
 
@@ -177,6 +214,7 @@ npm run test:coverage
 ```
 
 #### Backend Tests
+
 ```bash
 cd backend
 
@@ -193,6 +231,7 @@ npm run test:coverage
 ### Running Linters
 
 #### Frontend Linting
+
 ```bash
 cd frontend
 
@@ -210,6 +249,7 @@ npm run format
 ```
 
 #### Backend Linting
+
 ```bash
 cd backend
 
@@ -229,6 +269,7 @@ npm run format
 ### Continuous Integration
 
 All pushes and pull requests automatically trigger the CI pipeline which:
+
 - Runs ESLint on both frontend and backend
 - Runs Prettier to check code formatting
 - Executes all unit tests
@@ -238,12 +279,12 @@ All pushes and pull requests automatically trigger the CI pipeline which:
 
 ## Built With
 
-* [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
-* [Express](https://expressjs.com/) - Web framework used for backend
-* [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
-* [React](https://reactjs.org/) - Library used to build the frontend
-* [Redux](https://redux.js.org/) - State management library
-* [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API
+- [Node.js (>=18.12.0)](https://nodejs.org/en/download/) - Runtime environment
+- [Express](https://expressjs.com/) - Web framework used for backend
+- [PostgreSQL](https://www.postgresql.org/) - Relational database, accessed via [node-postgres (`pg`)](https://node-postgres.com/)
+- [React](https://reactjs.org/) - Library used to build the frontend
+- [Redux](https://redux.js.org/) - State management library
+- [google-maps-react](https://github.com/fullstackreact/google-maps-react) - React library for wrapping the Google Maps API
 
 ## Versioning
 
@@ -251,17 +292,21 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## CI/CD
 
-This project uses GitHub Actions for continuous integration and deployment. 
+This project uses GitHub Actions for continuous integration and deployment.
 
 ### Continuous Integration (CI)
+
 Every push and pull request triggers automated checks:
+
 - **Linting**: ESLint validates code quality for both frontend (React best practices) and backend (Node.js best practices)
 - **Formatting**: Prettier ensures consistent code formatting
 - **Unit Tests**: All tests must pass before merging
 - **Build**: Verifies the application builds successfully
 
 ### Continuous Deployment (CD)
+
 The deployment pipeline automatically:
+
 - Detects changes in backend and frontend directories
 - Builds Docker containers (`jauntdetour-backend` and `jauntdetour-frontend`)
 - Automatically bumps versions (patch by default, configurable via commit messages)
@@ -274,8 +319,8 @@ For detailed information about the CI/CD pipeline, version management, and deplo
 
 ## Authors
 
-* **Anthony Gray** - *Initial work* - [Portfolio](https://anthonyrgray.com)
+- **Anthony Gray** - _Initial work_ - [Portfolio](https://anthonyrgray.com)
 
 ## Acknowledgments
 
-* Thank you to the Digital Crafts instructors that helped me get this project off the ground
+- Thank you to the Digital Crafts instructors that helped me get this project off the ground


### PR DESCRIPTION
## Release v1.2.0 — Accounts, database, infrastructure & saved trips

Promotes `development` to `main`. **Merging this deploys to production** (push to `main` builds + deploys the changed services via the CI/CD pipeline). This is the first release carrying user accounts, the database, and infrastructure-as-code, so treat it as a foundational deploy rather than a routine one.

> **Versions (coupled major.minor, independent patch):** root/backend/frontend all `→ 1.2.0`. Frontend and backend cross to the `1.2` compatibility line together because the frontend depends on the new backend endpoints. Tag after merge: `v1.2.0`.

### What's shipping

**Authentication — Microsoft Entra External ID (CIAM)**
- Backend-driven confidential-client OAuth (MSAL Node, auth-code + PKCE) with a server-side session cookie.
- Sign in / sign out; `requireAuth` middleware sets `req.userId` as the authorization boundary (every data access is user-scoped).

**Database — PostgreSQL**
- `pg`-backed data layer with the repository pattern (users → trips → detours), parameterized queries, and transactions for multi-row writes.
- Defined schema (`docs/database/schema.sql`); trips → detours use `ON DELETE CASCADE`.
- Local Postgres dev-container setup.

**Infrastructure as code — Terraform**
- `infra/` Terraform defines the Azure resources (registry, web apps, database, etc.) so environments are reproducible and reviewable.

**Saved trips — full lifecycle**
- **Save** a trip and **view** saved trips (My Trips drawer).
- **Load** a saved trip back onto the map.
- **Update / rename**, **delete** (with confirmation), and **duplicate** ("Copy of {name}") saved trips.
- Save-flow polish: single **Save Trip** button, editable **Trip name** field above the timeline, live-refreshing list, and a fix so a rename no longer wipes distance/duration/coordinates.

### API surface (all behind `requireAuth`, user-scoped, additive)
`GET/POST /api/trips`, `GET/PUT/DELETE /api/trips/:tripId`, `POST /api/trips/:tripId/duplicate`, plus the `/auth/*` sign-in/out endpoints.

### Deploy impact & prerequisites
⚠️ This release depends on auth, a database, and provisioned infrastructure — confirm the production environment is ready **before** merging:
- **Infrastructure:** apply/verify the `infra/` Terraform so the Web Apps, container registry, and PostgreSQL instance exist.
- **Database:** apply `docs/database/schema.sql` to the production database.
- **Backend env:** `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_TENANT_ID`, `ENTRA_CLIENT_ID`, `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI`, `SESSION_SECRET`, `FRONTEND_URL`, and Postgres connection settings.
  - The MSAL authority **must include the tenant ID in the path** (`https://<subdomain>.ciamlogin.com/<tenantId>`) or CIAM discovery fails.
- **Cross-site cookies:** in production the session cookie is `sameSite=none; secure`; CORS uses an explicit `FRONTEND_URL` with credentials — make sure both hosts and URLs are set correctly.
- **Frontend build:** `REACT_APP_GOOGLE_API_KEY` is injected via CI secret.
- **Runtime:** `@azure/msal-node` requires **Node ≥ 20**; ensure prod runtime and CI use Node 20.
- Sessions use the in-memory store (fine for a single instance; needs a persistent store before scaling out).

### Testing
- CI green on `development`: backend `149` tests, frontend `69` tests, lint + format pass.
- Manually verified end-to-end: sign in/out, save, view, load, update/rename (incl. rename-only regression), delete (confirm + cancel), duplicate, and live list refresh.

### Post-deploy checks
1. Both Web Apps healthy; images tagged `1.2.0` deployed.
2. Sign in / sign out works against production Entra config (redirect URI matches).
3. Create → view → load → update → duplicate → delete a trip end-to-end against the prod database.

### Rollback
Re-deploy the previous known-good image tags to the Web Apps, or revert this merge on `main` and let the pipeline redeploy. Note: infrastructure/schema changes applied via Terraform/SQL are not undone by a code rollback — roll those back separately if needed.

### Notes
- Concurrency is last-write-wins (no version column). Duplicated trips are a full copy (status included).
- `development` is **not** deleted; continue feature work there.