### PR TITLE
Fixed map zooming and panning

### DIFF
--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -17,11 +17,27 @@ import {
   getVisibleDetourOptions,
 } from "./planner/discover-workflow/discoverRoute";
 
+const CONTIGUOUS_US_BOUNDS = {
+  north: 49.384358,
+  south: 24.396308,
+  east: -66.93457,
+  west: -124.848974,
+  padding: 24,
+};
+
+const WORLD_BOUNDS = {
+  north: 85.051129,
+  south: -85.051129,
+  east: 180,
+  west: -180,
+};
+
+const MIN_ZOOM = 4;
+
 // Custom hook for map bounds adjustment - only on route change
 function useMapBounds(map, route) {
   const mapsLibrary = useMapsLibrary("maps");
   const lastRouteIdRef = useRef(null);
-  const hasSetBoundsRef = useRef(false);
 
   useEffect(() => {
     if (!map || !mapsLibrary || !route) return;
@@ -48,7 +64,6 @@ function useMapBounds(map, route) {
 
         map.fitBounds(bounds);
         lastRouteIdRef.current = routeId;
-        hasSetBoundsRef.current = true;
       }
     }, 100);
 
@@ -201,12 +216,16 @@ function MapContainer(props) {
     <APIProvider apiKey={config.GOOGLE_API_KEY}>
       <Map
         ref={mapRef}
-        defaultZoom={9}
+        defaultBounds={CONTIGUOUS_US_BOUNDS}
+        minZoom={MIN_ZOOM}
+        restriction={{
+          latLngBounds: WORLD_BOUNDS,
+          strictBounds: true,
+        }}
         style={{
           width: "100%",
           height: "100%",
         }}
-        defaultCenter={{ lat: 33.749, lng: -84.388 }}
         fullscreenControl={false}
         mapId="DEMO_MAP_ID"
         streetViewControl={false}

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import MapContainer from "./MapContainer";
+
+const mockMapProps = jest.fn();
+const mockUseMap = jest.fn();
+
+jest.mock("@vis.gl/react-google-maps", () => {
+  const React = require("react");
+
+  return {
+    AdvancedMarker: ({ children }) => <>{children}</>,
+    APIProvider: ({ children }) => <>{children}</>,
+    Map: React.forwardRef(function MockMap({ children, ...props }, ref) {
+      mockMapProps(props);
+      return <div ref={ref}>{children}</div>;
+    }),
+    Pin: () => null,
+    useMap: () => mockUseMap(),
+    useMapsLibrary: () => ({}),
+  };
+});
+
+function createProps(overrides = {}) {
+  return {
+    route: null,
+    showRoute: false,
+    detourSearchLocation: 50,
+    detourSearchRadius: 20000,
+    showDetourSearchPoint: false,
+    detourOptions: [],
+    detourHighlight: [],
+    detourList: [],
+    setDetourHighlight: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("MapContainer", () => {
+  beforeEach(() => {
+    mockMapProps.mockClear();
+    mockUseMap.mockReturnValue(null);
+  });
+
+  test("starts over the contiguous United States with constrained navigation", () => {
+    render(<MapContainer {...createProps()} />);
+
+    expect(mockMapProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultBounds: {
+          north: 49.384358,
+          south: 24.396308,
+          east: -66.93457,
+          west: -124.848974,
+          padding: 24,
+        },
+        minZoom: 4,
+        restriction: {
+          latLngBounds: {
+            north: 85.051129,
+            south: -85.051129,
+            east: 180,
+            west: -180,
+          },
+          strictBounds: true,
+        },
+      })
+    );
+  });
+
+  test("fits the map to a newly loaded route", () => {
+    jest.useFakeTimers();
+
+    const extend = jest.fn();
+    const fitBounds = jest.fn();
+    mockUseMap.mockReturnValue({
+      fitBounds,
+      getDiv: () => document.createElement("div"),
+    });
+    window.google = {
+      maps: {
+        LatLng: jest.fn(function LatLng(lat, lng) {
+          this.lat = lat;
+          this.lng = lng;
+        }),
+        LatLngBounds: jest.fn(() => ({ extend })),
+      },
+    };
+
+    render(
+      <MapContainer
+        {...createProps({
+          route: {
+            bounds: {
+              northeast: { lat: 49.1, lng: -66.9 },
+              southwest: { lat: 24.4, lng: -124.8 },
+            },
+          },
+        })}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(extend).toHaveBeenCalledTimes(2);
+    expect(fitBounds).toHaveBeenCalledTimes(1);
+
+    delete window.google;
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary

Updated the planner map viewport behavior to keep the map focused on a useful geographic area.

* Initialized the map with bounds that fit the contiguous United States
* Limited zooming out to Google Maps zoom level 4
* Added strict Web Mercator world bounds to prevent panning into grey space
* Preserved route-based viewport fitting when a route is created or loaded
* Removed unused route-bounds tracking state

## Files Modified

* `frontend/src/components/MapContainer.jsx`
  * Added contiguous United States initial bounds
  * Added a minimum zoom level
  * Added strict world-boundary restrictions
  * Retained the existing route `fitBounds` behavior
* `frontend/src/components/MapContainer.test.jsx`
  * Added coverage for the initial viewport and navigation constraints
  * Added regression coverage for route-based viewport fitting

## Testing

* [x] Focused MapContainer Jest tests passed
* [x] Frontend ESLint passed
* [x] Prettier formatting check passed
* [x] Frontend production build passed
* [x] Playwright discovered all 8 desktop and compact tests
* [ ] Playwright browser execution completed

Playwright browser execution was blocked because the dev container is missing
the Chromium system libraries. No Playwright assertions ran or failed.

## Manual Verification

1. Open the planner at `/plan`.
2. Confirm the initial map approximately fits the contiguous United States.
3. Zoom out and confirm the map stops at zoom level 4.
4. Pan toward each world edge and confirm no grey area appears.
5. Create or load a route and confirm the map fits the route bounds.

## Related Issue

Closes #110