### PR TITLE
111 location autocomplete

### DIFF
--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -12,7 +12,7 @@ REACT_APP_GOOGLE_API_KEY=your_google_api_key_here
 APPLICATIONINSIGHTS_CONNECTION_STRING=
 REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING=
 
-# Node.js environment test
+# Node.js environment
 NODE_ENV=development
 NODE_OPTIONS=--openssl-legacy-provider
 

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -12,7 +12,7 @@ REACT_APP_GOOGLE_API_KEY=your_google_api_key_here
 APPLICATIONINSIGHTS_CONNECTION_STRING=
 REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING=
 
-# Node.js environment
+# Node.js environment test
 NODE_ENV=development
 NODE_OPTIONS=--openssl-legacy-provider
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,17 @@ trips.
   substrings + params); routes tested with `supertest` + mocked repos/db. Run
   `cd backend && npm test`.
 - Frontend: `cd frontend && CI=true npm test`.
+- Frontend UI changes that affect semantic roles, accessible names, labels,
+  routes, form controls, or user workflows must inspect
+  `frontend/e2e/**/*.spec.js` and update affected Playwright locators,
+  assertions, and API mocks in the same change. Prefer role-and-name locators
+  that match the rendered accessibility tree.
+- For frontend workflow changes, build the current frontend and run Playwright:
+  `npm run build:frontend && npm --prefix frontend run test:e2e`. If local
+  browser binaries or system dependencies prevent execution, run
+  `cd frontend && npx playwright test --list`, run the relevant unit/integration
+  tests, and explicitly report that E2E execution remains unverified. Do not
+  claim Playwright passed unless the browser suite completed.
 - Keep the suite green and add tests for new backend routes/repos.
 
 ## Reviewing code

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -1,6 +1,13 @@
-# Development Scripts and Commands
+---
+title: Development Scripts and Commands
+description: Commands and environment setup for local JauntDetour development
+author: JauntDetour Development Team
+ms.date: 2026-08-12
+ms.topic: how-to
+---
 
 ## Quick Start
+
 ```bash
 # Start both frontend and backend in development mode
 npm run dev
@@ -13,6 +20,7 @@ npm run frontend:dev
 ## Individual Commands
 
 ### Backend (Node.js/Express)
+
 ```bash
 cd backend
 npm install
@@ -21,6 +29,7 @@ npm start          # Start normally
 ```
 
 ### Frontend (React)
+
 ```bash
 cd frontend
 npm install
@@ -29,19 +38,27 @@ npm run build      # Build for production
 ```
 
 ## Ports
+
 - Backend API: http://localhost:3000
 - Frontend Dev Server: http://localhost:3001
 - Frontend Production Build: http://localhost:8080
 
 ## Environment Variables
+
 Make sure to set these in your environment:
+
 ```bash
 export GOOGLE_API_KEY=your_api_key_here
 export NODE_ENV=development
 export NODE_OPTIONS=--openssl-legacy-provider
 ```
 
+Enable Places API (New) and the Directions API for `GOOGLE_API_KEY` in Google
+Cloud. The backend uses Places API (New) for Start and Destination autocomplete.
+The frontend map continues to use `REACT_APP_GOOGLE_API_KEY`.
+
 ## DevContainer Features
+
 - Automatic dependency installation for both frontend and backend
 - Port forwarding configured for all services
 - VS Code extensions pre-installed for React/Node.js development
@@ -54,6 +71,7 @@ The dev container runs a PostgreSQL 14 sidecar (via `.devcontainer/docker-compos
 so you can develop against a local database with no Azure dependency or cost.
 
 ### First-time setup
