### PR TITLE
hotfix: cors allow list for backend (#102)

### DIFF
--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -17,8 +17,12 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
-# Frontend origin used by the backend for CORS and post-login/logout redirects.
+# Frontend destination used for post-login/logout redirects.
 FRONTEND_URL=http://localhost:3001
+
+# Comma-delimited frontend origins allowed to make credentialed API requests.
+# Defaults to FRONTEND_URL when unset.
+CORS_ALLOWED_ORIGINS=http://localhost:3001
 
 # Express session signing secret. Generate a long random value, e.g.
 #   openssl rand -base64 32

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ BACKEND_PORT=3000
 # Frontend development server configuration
 FRONTEND_PORT=3001
 
+# Backend authentication redirect and credentialed CORS configuration
+FRONTEND_URL=http://localhost:3001
+CORS_ALLOWED_ORIGINS=http://localhost:3001
+
 # Database connection (Azure Database for PostgreSQL - Flexible Server)
 # DB_HOST is the server FQDN from `terraform output server_fqdn`
 DB_HOST=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,11 +32,13 @@ trips.
     (`https://<subdomain>.ciamlogin.com/<tenantId>`) or CIAM discovery fails with
     `endpoints_resolution_error`. Config: `backend/config/auth.js`.
   - Env: `ENTRA_TENANT_SUBDOMAIN`, `ENTRA_TENANT_ID`, `ENTRA_CLIENT_ID`,
-    `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI`, `SESSION_SECRET`, `FRONTEND_URL`.
+    `ENTRA_CLIENT_SECRET`, `ENTRA_REDIRECT_URI`, `SESSION_SECRET`, `FRONTEND_URL`,
+    `CORS_ALLOWED_ORIGINS`.
 - **Cookies/CORS**: session cookie is `httpOnly`; `sameSite="none"` + `secure` in
   prod (frontend/backend are cross-site on `*.azurewebsites.net`), `lax` in dev.
-  CORS uses an explicit origin (`FRONTEND_URL`) + `credentials: true`; frontend
-  axios calls that need auth use `withCredentials: true`.
+  CORS uses the explicit `CORS_ALLOWED_ORIGINS` allowlist + `credentials: true`
+  (falling back to `FRONTEND_URL`); frontend axios calls that need auth use
+  `withCredentials: true`.
 - **Data access: repository pattern** (`backend/app/repositories/*Repository.js`).
   A `pg` pool (or a transaction client) is injected via the constructor. All SQL
   is parameterized. Every query is scoped by `user_id`.

--- a/.github/scripts/verify-production-cors.sh
+++ b/.github/scripts/verify-production-cors.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# verify-production-cors.sh
+# Verify credentialed CORS behavior for the deployed Jaunt API.
+
+set -euo pipefail
+
+readonly API_BASE_URL="${API_BASE_URL:-https://api.jauntdetour.com}"
+readonly UNTRUSTED_ORIGIN="https://example.com"
+
+err() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_unauthenticated_response() {
+  local status="$1"
+  local origin="$2"
+
+  if [[ "${status}" != "401" ]]; then
+    err "Expected /auth/me to return 401 for ${origin}, received ${status}"
+  fi
+}
+
+assert_header() {
+  local headers_file="$1"
+  local expected_header="$2"
+
+  if ! tr -d '\r' < "${headers_file}" \
+    | grep --ignore-case --fixed-strings --line-regexp --quiet \
+      "${expected_header}"; then
+    err "Expected response header: ${expected_header}"
+  fi
+}
+
+verify_origin() {
+  local origin="$1"
+  local headers_file
+  local status
+  headers_file="$(mktemp)"
+
+  if ! status="$(curl --silent --show-error \
+    --dump-header "${headers_file}" \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --header "Origin: ${origin}" \
+    "${API_BASE_URL}/auth/me")"; then
+    rm -f "${headers_file}"
+    err "Failed to request /auth/me from ${origin}"
+  fi
+
+  assert_unauthenticated_response "${status}" "${origin}"
+  assert_header "${headers_file}" "access-control-allow-origin: ${origin}"
+  assert_header "${headers_file}" "access-control-allow-credentials: true"
+  rm -f "${headers_file}"
+}
+
+verify_untrusted_origin() {
+  local headers_file
+  local status
+  headers_file="$(mktemp)"
+
+  if ! status="$(curl --silent --show-error \
+    --dump-header "${headers_file}" \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --header "Origin: ${UNTRUSTED_ORIGIN}" \
+    "${API_BASE_URL}/auth/me")"; then
+    rm -f "${headers_file}"
+    err "Failed to perform the untrusted-origin check"
+  fi
+
+  assert_unauthenticated_response "${status}" "${UNTRUSTED_ORIGIN}"
+  if tr -d '\r' < "${headers_file}" \
+    | grep --ignore-case --quiet '^access-control-allow-origin:'; then
+    rm -f "${headers_file}"
+    err "Unexpectedly allowed untrusted origin ${UNTRUSTED_ORIGIN}"
+  fi
+  rm -f "${headers_file}"
+}
+
+main() {
+  local -a trusted_origins
+
+  if [[ -z "${CORS_ALLOWED_ORIGINS:-}" ]]; then
+    err "CORS_ALLOWED_ORIGINS must contain at least one origin"
+  fi
+
+  curl --silent --show-error --fail \
+    --retry 12 --retry-all-errors --retry-delay 5 \
+    "${API_BASE_URL}/test" > /dev/null
+
+  IFS=',' read -r -a trusted_origins <<< "${CORS_ALLOWED_ORIGINS}"
+  for origin in "${trusted_origins[@]}"; do
+    verify_origin "${origin}"
+  done
+
+  verify_untrusted_origin
+}
+
+main "$@"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -165,6 +165,8 @@ jobs:
     needs: build-backend
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      CORS_ALLOWED_ORIGINS: https://jauntdetour.com,https://www.jauntdetour.com
     permissions:
       contents: read
       id-token: write
@@ -186,11 +188,21 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Configure backend CORS origins
+        run: |
+          az webapp config appsettings set \
+            --resource-group jauntdetour-rg \
+            --name jauntdetour-backend \
+            --settings "CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}"
+
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2
         with:
           app-name: jauntdetour-backend # Your Azure Web App name
           images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ steps.package-version.outputs.version }}
