### PR TITLE
hotfix: restore saved Jaunt list loading

### DIFF
--- a/backend/app/repositories/TripRepository.js
+++ b/backend/app/repositories/TripRepository.js
@@ -150,13 +150,8 @@ class TripRepository {
     let position = 1;
     let text = `
       SELECT ${RETURNING_COLUMNS},
-        COALESCE(dc.detour_count, 0) AS detour_count
+        (SELECT COUNT(*)::int FROM detours d WHERE d.trip_id = trips.trip_id) AS detour_count
       FROM trips
-      LEFT JOIN (
-        SELECT d.trip_id, COUNT(*)::int AS detour_count
-        FROM detours d
-        GROUP BY d.trip_id
-      ) dc ON dc.trip_id = trips.trip_id
       WHERE user_id = $1
     `;
     if (status !== undefined) {

--- a/backend/app/repositories/TripRepository.test.js
+++ b/backend/app/repositories/TripRepository.test.js
@@ -167,7 +167,8 @@ describe("TripRepository", () => {
       const [sql, params] = pool.query.mock.calls[0];
       expect(sql).toContain("WHERE user_id = $1");
       expect(sql).toContain("AS detour_count");
-      expect(sql).toContain("dc.trip_id = trips.trip_id");
+      expect(sql).toContain("d.trip_id = trips.trip_id");
+      expect(sql).not.toContain("LEFT JOIN");
       expect(sql).toContain("ORDER BY created_at DESC");
       expect(sql).not.toContain("status = $2");
       expect(params).toEqual([USER_ID]);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capstone-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capstone-backend",
-      "version": "1.1.2",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^5.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstone-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- replace ambiguous detour-count join with a correlated query
- add SQL regression coverage
- bump backend release to 1.3.1