+
 1. Copy the environment template and add your Google Maps API key:
    ```bash
    cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
@@ -66,19 +84,24 @@ so you can develop against a local database with no Azure dependency or cost.
 3. `npm run dev` starts the frontend and backend, which connect to the `db` service.
 
 ### Connecting to the database
+
 - **From the app container:** host `db`, port `5432`.
 - **From your host machine** (DBeaver, pgAdmin, psql): `localhost:5432`.
 - The backend connects as `jauntdetour_app` (least privilege). The `dbadmin` superuser
   (password `localdev`) is used only for initialization.
 
 ### Resetting the database
-Init scripts run only when the data volume is empty (first boot). To wipe and reseed (note: `-v` also removes node_modules_* volumes, so deps will reinstall on next start):
+
+Init scripts run only when the data volume is empty (first boot). To wipe and reseed (note: `-v` also removes `node_modules_*` volumes, so deps will reinstall on next start):
+
 ```bash
 docker compose -f .devcontainer/docker-compose.yml down -v
 ```
+
 Then rebuild/reopen the container.
 
 ## Development Tips
+
 1. The backend will auto-restart when you change files (thanks to nodemon)
 2. The frontend has fast refresh enabled for live updates
 3. Both services can run simultaneously using `npm run dev`

--- a/backend/app/modules/placeAutocompleteAPI.js
+++ b/backend/app/modules/placeAutocompleteAPI.js
@@ -1,0 +1,47 @@
+var config = require("../../config/config.js");
+const axios = require("axios");
+
+const AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete";
+const FIELD_MASK = [
+  "suggestions.placePrediction.placeId",
+  "suggestions.placePrediction.text.text",
+  "suggestions.placePrediction.structuredFormat.mainText.text",
+  "suggestions.placePrediction.structuredFormat.secondaryText.text",
+].join(",");
+
+function formatLocationLabel(value) {
+  return (value || "").replace(/,?\s+USA$/i, "");
+}
+
+function normalizeSuggestions(data) {
+  return (data.suggestions || [])
+    .map((suggestion) => suggestion.placePrediction)
+    .filter((prediction) => prediction && prediction.placeId)
+    .slice(0, 5)
+    .map((prediction) => ({
+      placeId: prediction.placeId,
+      text: formatLocationLabel(prediction.text?.text),
+      mainText: prediction.structuredFormat?.mainText?.text || "",
+      secondaryText: formatLocationLabel(
+        prediction.structuredFormat?.secondaryText?.text
+      ),
+    }));
+}
+
+async function getSuggestions(input) {
+  const response = await axios.post(
+    AUTOCOMPLETE_URL,
+    { input },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": config.GOOGLE_API_KEY,
+        "X-Goog-FieldMask": FIELD_MASK,
+      },
+    }
+  );
+
+  return normalizeSuggestions(response.data);
+}
+
+module.exports = { getSuggestions };

--- a/backend/app/modules/placeAutocompleteAPI.js
+++ b/backend/app/modules/placeAutocompleteAPI.js
@@ -10,7 +10,12 @@ const FIELD_MASK = [
 ].join(",");
 
 function formatLocationLabel(value) {
-  return (value || "").replace(/,?\s+USA$/i, "");
+  const label = value || "";
+  const segments = label.split(",");
+  if (segments.length > 1 && segments[segments.length - 1].trim() === "USA") {
+    return segments.slice(0, -1).join(",").trimEnd();
+  }
+  return label;
 }
 
 function normalizeSuggestions(data) {

--- a/backend/app/modules/placeAutocompleteAPI.test.js
+++ b/backend/app/modules/placeAutocompleteAPI.test.js
@@ -1,0 +1,118 @@
+jest.mock("axios");
+
+const axios = require("axios");
+const config = require("../../config/config.js");
+const placeAutocompleteAPI = require("./placeAutocompleteAPI");
+
+describe("placeAutocompleteAPI", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests and normalizes place predictions", async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place-ohio",
+              text: { text: "Ashland, OH, USA" },
+              structuredFormat: {
+                mainText: { text: "Ashland" },
+                secondaryText: { text: "OH, USA" },
+              },
+            },
+          },
+          { queryPrediction: { text: { text: "Ashland hotels" } } },
+        ],
+      },
+    });
+
+    await expect(
+      placeAutocompleteAPI.getSuggestions("Ashland")
+    ).resolves.toEqual([
+      {
+        placeId: "place-ohio",
+        text: "Ashland, OH",
+        mainText: "Ashland",
+        secondaryText: "OH",
+      },
+    ]);
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://places.googleapis.com/v1/places:autocomplete",
+      { input: "Ashland" },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Goog-Api-Key": config.GOOGLE_API_KEY,
+          "X-Goog-FieldMask": expect.stringContaining(
+            "suggestions.placePrediction.placeId"
+          ),
+        },
+      }
+    );
+  });
+
+  it("preserves countries outside the United States", async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        suggestions: [
+          {
+            placePrediction: {
+              placeId: "place-ontario",
+              text: { text: "London, ON, Canada" },
+              structuredFormat: {
+                mainText: { text: "London" },
+                secondaryText: { text: "ON, Canada" },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      placeAutocompleteAPI.getSuggestions("London")
+    ).resolves.toEqual([
+      {
+        placeId: "place-ontario",
+        text: "London, ON, Canada",
+        mainText: "London",
+        secondaryText: "ON, Canada",
+      },
+    ]);
+  });
+
+  it("returns an empty list when Google has no predictions", async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    await expect(placeAutocompleteAPI.getSuggestions("zzzz")).resolves.toEqual(
+      []
+    );
+  });
+
+  it("limits normalized predictions to five results", async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        suggestions: Array.from({ length: 6 }, (_, index) => ({
+          placePrediction: {
+            placeId: `place-${index}`,
+            text: { text: `Place ${index}` },
+          },
+        })),
+      },
+    });
+
+    const result = await placeAutocompleteAPI.getSuggestions("Place");
+
+    expect(result).toHaveLength(5);
+  });
+
+  it("propagates Google request failures", async () => {
+    axios.post.mockRejectedValue(new Error("Google unavailable"));
+
+    await expect(
+      placeAutocompleteAPI.getSuggestions("Ashland")
+    ).rejects.toThrow("Google unavailable");
+  });
+});

--- a/backend/app/routes/placeAutocomplete.js
+++ b/backend/app/routes/placeAutocomplete.js
@@ -1,0 +1,42 @@
+const express = require("express");
+const logger = require("../utils/logger");
+
+const MIN_INPUT_LENGTH = 2;
+const MAX_INPUT_LENGTH = 200;
+
+function createPlaceAutocompleteRouter({ placeAutocompleteAPI }) {
+  if (!placeAutocompleteAPI?.getSuggestions) {
+    throw new Error(
+      "createPlaceAutocompleteRouter requires a placeAutocompleteAPI"
+    );
+  }
+
+  const router = express.Router();
+
+  router.get("/", async (req, res) => {
+    const input =
+      typeof req.query.input === "string" ? req.query.input.trim() : "";
+    if (input.length < MIN_INPUT_LENGTH || input.length > MAX_INPUT_LENGTH) {
+      return res.status(400).json({
+        error: `Input must be between ${MIN_INPUT_LENGTH} and ${MAX_INPUT_LENGTH} characters`,
+      });
+    }
+
+    try {
+      const suggestions = await placeAutocompleteAPI.getSuggestions(input);
+      return res.json({ suggestions });
+    } catch (error) {
+      logger.error("GET /api/places/autocomplete failed", {
+        message: error.message,
+        status: error.response?.status,
+      });
+      return res
+        .status(502)
+        .json({ error: "Failed to load place suggestions" });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createPlaceAutocompleteRouter;

--- a/backend/app/routes/placeAutocomplete.test.js
+++ b/backend/app/routes/placeAutocomplete.test.js
@@ -1,0 +1,75 @@
+const express = require("express");
+const request = require("supertest");
+const logger = require("../utils/logger");
+const createPlaceAutocompleteRouter = require("./placeAutocomplete");
+
+jest.mock("../utils/logger", () => ({
+  error: jest.fn(),
+}));
+
+describe("place autocomplete routes", () => {
+  function buildApp(placeAutocompleteAPI) {
+    const app = express();
+    app.use(
+      "/api/places/autocomplete",
+      createPlaceAutocompleteRouter({ placeAutocompleteAPI })
+    );
+    return app;
+  }
+
+  it("requires an autocomplete API dependency", () => {
+    expect(() => createPlaceAutocompleteRouter({})).toThrow(
+      "createPlaceAutocompleteRouter requires a placeAutocompleteAPI"
+    );
+  });
+
+  it("returns normalized suggestions for trimmed input", async () => {
+    const suggestions = [{ placeId: "place-ohio", text: "Ashland, OH, USA" }];
+    const placeAutocompleteAPI = {
+      getSuggestions: jest.fn().mockResolvedValue(suggestions),
+    };
+
+    const response = await request(buildApp(placeAutocompleteAPI))
+      .get("/api/places/autocomplete")
+      .query({ input: "  Ashland  " });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ suggestions });
+    expect(placeAutocompleteAPI.getSuggestions).toHaveBeenCalledWith("Ashland");
+  });
+
+  it.each(["", "A", "x".repeat(201)])(
+    "rejects invalid input length for %p",
+    async (input) => {
+      const placeAutocompleteAPI = { getSuggestions: jest.fn() };
+
+      const response = await request(buildApp(placeAutocompleteAPI))
+        .get("/api/places/autocomplete")
+        .query({ input });
+
+      expect(response.status).toBe(400);
+      expect(placeAutocompleteAPI.getSuggestions).not.toHaveBeenCalled();
+    }
+  );
+
+  it("returns a gateway error when Google fails", async () => {
+    const error = new Error("unavailable");
+    error.response = { status: 403 };
+    const placeAutocompleteAPI = {
+      getSuggestions: jest.fn().mockRejectedValue(error),
+    };
+
+    const response = await request(buildApp(placeAutocompleteAPI))
+      .get("/api/places/autocomplete")
+      .query({ input: "Ashland" });
+
+    expect(response.status).toBe(502);
+    expect(response.body).toEqual({
+      error: "Failed to load place suggestions",
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "GET /api/places/autocomplete failed",
+      { message: "unavailable", status: 403 }
+    );
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,7 @@ var cookieParser = require("cookie-parser");
 var bodyParser = require("body-parser");
 const routeAPI = require("./app/modules/routeAPI");
 const placesAPI = require("./app/modules/placesAPI");
+const placeAutocompleteAPI = require("./app/modules/placeAutocompleteAPI");
 
 const db = require("./app/db/pool");
 const UserRepository = require("./app/repositories/UserRepository");
@@ -14,6 +15,7 @@ const TripRepository = require("./app/repositories/TripRepository");
 const DetourRepository = require("./app/repositories/DetourRepository");
 const createAuthRouter = require("./app/routes/auth");
 const createTripsRouter = require("./app/routes/trips");
+const createPlaceAutocompleteRouter = require("./app/routes/placeAutocomplete");
 const createCorsOptions = require("./app/middleware/corsConfig");
 
 const IS_PROD = process.env.NODE_ENV === "production";
@@ -76,6 +78,10 @@ app.use("/auth", createAuthRouter({ userRepository }));
 app.use(
   "/api/trips",
   createTripsRouter({ tripRepository, detourRepository, db })
+);
+app.use(
+  "/api/places/autocomplete",
+  createPlaceAutocompleteRouter({ placeAutocompleteAPI })
 );
 
 app.get("/test", function (req, res) {

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -115,8 +115,8 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   );
   await page.goto("/plan", { waitUntil: "domcontentloaded" });
 
-  await expect(page.getByRole("textbox", { name: "Start" })).toHaveCount(1);
-  await expect(page.getByRole("textbox", { name: "Destination" })).toHaveCount(
+  await expect(page.getByRole("combobox", { name: "Start" })).toHaveCount(1);
+  await expect(page.getByRole("combobox", { name: "Destination" })).toHaveCount(
     1
   );
   await expect(page.locator('nav:visible a[href="/plan"]')).toHaveAttribute(
@@ -135,9 +135,9 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   );
   await expect(page.getByRole("tab", { name: "Discover" })).toBeDisabled();
 
-  await page.getByRole("textbox", { name: "Start" }).fill("Atlanta, GA");
+  await page.getByRole("combobox", { name: "Start" }).fill("Atlanta, GA");
   await page
-    .getByRole("textbox", { name: "Destination" })
+    .getByRole("combobox", { name: "Destination" })
     .fill("Charlotte, NC");
   await page.getByRole("button", { name: "Create route" }).click();
   await expect(

--- a/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.jsx
+++ b/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.jsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Combobox,
+  Field,
+  Option,
+  Spinner,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import PlaceAutocompleteRequester from "../../../scripts/PlaceAutocompleteRequester";
+import { jauntSpacing, jauntTypography } from "../../../design-system/tokens";
+
+const MIN_INPUT_LENGTH = 2;
+const SEARCH_DELAY_MS = 250;
+
+const useStyles = makeStyles({
+  control: {
+    position: "relative",
+  },
+  controlOpen: {
+    zIndex: 2,
+  },
+  combobox: {
+    width: "100%",
+  },
+  input: {
+    paddingLeft: "2.5rem",
+  },
+  icon: {
+    position: "absolute",
+    left: jauntSpacing[3],
+    top: "50%",
+    zIndex: 1,
+    display: "inline-flex",
+    color: tokens.colorNeutralForeground2,
+    transform: "translateY(-50%)",
+    pointerEvents: "none",
+  },
+  option: {
+    display: "grid",
+    minWidth: 0,
+    rowGap: jauntSpacing[1],
+  },
+  optionMain: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  optionSecondary: {
+    overflow: "hidden",
+    color: tokens.colorNeutralForeground2,
+    fontSize: jauntTypography.size.bodySmall,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+});
+
+export default function PlaceAutocompleteField({
+  disabled = false,
+  icon,
+  invalid = false,
+  label,
+  onSelect,
+  onValueChange,
+  placeholder,
+  selectedPlace = null,
+  validationMessage = null,
+  value,
+}) {
+  const styles = useStyles();
+  const [suggestions, setSuggestions] = useState([]);
+  const [status, setStatus] = useState("idle");
+  const [open, setOpen] = useState(false);
+  const requestIdRef = useRef(0);
+  const requesterRef = useRef(null);
+
+  if (!requesterRef.current) {
+    requesterRef.current = new PlaceAutocompleteRequester();
+  }
+
+  useEffect(() => {
+    const input = value.trim();
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    if (selectedPlace || input.length < MIN_INPUT_LENGTH) {
+      setSuggestions([]);
+      setStatus("idle");
+      setOpen(false);
+      return undefined;
+    }
+
+    setStatus("loading");
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const nextSuggestions =
+          await requesterRef.current.getSuggestions(input);
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setSuggestions(nextSuggestions);
+        setStatus(nextSuggestions.length ? "ready" : "empty");
+      } catch {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setSuggestions([]);
+        setStatus("error");
+      }
+    }, SEARCH_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [selectedPlace, value]);
+
+  const handleInput = (event) => {
+    setOpen(event.target.value.trim().length >= MIN_INPUT_LENGTH);
+    onValueChange(event.target.value);
+  };
+
+  const handleOptionSelect = (event, data) => {
+    const suggestion = suggestions.find(
+      (option) => option.placeId === data.optionValue
+    );
+    if (suggestion) {
+      setOpen(false);
+      onSelect(suggestion);
+    }
+  };
+
+  const statusMessage =
+    status === "loading"
+      ? `Loading ${label.toLowerCase()} suggestions`
+      : status === "empty"
+        ? "No matching locations found. You can still use your typed location."
+        : status === "error"
+          ? "Suggestions are unavailable. You can still use your typed location."
+          : "";
+  const canOpen =
+    !selectedPlace &&
+    value.trim().length >= MIN_INPUT_LENGTH &&
+    (status === "loading" || suggestions.length > 0);
+
+  return (
+    <Field
+      label={label}
+      required
+      validationMessage={invalid ? validationMessage : null}
+      validationState={invalid ? "error" : "none"}
+    >
+      <div
+        className={`${styles.control} ${open ? styles.controlOpen : ""}`}
+        data-testid={`${label.toLowerCase()}-autocomplete-control`}
+      >
+        <span className={styles.icon} aria-hidden="true">
+          {icon}
+        </span>
+        <Combobox
+          aria-label={label}
+          className={styles.combobox}
+          disabled={disabled}
+          disableAutoFocus
+          expandIcon={null}
+          freeform
+          inlinePopup
+          input={{
+            className: styles.input,
+            onFocus: () => setOpen(canOpen),
+            spellCheck: false,
+          }}
+          open={open}
+          placeholder={placeholder}
+          selectedOptions={selectedPlace ? [selectedPlace.placeId] : []}
+          size="large"
+          value={value}
+          onInput={handleInput}
+          onOpenChange={(event, data) => setOpen(data.open && canOpen)}
+          onOptionSelect={handleOptionSelect}
+        >
+          {status === "loading" ? (
+            <Option disabled text="Loading suggestions" value="loading">
+              <Spinner size="tiny" label="Loading suggestions" />
+            </Option>
+          ) : null}
+          {suggestions.map((suggestion) => (
+            <Option
+              key={suggestion.placeId}
+              text={suggestion.text}
+              value={suggestion.placeId}
+            >
+              <span className={styles.option}>
+                <span className={styles.optionMain}>
+                  {suggestion.mainText || suggestion.text}
+                </span>
+                {suggestion.secondaryText ? (
+                  <span className={styles.optionSecondary}>
+                    {suggestion.secondaryText}
+                  </span>
+                ) : null}
+              </span>
+            </Option>
+          ))}
+        </Combobox>
+        <span role="status" className="sr-only">
+          {statusMessage}
+        </span>
+      </div>
+    </Field>
+  );
+}
+
+PlaceAutocompleteField.propTypes = {
+  disabled: PropTypes.bool,
+  icon: PropTypes.node.isRequired,
+  invalid: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  selectedPlace: PropTypes.shape({
+    placeId: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }),
+  validationMessage: PropTypes.string,
+  value: PropTypes.string.isRequired,
+};

--- a/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.jsx
+++ b/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.jsx
@@ -54,6 +54,16 @@ const useStyles = makeStyles({
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
+  visuallyHidden: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+  },
 });
 
 export default function PlaceAutocompleteField({
@@ -110,7 +120,10 @@ export default function PlaceAutocompleteField({
       }
     }, SEARCH_DELAY_MS);
 
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      window.clearTimeout(timeoutId);
+      requestIdRef.current += 1;
+    };
   }, [selectedPlace, value]);
 
   const handleInput = (event) => {
@@ -168,7 +181,7 @@ export default function PlaceAutocompleteField({
             onFocus: () => setOpen(canOpen),
             spellCheck: false,
           }}
-          open={open}
+          open={open && canOpen}
           placeholder={placeholder}
           selectedOptions={selectedPlace ? [selectedPlace.placeId] : []}
           size="large"
@@ -201,7 +214,7 @@ export default function PlaceAutocompleteField({
             </Option>
           ))}
         </Combobox>
-        <span role="status" className="sr-only">
+        <span role="status" className={styles.visuallyHidden}>
           {statusMessage}
         </span>
       </div>

--- a/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
+++ b/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
@@ -1,11 +1,5 @@
 import React, { useState } from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { FluentProvider } from "@fluentui/react-components";
 import { LocationRegular } from "@fluentui/react-icons";
 import { axe } from "jest-axe";
@@ -91,7 +85,7 @@ describe("PlaceAutocompleteField", () => {
       jest.advanceTimersByTime(250);
     });
 
-    const option = await screen.findByRole("option", {
+    const option = screen.getByRole("option", {
       name: /Ashland OH, USA/i,
     });
     expect(
@@ -128,7 +122,7 @@ describe("PlaceAutocompleteField", () => {
     });
 
     expect(
-      await screen.findByText(/suggestions are unavailable/i)
+      screen.getByText(/suggestions are unavailable/i)
     ).toBeInTheDocument();
     expect(input).toHaveValue("Ashland");
     expect(input).not.toBeDisabled();
@@ -155,7 +149,10 @@ describe("PlaceAutocompleteField", () => {
     await act(async () => jest.advanceTimersByTime(250));
     fireEvent.input(input, { target: { value: "Ashland" } });
     await act(async () => jest.advanceTimersByTime(250));
-    await screen.findByRole("option", { name: /Ashland KY, USA/i });
+    expect(getSuggestions).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole("option", { name: /Ashland KY, USA/i })
+    ).toBeInTheDocument();
 
     await act(async () => {
       resolveFirst([

--- a/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
+++ b/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
@@ -1,0 +1,182 @@
+import React, { useState } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { FluentProvider } from "@fluentui/react-components";
+import { LocationRegular } from "@fluentui/react-icons";
+import { axe } from "jest-axe";
+import PlaceAutocompleteField from "./PlaceAutocompleteField";
+import PlaceAutocompleteRequester from "../../../scripts/PlaceAutocompleteRequester";
+import { jauntDetourTheme } from "../../../design-system/jauntDetourTheme";
+
+jest.mock("../../../scripts/PlaceAutocompleteRequester");
+
+function Harness({ onSelection = () => {} }) {
+  const [value, setValue] = useState("");
+  const [selectedPlace, setSelectedPlace] = useState(null);
+
+  return (
+    <FluentProvider theme={jauntDetourTheme}>
+      <PlaceAutocompleteField
+        icon={<LocationRegular />}
+        label="Destination"
+        placeholder="Where are you going?"
+        selectedPlace={selectedPlace}
+        value={value}
+        onValueChange={(nextValue) => {
+          setValue(nextValue);
+          setSelectedPlace(null);
+        }}
+        onSelect={(place) => {
+          setValue(place.text);
+          setSelectedPlace(place);
+          onSelection(place);
+        }}
+      />
+    </FluentProvider>
+  );
+}
+
+describe("PlaceAutocompleteField", () => {
+  let getSuggestions;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    getSuggestions = jest.fn();
+    PlaceAutocompleteRequester.mockImplementation(() => ({ getSuggestions }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("does not open an empty popup when initially clicked", () => {
+    render(<Harness />);
+
+    const input = screen.getByRole("combobox", { name: "Destination" });
+    fireEvent.click(input);
+
+    expect(input).toHaveAttribute("spellcheck", "false");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", { name: "Open Destination" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("debounces suggestions and selects a location", async () => {
+    const suggestion = {
+      placeId: "place-ohio",
+      text: "Ashland, OH, USA",
+      mainText: "Ashland",
+      secondaryText: "OH, USA",
+    };
+    getSuggestions.mockResolvedValue([suggestion]);
+    const onSelection = jest.fn();
+    render(<Harness onSelection={onSelection} />);
+    const control = screen.getByTestId("destination-autocomplete-control");
+    const closedClassName = control.className;
+
+    fireEvent.input(screen.getByRole("combobox", { name: "Destination" }), {
+      target: { value: "Ashland" },
+    });
+    expect(getSuggestions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+
+    const option = await screen.findByRole("option", {
+      name: /Ashland OH, USA/i,
+    });
+    expect(
+      screen.getByRole("combobox", { name: "Destination" })
+    ).not.toHaveAttribute("aria-activedescendant");
+    expect(control.className).not.toBe(closedClassName);
+    fireEvent.click(option);
+
+    expect(onSelection).toHaveBeenCalledWith(suggestion);
+    expect(screen.getByRole("combobox", { name: "Destination" })).toHaveValue(
+      "Ashland, OH, USA"
+    );
+  });
+
+  it("does not search until two trimmed characters are entered", () => {
+    render(<Harness />);
+
+    fireEvent.input(screen.getByRole("combobox", { name: "Destination" }), {
+      target: { value: " A " },
+    });
+    act(() => jest.advanceTimersByTime(250));
+
+    expect(getSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("keeps free text usable when suggestions fail", async () => {
+    getSuggestions.mockRejectedValue(new Error("offline"));
+    render(<Harness />);
+
+    const input = screen.getByRole("combobox", { name: "Destination" });
+    fireEvent.input(input, { target: { value: "Ashland" } });
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(
+      await screen.findByText(/suggestions are unavailable/i)
+    ).toBeInTheDocument();
+    expect(input).toHaveValue("Ashland");
+    expect(input).not.toBeDisabled();
+  });
+
+  it("ignores an older response after the input changes", async () => {
+    let resolveFirst;
+    getSuggestions
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveFirst = resolve))
+      )
+      .mockResolvedValueOnce([
+        {
+          placeId: "place-kentucky",
+          text: "Ashland, KY, USA",
+          mainText: "Ashland",
+          secondaryText: "KY, USA",
+        },
+      ]);
+    render(<Harness />);
+    const input = screen.getByRole("combobox", { name: "Destination" });
+
+    fireEvent.input(input, { target: { value: "Ash" } });
+    await act(async () => jest.advanceTimersByTime(250));
+    fireEvent.input(input, { target: { value: "Ashland" } });
+    await act(async () => jest.advanceTimersByTime(250));
+    await screen.findByRole("option", { name: /Ashland KY, USA/i });
+
+    await act(async () => {
+      resolveFirst([
+        {
+          placeId: "old-place",
+          text: "Ash, England",
+          mainText: "Ash",
+          secondaryText: "England",
+        },
+      ]);
+    });
+
+    expect(
+      screen.queryByRole("option", { name: /Ash England/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("has no automated accessibility violations", async () => {
+    jest.useRealTimers();
+    const { container } = render(<Harness />);
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
+++ b/frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx
@@ -143,16 +143,14 @@ describe("PlaceAutocompleteField", () => {
         },
       ]);
     render(<Harness />);
-    const input = screen.getByRole("combobox", { name: "Destination" });
+    const input = screen.getByLabelText("Destination");
 
     fireEvent.input(input, { target: { value: "Ash" } });
     await act(async () => jest.advanceTimersByTime(250));
     fireEvent.input(input, { target: { value: "Ashland" } });
     await act(async () => jest.advanceTimersByTime(250));
     expect(getSuggestions).toHaveBeenCalledTimes(2);
-    expect(
-      screen.getByRole("option", { name: /Ashland KY, USA/i })
-    ).toBeInTheDocument();
+    expect(screen.getByText("KY, USA")).toBeInTheDocument();
 
     await act(async () => {
       resolveFirst([
@@ -165,10 +163,8 @@ describe("PlaceAutocompleteField", () => {
       ]);
     });
 
-    expect(
-      screen.queryByRole("option", { name: /Ash England/i })
-    ).not.toBeInTheDocument();
-  });
+    expect(screen.queryByText("England")).not.toBeInTheDocument();
+  }, 15000);
 
   it("has no automated accessibility violations", async () => {
     jest.useRealTimers();

--- a/frontend/src/components/planner/build-workflow/RouteForm.jsx
+++ b/frontend/src/components/planner/build-workflow/RouteForm.jsx
@@ -26,6 +26,7 @@ import RouteRequester from "../../../scripts/RouteRequester";
 import PlaceAutocompleteField from "./PlaceAutocompleteField";
 import { jauntSpacing, jauntTypography } from "../../../design-system/tokens";
 import { trackEvent } from "../../../telemetry/telemetry";
+import { formatLocationLabel } from "../../../utils/locationLabel";
 
 const useStyles = makeStyles({
   root: {
@@ -72,10 +73,6 @@ function normalizeEndpoint(value) {
     return value;
   }
   return value?.address || "";
-}
-
-function formatLocationLabel(value) {
-  return (value || "").replace(/,?\s+USA$/i, "");
 }
 
 export default function RouteForm({

--- a/frontend/src/components/planner/build-workflow/RouteForm.jsx
+++ b/frontend/src/components/planner/build-workflow/RouteForm.jsx
@@ -9,8 +9,6 @@ import {
   DialogContent,
   DialogSurface,
   DialogTitle,
-  Field,
-  Input,
   MessageBar,
   MessageBarBody,
   Spinner,
@@ -25,6 +23,7 @@ import {
   NavigationRegular,
 } from "@fluentui/react-icons";
 import RouteRequester from "../../../scripts/RouteRequester";
+import PlaceAutocompleteField from "./PlaceAutocompleteField";
 import { jauntSpacing, jauntTypography } from "../../../design-system/tokens";
 import { trackEvent } from "../../../telemetry/telemetry";
 
@@ -75,6 +74,10 @@ function normalizeEndpoint(value) {
   return value?.address || "";
 }
 
+function formatLocationLabel(value) {
+  return (value || "").replace(/,?\s+USA$/i, "");
+}
+
 export default function RouteForm({
   clearAll,
   destination,
@@ -93,6 +96,8 @@ export default function RouteForm({
   const [destinationValue, setDestinationValue] = useState(
     normalizeEndpoint(destination)
   );
+  const [selectedOrigin, setSelectedOrigin] = useState(null);
+  const [selectedDestination, setSelectedDestination] = useState(null);
   const [submitted, setSubmitted] = useState(false);
   const [status, setStatus] = useState("idle");
   const [errorMessage, setErrorMessage] = useState("");
@@ -102,10 +107,12 @@ export default function RouteForm({
 
   useEffect(() => {
     setOriginValue(normalizeEndpoint(origin));
+    setSelectedOrigin(null);
   }, [origin]);
 
   useEffect(() => {
     setDestinationValue(normalizeEndpoint(destination));
+    setSelectedDestination(null);
   }, [destination]);
 
   const trimmedOrigin = originValue.trim();
@@ -116,9 +123,32 @@ export default function RouteForm({
   const editingExistingJaunt = onCancel != null;
   const hasExistingDetours = editingExistingJaunt && detourList.length > 0;
 
-  const commitRoute = (nextRoute, { removeDetours = false } = {}) => {
-    setOrigin(trimmedOrigin);
-    setDestination(trimmedDestination);
+  const commitRoute = (
+    nextRoute,
+    {
+      fallbackOrigin = trimmedOrigin,
+      fallbackDestination = trimmedDestination,
+      selectedOriginLabel = null,
+      selectedDestinationLabel = null,
+      removeDetours = false,
+    } = {}
+  ) => {
+    const legs = nextRoute.legs || [];
+    const firstLeg = legs[0];
+    const lastLeg = legs[legs.length - 1];
+    const resolvedOrigin = formatLocationLabel(
+      selectedOriginLabel || firstLeg?.start_address || fallbackOrigin
+    );
+    const resolvedDestination = formatLocationLabel(
+      selectedDestinationLabel || lastLeg?.end_address || fallbackDestination
+    );
+
+    setOriginValue(resolvedOrigin);
+    setDestinationValue(resolvedDestination);
+    setSelectedOrigin(null);
+    setSelectedDestination(null);
+    setOrigin(resolvedOrigin);
+    setDestination(resolvedDestination);
     setRoute(nextRoute);
     setTripSummary(nextRoute.summary);
     if (removeDetours) {
@@ -143,6 +173,16 @@ export default function RouteForm({
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    const submittedOrigin = trimmedOrigin;
+    const submittedDestination = trimmedDestination;
+    const selectedOriginLabel = selectedOrigin?.text || null;
+    const selectedDestinationLabel = selectedDestination?.text || null;
+    const routeOrigin = selectedOrigin
+      ? `place_id:${selectedOrigin.placeId}`
+      : submittedOrigin;
+    const routeDestination = selectedDestination
+      ? `place_id:${selectedDestination.placeId}`
+      : submittedDestination;
     setStatus("loading");
     trackEvent("route_search_started", { feature: "route" });
 
@@ -154,8 +194,8 @@ export default function RouteForm({
       const preserveDetours =
         hasExistingDetours && keepExistingDetours && waypointIds.length > 0;
       const data = await requester.getRoute(
-        trimmedOrigin,
-        trimmedDestination,
+        routeOrigin,
+        routeDestination,
         "Address",
         preserveDetours ? { waypoints: waypointIds } : {}
       );
@@ -167,8 +207,8 @@ export default function RouteForm({
       if (!nextRoute) {
         if (preserveDetours) {
           const directData = await requester.getRoute(
-            trimmedOrigin,
-            trimmedDestination,
+            routeOrigin,
+            routeDestination,
             "Address",
             {}
           );
@@ -178,7 +218,13 @@ export default function RouteForm({
           nextRoute = directData.routes && directData.routes[0];
           if (nextRoute) {
             setStatus("idle");
-            setIncompatibleRoute(nextRoute);
+            setIncompatibleRoute({
+              route: nextRoute,
+              fallbackOrigin: submittedOrigin,
+              fallbackDestination: submittedDestination,
+              selectedOriginLabel,
+              selectedDestinationLabel,
+            });
             return;
           }
         }
@@ -194,6 +240,10 @@ export default function RouteForm({
       }
 
       commitRoute(nextRoute, {
+        fallbackOrigin: submittedOrigin,
+        fallbackDestination: submittedDestination,
+        selectedOriginLabel,
+        selectedDestinationLabel,
         removeDetours: hasExistingDetours && !keepExistingDetours,
       });
     } catch {
@@ -220,6 +270,8 @@ export default function RouteForm({
     requestIdRef.current += 1;
     setOriginValue("");
     setDestinationValue("");
+    setSelectedOrigin(null);
+    setSelectedDestination(null);
     setSubmitted(false);
     setStatus("idle");
     setErrorMessage("");
@@ -252,38 +304,42 @@ export default function RouteForm({
         ) : null}
       </div>
       <div className={styles.fields}>
-        <Field
+        <PlaceAutocompleteField
+          disabled={loading}
+          icon={<NavigationRegular />}
+          invalid={originInvalid}
           label="Start"
-          required
-          validationMessage={originInvalid ? "Enter a starting point." : null}
-          validationState={originInvalid ? "error" : "none"}
-        >
-          <Input
-            aria-label="Start"
-            autoComplete="off"
-            contentBefore={<NavigationRegular aria-hidden="true" />}
-            placeholder="Enter a starting point"
-            size="large"
-            value={originValue}
-            onChange={(event) => setOriginValue(event.target.value)}
-          />
-        </Field>
-        <Field
+          placeholder="Enter a starting point"
+          selectedPlace={selectedOrigin}
+          validationMessage="Enter a starting point."
+          value={originValue}
+          onValueChange={(value) => {
+            setOriginValue(value);
+            setSelectedOrigin(null);
+          }}
+          onSelect={(place) => {
+            setOriginValue(place.text);
+            setSelectedOrigin(place);
+          }}
+        />
+        <PlaceAutocompleteField
+          disabled={loading}
+          icon={<LocationRegular />}
+          invalid={destinationInvalid}
           label="Destination"
-          required
-          validationMessage={destinationInvalid ? "Enter a destination." : null}
-          validationState={destinationInvalid ? "error" : "none"}
-        >
-          <Input
-            aria-label="Destination"
-            autoComplete="off"
-            contentBefore={<LocationRegular aria-hidden="true" />}
-            placeholder="Where are you going?"
-            size="large"
-            value={destinationValue}
-            onChange={(event) => setDestinationValue(event.target.value)}
-          />
-        </Field>
+          placeholder="Where are you going?"
+          selectedPlace={selectedDestination}
+          validationMessage="Enter a destination."
+          value={destinationValue}
+          onValueChange={(value) => {
+            setDestinationValue(value);
+            setSelectedDestination(null);
+          }}
+          onSelect={(place) => {
+            setDestinationValue(place.text);
+            setSelectedDestination(place);
+          }}
+        />
       </div>
 
       {hasExistingDetours ? (
@@ -334,7 +390,7 @@ export default function RouteForm({
       </div>
 
       <Dialog
-        open={incompatibleRoute != null}
+        open={incompatibleRoute !== null}
         onOpenChange={(event, data) => {
           if (!data.open) {
             setIncompatibleRoute(null);
@@ -358,7 +414,14 @@ export default function RouteForm({
               <Button
                 appearance="primary"
                 onClick={() =>
-                  commitRoute(incompatibleRoute, { removeDetours: true })
+                  commitRoute(incompatibleRoute.route, {
+                    fallbackOrigin: incompatibleRoute.fallbackOrigin,
+                    fallbackDestination: incompatibleRoute.fallbackDestination,
+                    selectedOriginLabel: incompatibleRoute.selectedOriginLabel,
+                    selectedDestinationLabel:
+                      incompatibleRoute.selectedDestinationLabel,
+                    removeDetours: true,
+                  })
                 }
               >
                 Proceed

--- a/frontend/src/components/planner/build-workflow/RouteForm.test.jsx
+++ b/frontend/src/components/planner/build-workflow/RouteForm.test.jsx
@@ -15,6 +15,44 @@ import { trackEvent } from "../../../telemetry/telemetry";
 
 jest.mock("../../../scripts/RouteRequester");
 jest.mock("../../../telemetry/telemetry", () => ({ trackEvent: jest.fn() }));
+jest.mock("./PlaceAutocompleteField", () => {
+  const React = require("react");
+
+  return function MockPlaceAutocompleteField({
+    invalid,
+    label,
+    onSelect,
+    onValueChange,
+    validationMessage,
+    value,
+  }) {
+    return React.createElement(
+      "div",
+      null,
+      React.createElement("label", null, label),
+      React.createElement("input", {
+        "aria-label": label,
+        value,
+        onChange: (event) => onValueChange(event.target.value),
+      }),
+      value === "Ashland"
+        ? React.createElement(
+            "button",
+            {
+              type: "button",
+              onClick: () =>
+                onSelect({
+                  placeId: `place-${label.toLowerCase()}`,
+                  text: `Ashland ${label}`,
+                }),
+            },
+            `Select ${label} suggestion`
+          )
+        : null,
+      invalid ? React.createElement("span", null, validationMessage) : null
+    );
+  };
+});
 
 function createProps(overrides = {}) {
   return {
@@ -99,6 +137,138 @@ describe("RouteForm", () => {
     expect(trackEvent).toHaveBeenNthCalledWith(2, "route_search_succeeded", {
       feature: "route",
     });
+  });
+
+  it("routes selected suggestions by place ID", async () => {
+    const route = {
+      summary: {},
+      legs: [
+        {
+          start_address: "1 Stadium Drive, Ashland, OH, USA",
+          end_address: "99 Main Street, Ashland, KY, USA",
+        },
+      ],
+    };
+    const getRoute = jest.fn().mockResolvedValue({ routes: [route] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+    const props = createProps();
+    renderForm(props);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Start" }), {
+      target: { value: "Ashland" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Start suggestion" })
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Destination" }), {
+      target: { value: "Ashland" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Destination suggestion" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create route" }));
+
+    await waitFor(() => expect(props.setRoute).toHaveBeenCalledWith(route));
+    expect(getRoute).toHaveBeenCalledWith(
+      "place_id:place-start",
+      "place_id:place-destination",
+      "Address",
+      {}
+    );
+    expect(props.setOrigin).toHaveBeenCalledWith("Ashland Start");
+    expect(props.setDestination).toHaveBeenCalledWith("Ashland Destination");
+  });
+
+  it("falls back to edited free text after a suggestion was selected", async () => {
+    const route = { summary: {}, legs: [] };
+    const getRoute = jest.fn().mockResolvedValue({ routes: [route] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+    renderForm(createProps({ destination: "Charlotte" }));
+
+    const start = screen.getByRole("textbox", { name: "Start" });
+    fireEvent.change(start, { target: { value: "Ashland" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Start suggestion" })
+    );
+    fireEvent.change(start, { target: { value: "Ashland custom" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create route" }));
+
+    await waitFor(() => expect(getRoute).toHaveBeenCalled());
+    expect(getRoute).toHaveBeenCalledWith(
+      "Ashland custom",
+      "Charlotte",
+      "Address",
+      {}
+    );
+  });
+
+  it("preserves a selected place while resolving a free-text endpoint", async () => {
+    const route = {
+      summary: {},
+      legs: [
+        {
+          start_address: "1 AMB Drive Northwest, Atlanta, GA, USA",
+          end_address: "Athens, GA, USA",
+        },
+      ],
+    };
+    RouteRequester.mockImplementation(() => ({
+      getRoute: jest.fn().mockResolvedValue({ routes: [route] }),
+    }));
+    const props = createProps();
+    renderForm(props);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Start" }), {
+      target: { value: "Ashland" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Start suggestion" })
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Destination" }), {
+      target: { value: "athens georgiaa" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create route" }));
+
+    await waitFor(() =>
+      expect(props.setOrigin).toHaveBeenCalledWith("Ashland Start")
+    );
+    expect(props.setDestination).toHaveBeenCalledWith("Athens, GA");
+  });
+
+  it("replaces free text with the locations resolved by Google", async () => {
+    const route = {
+      summary: { distance: 120, time: { hours: 2, min: 5 } },
+      legs: [
+        {
+          start_address: "Ashland, OH 44805, USA",
+          end_address: "Lexington, KY, USA",
+        },
+      ],
+    };
+    RouteRequester.mockImplementation(() => ({
+      getRoute: jest.fn().mockResolvedValue({ routes: [route] }),
+    }));
+    const props = createProps();
+    renderForm(props);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Start" }), {
+      target: { value: "Ashland ohioo" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "Destination" }), {
+      target: { value: "Lexington" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create route" }));
+
+    await waitFor(() =>
+      expect(props.setOrigin).toHaveBeenCalledWith("Ashland, OH 44805")
+    );
+    expect(props.setDestination).toHaveBeenCalledWith("Lexington, KY");
+    expect(screen.getByRole("textbox", { name: "Start" })).toHaveValue(
+      "Ashland, OH 44805"
+    );
+    expect(screen.getByRole("textbox", { name: "Destination" })).toHaveValue(
+      "Lexington, KY"
+    );
   });
 
   it("retains the prior route when a request fails and supports retry", async () => {

--- a/frontend/src/scripts/PlaceAutocompleteRequester.js
+++ b/frontend/src/scripts/PlaceAutocompleteRequester.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+import config from "../config/config.js";
+import log from "../utils/logger";
+
+export default class PlaceAutocompleteRequester {
+  getUrlBase() {
+    return config.BACKEND_URL;
+  }
+
+  getSuggestions(input) {
+    return axios
+      .get(this.getUrlBase() + "/api/places/autocomplete", {
+        params: { input },
+      })
+      .then((response) => response.data.suggestions || [])
+      .catch((error) => {
+        log.error("Failed to load place suggestions:", error);
+        throw error;
+      });
+  }
+}

--- a/frontend/src/scripts/PlaceAutocompleteRequester.test.js
+++ b/frontend/src/scripts/PlaceAutocompleteRequester.test.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+import config from "../config/config.js";
+import PlaceAutocompleteRequester from "./PlaceAutocompleteRequester";
+import log from "../utils/logger";
+
+jest.mock("axios");
+jest.mock("../utils/logger", () => ({ error: jest.fn() }));
+
+describe("PlaceAutocompleteRequester", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests and returns normalized suggestions", async () => {
+    const suggestions = [{ placeId: "place-ohio", text: "Ashland, OH, USA" }];
+    axios.get.mockResolvedValue({ data: { suggestions } });
+    const requester = new PlaceAutocompleteRequester();
+
+    await expect(requester.getSuggestions("Ashland")).resolves.toEqual(
+      suggestions
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      config.BACKEND_URL + "/api/places/autocomplete",
+      { params: { input: "Ashland" } }
+    );
+  });
+
+  it("returns an empty list when suggestions are omitted", async () => {
+    axios.get.mockResolvedValue({ data: {} });
+
+    await expect(
+      new PlaceAutocompleteRequester().getSuggestions("zzzz")
+    ).resolves.toEqual([]);
+  });
+
+  it("logs and propagates request failures", async () => {
+    const error = new Error("offline");
+    axios.get.mockRejectedValue(error);
+
+    await expect(
+      new PlaceAutocompleteRequester().getSuggestions("Ashland")
+    ).rejects.toThrow("offline");
+    expect(log.error).toHaveBeenCalledWith(
+      "Failed to load place suggestions:",
+      error
+    );
+  });
+});

--- a/frontend/src/utils/locationLabel.js
+++ b/frontend/src/utils/locationLabel.js
@@ -1,0 +1,7 @@
+// Google's Places/Directions labels append ", USA" to domestic results. We
+// strip that trailing country segment so the planner shows friendlier labels
+// (e.g. "Ashland, OH" instead of "Ashland, OH, USA"). Non-US labels are left
+// untouched.
+export function formatLocationLabel(value) {
+  return (value || "").replace(/,?\s+USA$/i, "");
+}

--- a/frontend/src/utils/locationLabel.js
+++ b/frontend/src/utils/locationLabel.js
@@ -1,7 +1,14 @@
-// Google's Places/Directions labels append ", USA" to domestic results. We
-// strip that trailing country segment so the planner shows friendlier labels
-// (e.g. "Ashland, OH" instead of "Ashland, OH, USA"). Non-US labels are left
-// untouched.
+// Google's Places/Directions labels append the country as the final
+// comma-separated segment (e.g. "Ashland, OH, USA"). For domestic results we
+// drop that trailing country field when it is the United States so the planner
+// shows friendlier labels ("Ashland, OH"). We only remove a whole final
+// segment equal to "USA" — never a substring — so a place literally named
+// "... USA" (with no country field) and non-US labels are left intact.
 export function formatLocationLabel(value) {
-  return (value || "").replace(/,?\s+USA$/i, "");
+  const label = value || "";
+  const segments = label.split(",");
+  if (segments.length > 1 && segments[segments.length - 1].trim() === "USA") {
+    return segments.slice(0, -1).join(",").trimEnd();
+  }
+  return label;
 }

--- a/frontend/src/utils/locationLabel.test.js
+++ b/frontend/src/utils/locationLabel.test.js
@@ -1,18 +1,24 @@
 import { formatLocationLabel } from "./locationLabel";
 
 describe("formatLocationLabel", () => {
-  it("strips a trailing US country segment", () => {
+  it("drops a trailing USA country field", () => {
     expect(formatLocationLabel("Ashland, OH, USA")).toBe("Ashland, OH");
     expect(formatLocationLabel("OH, USA")).toBe("OH");
   });
 
-  it("is case-insensitive and tolerates missing comma", () => {
-    expect(formatLocationLabel("Portland usa")).toBe("Portland");
+  it("leaves non-US country fields untouched", () => {
+    expect(formatLocationLabel("Paris, France")).toBe("Paris, France");
+    expect(formatLocationLabel("London, ON, Canada")).toBe("London, ON, Canada");
   });
 
-  it("leaves non-US labels untouched", () => {
-    expect(formatLocationLabel("Paris, France")).toBe("Paris, France");
+  it("only drops a whole final segment, never a substring", () => {
+    expect(formatLocationLabel("Mall of USA, CA, USA")).toBe("Mall of USA, CA");
     expect(formatLocationLabel("USANville, CA")).toBe("USANville, CA");
+    expect(formatLocationLabel("Portland USA")).toBe("Portland USA");
+  });
+
+  it("keeps a bare USA when it is the only segment", () => {
+    expect(formatLocationLabel("USA")).toBe("USA");
   });
 
   it("returns an empty string for nullish input", () => {

--- a/frontend/src/utils/locationLabel.test.js
+++ b/frontend/src/utils/locationLabel.test.js
@@ -8,7 +8,9 @@ describe("formatLocationLabel", () => {
 
   it("leaves non-US country fields untouched", () => {
     expect(formatLocationLabel("Paris, France")).toBe("Paris, France");
-    expect(formatLocationLabel("London, ON, Canada")).toBe("London, ON, Canada");
+    expect(formatLocationLabel("London, ON, Canada")).toBe(
+      "London, ON, Canada"
+    );
   });
 
   it("only drops a whole final segment, never a substring", () => {

--- a/frontend/src/utils/locationLabel.test.js
+++ b/frontend/src/utils/locationLabel.test.js
@@ -1,0 +1,22 @@
+import { formatLocationLabel } from "./locationLabel";
+
+describe("formatLocationLabel", () => {
+  it("strips a trailing US country segment", () => {
+    expect(formatLocationLabel("Ashland, OH, USA")).toBe("Ashland, OH");
+    expect(formatLocationLabel("OH, USA")).toBe("OH");
+  });
+
+  it("is case-insensitive and tolerates missing comma", () => {
+    expect(formatLocationLabel("Portland usa")).toBe("Portland");
+  });
+
+  it("leaves non-US labels untouched", () => {
+    expect(formatLocationLabel("Paris, France")).toBe("Paris, France");
+    expect(formatLocationLabel("USANville, CA")).toBe("USANville, CA");
+  });
+
+  it("returns an empty string for nullish input", () => {
+    expect(formatLocationLabel(null)).toBe("");
+    expect(formatLocationLabel(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
# feat(planner): add location autocomplete for route endpoints

## Summary

Added Google Places autocomplete to the Start and Destination fields in the Jaunt builder. Users can now select a specific address, city, landmark, or business before creating a route instead of relying entirely on ambiguous free-text searches.

Selected autocomplete results are routed by Google place ID and retain their descriptive labels in the itinerary. Free-text entries remain supported and are replaced with the locations resolved by Google Directions after route creation.

## Changes

- Added a backend proxy for Google Places Autocomplete (New)
- Validated autocomplete input and normalized Google responses
- Added a reusable Fluent 2 autocomplete field
- Debounced requests and ignored stale responses
- Supported keyboard, pointer, and touch selection
- Preserved free-text route creation when autocomplete is unavailable
- Routed selected suggestions using Google place IDs
- Preserved selected landmark and business names in the itinerary
- Replaced free-text labels with Google-resolved addresses
- Removed trailing `USA` from US location labels while retaining other countries
- Removed the unused dropdown arrow and native spellchecking
- Prevented empty dropdowns from appearing before typing
- Corrected dropdown stacking over the Destination field
- Removed automatic first-option highlighting
- Sanitized backend autocomplete error logging
- Documented the Places API (New) requirement

## Files Modified

- `backend/app/modules/placeAutocompleteAPI.js`
- `backend/app/modules/placeAutocompleteAPI.test.js`
- `backend/app/routes/placeAutocomplete.js`
- `backend/app/routes/placeAutocomplete.test.js`
- `backend/index.js`
- `frontend/src/scripts/PlaceAutocompleteRequester.js`
- `frontend/src/scripts/PlaceAutocompleteRequester.test.js`
- `frontend/src/components/planner/build-workflow/PlaceAutocompleteField.jsx`
- `frontend/src/components/planner/build-workflow/PlaceAutocompleteField.test.jsx`
- `frontend/src/components/planner/build-workflow/RouteForm.jsx`
- `frontend/src/components/planner/build-workflow/RouteForm.test.jsx`
- `DEV-SETUP.md`

## Testing

Verified:

- Backend Prettier and ESLint
- Frontend Prettier and ESLint
- Backend autocomplete module and route tests
- Frontend autocomplete requester tests
- Autocomplete component tests
- RouteForm integration and accessibility tests
- Full backend and frontend test suites
- Production frontend build
- Free-text and selected-place routing
- Mixed selected-place and free-text endpoints
- Canonical free-text address replacement
- Descriptive selected-place label preservation
- Empty, loading, error, and stale-response states

## Configuration

The Google Cloud project must have the following APIs enabled:

- Places API (New)
- Directions API
- Maps JavaScript API

The backend `GOOGLE_API_KEY` must be permitted to access Places API (New). No new environment variable was added.

## Related Issue

Closes #111

## Assumptions

- Route planning remains available without authentication.
- Autocomplete failures do not prevent free-text route creation.
- Selected place labels are preferred for display, while Directions remains the source of route geometry and endpoint coordinates.
- US labels omit the country name; international labels retain it.