+
+      - name: Verify production CORS headers
+        run: bash .github/scripts/verify-production-cors.sh
 
   deploy-frontend:
     needs: build-frontend

--- a/backend/app/middleware/corsConfig.js
+++ b/backend/app/middleware/corsConfig.js
@@ -1,0 +1,13 @@
+function createCorsOptions({ allowedOrigins, fallbackOrigin }) {
+  const origins = (allowedOrigins || fallbackOrigin)
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return {
+    origin: origins,
+    credentials: true,
+  };
+}
+
+module.exports = createCorsOptions;

--- a/backend/app/middleware/corsConfig.test.js
+++ b/backend/app/middleware/corsConfig.test.js
@@ -1,0 +1,71 @@
+const cors = require("cors");
+const express = require("express");
+const request = require("supertest");
+const createCorsOptions = require("./corsConfig");
+
+function createApp(allowedOrigins) {
+  const app = express();
+  app.use(
+    cors(
+      createCorsOptions({
+        allowedOrigins,
+        fallbackOrigin: "http://localhost:3001",
+      })
+    )
+  );
+  app.get("/auth/me", (req, res) => res.sendStatus(401));
+  return app;
+}
+
+describe("CORS configuration", () => {
+  const apexOrigin = "https://jauntdetour.com";
+  const wwwOrigin = "https://www.jauntdetour.com";
+  const app = createApp(` ${apexOrigin}, ${wwwOrigin} `);
+
+  it.each([apexOrigin, wwwOrigin])(
+    "allows credentialed requests from %s",
+    async (origin) => {
+      const response = await request(app).get("/auth/me").set("Origin", origin);
+
+      expect(response.status).toBe(401);
+      expect(response.headers["access-control-allow-origin"]).toBe(origin);
+      expect(response.headers["access-control-allow-credentials"]).toBe("true");
+    }
+  );
+
+  it("allows preflight requests from an allowed origin", async () => {
+    const response = await request(app)
+      .options("/auth/me")
+      .set("Origin", wwwOrigin)
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(response.status).toBe(204);
+    expect(response.headers["access-control-allow-origin"]).toBe(wwwOrigin);
+    expect(response.headers["access-control-allow-credentials"]).toBe("true");
+  });
+
+  it("does not allow an unknown origin", async () => {
+    const response = await request(app)
+      .get("/auth/me")
+      .set("Origin", "https://example.com");
+
+    expect(response.status).toBe(401);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("allows requests without an Origin header", async () => {
+    const response = await request(app).get("/auth/me");
+
+    expect(response.status).toBe(401);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("falls back to FRONTEND_URL when no allowlist is configured", () => {
+    expect(
+      createCorsOptions({
+        allowedOrigins: undefined,
+        fallbackOrigin: "http://localhost:3001",
+      }).origin
+    ).toEqual(["http://localhost:3001"]);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -12,9 +12,11 @@ const TripRepository = require("./app/repositories/TripRepository");
 const DetourRepository = require("./app/repositories/DetourRepository");
 const createAuthRouter = require("./app/routes/auth");
 const createTripsRouter = require("./app/routes/trips");
+const createCorsOptions = require("./app/middleware/corsConfig");
 
 const IS_PROD = process.env.NODE_ENV === "production";
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3001";
+const CORS_ALLOWED_ORIGINS = process.env.CORS_ALLOWED_ORIGINS;
 const SESSION_SECRET = process.env.SESSION_SECRET;
 
 if (!SESSION_SECRET) {
@@ -35,10 +37,16 @@ app.use(cookieParser());
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 
-// Explicit origin + credentials so the browser sends/accepts the session cookie
-// on cross-origin XHR from the frontend dev server. A wildcard origin cannot be
-// combined with credentials.
-app.use(cors({ origin: FRONTEND_URL, credentials: true }));
+// Explicit origins + credentials allow trusted frontends to use the session
+// cookie. A wildcard origin cannot be combined with credentials.
+app.use(
+  cors(
+    createCorsOptions({
+      allowedOrigins: CORS_ALLOWED_ORIGINS,
+      fallbackOrigin: FRONTEND_URL,
+    })
+  )
+);
 
 app.use(
   session({

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstone-backend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,8 @@ ENTRA_CLIENT_ID=<app registration client id>
 ENTRA_CLIENT_SECRET=<app registration client secret>
 ENTRA_REDIRECT_URI=http://localhost:3000/auth/callback
 SESSION_SECRET=<long random string>       # e.g. openssl rand -base64 32
-FRONTEND_URL=http://localhost:3001        # CORS origin + post-login redirect
+FRONTEND_URL=http://localhost:3001        # post-login/logout destination
+CORS_ALLOWED_ORIGINS=http://localhost:3001 # comma-delimited trusted origins
 ```
 
 Frontend


### PR DESCRIPTION
## PR Reference Analysis

### Summary

The hotfix allowed credentialed API requests from both public Jaunt frontend origins while preserving the existing authentication redirect destination.

### Changes by Significance

#### CORS behavior

- Added an explicit comma-delimited CORS allowlist with whitespace trimming and a `FRONTEND_URL` fallback.
- Kept credential support enabled and omitted allow-origin headers for untrusted origins.
- Added focused coverage for both public origins, preflight, untrusted origins, requests without an Origin header, and fallback behavior.

#### Deployment verification

- Configured `CORS_ALLOWED_ORIGINS` on the Azure backend during deployment.
- Added a standalone production smoke script that verifies API readiness, exact allow-origin headers, credentials, expected unauthenticated responses, and untrusted-origin rejection.
- Invoked the tracked script through Bash so workflow execution does not depend on executable file mode.

#### Configuration documentation

- Documented the separate responsibilities of `FRONTEND_URL` and `CORS_ALLOWED_ORIGINS` in environment examples, the README, and repository instructions.

### Issue References

None

### Verification Notes

- Backend tests passed: 10 suites and 155 tests.
- Focused CORS tests passed: 6 tests.
- Backend ESLint, workflow Prettier, Bash syntax, patch whitespace, and editor diagnostics passed.
- Live production verification remains pending deployment.
