### PR TITLE
Clear planner on logout to prevent trip persisting after sign-out

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -14,9 +14,27 @@ import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 // to sessionStorage so it's per-tab and cleared when the tab closes. `user` is
 // deliberately not persisted: auth state is always re-resolved from /auth/me.
 const PERSIST_KEY = "jaunt.tripState";
+// Set by AuthRequester.logout after a successful sign-out. When present on
+// load, we discard the previous user's persisted planning state instead of
+// rehydrating it — deferring the clear to here means nothing is visibly erased
+// before the Entra logout redirect, and the app returns to a clean, empty
+// state. See the "Planned trip persists after logout" fix.
+const LOGOUT_FLAG = "jaunt.pendingLogout";
 
 function loadState() {
   try {
+    if (sessionStorage.getItem(LOGOUT_FLAG)) {
+      // Returning from a sign-out: drop every app-owned key (all namespaced
+      // under "jaunt.", including the flag itself) so nothing lingers for a
+      // signed-out visitor on a shared browser, and start from empty state.
+      for (let i = sessionStorage.length - 1; i >= 0; i--) {
+        const key = sessionStorage.key(i);
+        if (key && key.startsWith("jaunt.")) {
+          sessionStorage.removeItem(key);
+        }
+      }
+      return undefined;
+    }
     const saved = sessionStorage.getItem(PERSIST_KEY);
     return saved ? JSON.parse(saved) : undefined;
   } catch {

--- a/frontend/src/scripts/AuthRequester.js
+++ b/frontend/src/scripts/AuthRequester.js
@@ -56,7 +56,13 @@ export default class AuthRequester {
         // index.js) — deferred so nothing is visibly erased before the
         // redirect, and set only after the backend session is actually
         // destroyed so a failed logout doesn't wipe an in-progress trip.
-        sessionStorage.setItem("jaunt.pendingLogout", "1");
+        try {
+          sessionStorage.setItem("jaunt.pendingLogout", "1");
+        } catch (storageError) {
+          // Best-effort UX/privacy helper: if storage is disabled or full,
+          // never let it block the sign-out navigation below.
+          log.error("Failed to set pending logout flag:", storageError);
+        }
         const logoutUrl = response.data && response.data.logoutUrl;
         if (logoutUrl) {
           window.location.assign(logoutUrl);

--- a/frontend/src/scripts/AuthRequester.js
+++ b/frontend/src/scripts/AuthRequester.js
@@ -51,6 +51,12 @@ export default class AuthRequester {
     return axios
       .post(this.getUrlBase() + "/auth/logout", {}, { withCredentials: true })
       .then((response) => {
+        // Mark that a sign-out completed so the app discards the previous
+        // user's persisted planning state on the next load (see loadState in
+        // index.js) — deferred so nothing is visibly erased before the
+        // redirect, and set only after the backend session is actually
+        // destroyed so a failed logout doesn't wipe an in-progress trip.
+        sessionStorage.setItem("jaunt.pendingLogout", "1");
         const logoutUrl = response.data && response.data.logoutUrl;
         if (logoutUrl) {
           window.location.assign(logoutUrl);

--- a/frontend/src/scripts/AuthRequester.test.js
+++ b/frontend/src/scripts/AuthRequester.test.js
@@ -59,4 +59,25 @@ describe("AuthRequester.logout", () => {
     expect(window.location.assign).not.toHaveBeenCalled();
     expect(window.location.reload).not.toHaveBeenCalled();
   });
+
+  it("still redirects when setting the logout flag throws", async () => {
+    axios.post.mockResolvedValue({
+      data: { logoutUrl: "http://entra.test/logout" },
+    });
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+
+    try {
+      await new AuthRequester().logout();
+
+      expect(window.location.assign).toHaveBeenCalledWith(
+        "http://entra.test/logout"
+      );
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
 });

--- a/frontend/src/scripts/AuthRequester.test.js
+++ b/frontend/src/scripts/AuthRequester.test.js
@@ -1,0 +1,62 @@
+import axios from "axios";
+import AuthRequester from "./AuthRequester";
+
+jest.mock("axios");
+
+jest.mock("../utils/logger", () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.mock("../config/config.js", () => ({
+  BACKEND_URL: "http://backend.test",
+}));
+
+describe("AuthRequester.logout", () => {
+  let originalLocation;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    // jsdom's window.location.assign is not implemented, so swap in a mock.
+    originalLocation = window.location;
+    delete window.location;
+    window.location = { assign: jest.fn(), reload: jest.fn() };
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  it("flags a pending logout and redirects to the Entra logout URL on success", async () => {
+    axios.post.mockResolvedValue({
+      data: { logoutUrl: "http://entra.test/logout" },
+    });
+
+    await new AuthRequester().logout();
+
+    expect(sessionStorage.getItem("jaunt.pendingLogout")).toBe("1");
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "http://entra.test/logout"
+    );
+  });
+
+  it("flags a pending logout and reloads when no logout URL is returned", async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    await new AuthRequester().logout();
+
+    expect(sessionStorage.getItem("jaunt.pendingLogout")).toBe("1");
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it("does not flag a logout when the request fails", async () => {
+    axios.post.mockRejectedValue(new Error("network down"));
+
+    await new AuthRequester().logout();
+
+    expect(sessionStorage.getItem("jaunt.pendingLogout")).toBeNull();
+    expect(window.location.assign).not.toHaveBeenCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Fix: Planned trip persists after logout (#91)

### Summary
After signing in, planning a trip, and logging out, the planned trip stayed loaded — reloading or revisiting while signed out still showed it. On a shared browser this exposed the previous user's in-progress/loaded trip (name + loaded trip id) via `sessionStorage`.

The planning state is persisted to `sessionStorage` (`jaunt.tripState`) so an in-progress trip survives the sign-in redirect. Logout only dispatched `CLEAR_USER`, leaving the planning slice and the persisted key intact, so it rehydrated on the next load.

### Approach
The clear is **deferred to the next app load** and tied to a **successful** logout, so nothing is visibly erased before the Entra redirect and an in-progress trip isn't wiped if logout fails:

- `AuthRequester.logout` sets a `jaunt.pendingLogout` flag **only after** the backend session is destroyed, just before the redirect/reload.
- `index.js` `loadState` honors the flag on the next load: it discards the persisted planner and removes all `jaunt.*` keys, returning empty state.

This keeps the smooth UX (no flash of the trip erasing in front of the user) while guaranteeing a signed-out visitor lands on an empty planner.

### Changes
| File | Change |
|---|---|
| `frontend/src/scripts/AuthRequester.js` | Set `jaunt.pendingLogout` flag on successful logout, before the redirect |
| `frontend/src/index.js` | `loadState` discards persisted planner + wipes `jaunt.*` keys when the flag is present |
| `frontend/src/scripts/AuthRequester.test.js` | **New** — covers flag+redirect on success, flag+reload when no URL, and no flag on failure |

### How to test
**Automated:**
```bash
cd frontend && CI=true npm test