### PR TITLE
Added hover state

### DIFF
--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -167,6 +167,10 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await page.getByRole("button", { name: "Search this area" }).click();
   await expect(page.getByRole("heading", { name: "2 places" })).toBeVisible();
   await expect(page.getByRole("listitem")).toHaveCount(2);
+  await page.getByRole("listitem").first().hover();
+  await expect(
+    page.getByRole("button", { name: "Add", exact: true })
+  ).toHaveCount(0);
   await page.getByRole("button", { name: "Select Paris Mountain" }).click();
   await page.getByRole("button", { name: "Add", exact: true }).click();
   await expect(page.getByRole("tab", { name: "Discover" })).toHaveAttribute(

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -292,7 +292,7 @@ function MapContainer(props) {
                           : jauntColors.map.result
                     }
                     glyphColor={
-                      highlight || hovered
+                      highlight
                         ? jauntColors.neutral.foregroundOnDark
                         : jauntColors.map.endpoint
                     }

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -267,27 +267,32 @@ function MapContainer(props) {
                   detourHighlight.id === detour.place_id &&
                   detourHighlight.highlight
               );
+              const hovered = props.hoveredDetourId === detour.place_id;
 
               return (
                 <AdvancedMarker
                   key={`detour-option-${detour.place_id || index}`}
                   title={`${index + 1}. ${detour.name}`}
                   onClick={() => selectDetourOption(detour.place_id)}
+                  onMouseEnter={() => props.onDetourHover?.(detour.place_id)}
+                  onMouseLeave={() => props.onDetourHover?.(null)}
                   position={{
                     lat: detour.geometry.location.lat,
                     lng: detour.geometry.location.lng,
                   }}
-                  zIndex={highlight ? 2 : 1}
+                  zIndex={highlight ? 3 : hovered ? 2 : 1}
                 >
                   <Pin
                     scale={highlight ? 1 : 0.85}
                     background={
                       highlight
                         ? jauntColors.map.selected
-                        : jauntColors.map.result
+                        : hovered
+                          ? jauntColors.brand.accent
+                          : jauntColors.map.result
                     }
                     glyphColor={
-                      highlight
+                      highlight || hovered
                         ? jauntColors.neutral.foregroundOnDark
                         : jauntColors.map.endpoint
                     }
@@ -338,7 +343,9 @@ MapContainer.propTypes = {
   showDetourSearchPoint: PropTypes.bool,
   detourOptions: PropTypes.array,
   detourHighlight: PropTypes.array,
+  hoveredDetourId: PropTypes.string,
   detourList: PropTypes.array,
+  onDetourHover: PropTypes.func,
   setDetourHighlight: PropTypes.func,
 };
 

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -147,6 +147,7 @@ describe("MapContainer", () => {
     expect(mockPinProps).toHaveBeenLastCalledWith(
       expect.objectContaining({
         background: "#e36a2e",
+        glyphColor: "#14282f",
         scale: 0.85,
       })
     );
@@ -176,6 +177,7 @@ describe("MapContainer", () => {
     expect(mockPinProps).toHaveBeenLastCalledWith(
       expect.objectContaining({
         background: "#b84a18",
+        glyphColor: "#ffffff",
         scale: 1,
       })
     );

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -1,21 +1,40 @@
 import React from "react";
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import MapContainer from "./MapContainer";
 
 const mockMapProps = jest.fn();
+const mockPinProps = jest.fn();
 const mockUseMap = jest.fn();
 
 jest.mock("@vis.gl/react-google-maps", () => {
   const React = require("react");
 
   return {
-    AdvancedMarker: ({ children }) => <>{children}</>,
+    AdvancedMarker: ({
+      children,
+      onClick,
+      onMouseEnter,
+      onMouseLeave,
+      title,
+    }) => (
+      <div
+        data-testid={title ? `marker-${title}` : undefined}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {children}
+      </div>
+    ),
     APIProvider: ({ children }) => <>{children}</>,
     Map: React.forwardRef(function MockMap({ children, ...props }, ref) {
       mockMapProps(props);
       return <div ref={ref}>{children}</div>;
     }),
-    Pin: () => null,
+    Pin: (props) => {
+      mockPinProps(props);
+      return null;
+    },
     useMap: () => mockUseMap(),
     useMapsLibrary: () => ({}),
   };
@@ -31,6 +50,7 @@ function createProps(overrides = {}) {
     detourOptions: [],
     detourHighlight: [],
     detourList: [],
+    onDetourHover: jest.fn(),
     setDetourHighlight: jest.fn(),
     ...overrides,
   };
@@ -39,6 +59,7 @@ function createProps(overrides = {}) {
 describe("MapContainer", () => {
   beforeEach(() => {
     mockMapProps.mockClear();
+    mockPinProps.mockClear();
     mockUseMap.mockReturnValue(null);
   });
 
@@ -109,5 +130,59 @@ describe("MapContainer", () => {
 
     delete window.google;
     jest.useRealTimers();
+  });
+
+  test("previews a detour marker on hover without selecting it", () => {
+    const detour = {
+      name: "Paris Mountain",
+      place_id: "place-1",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const props = createProps({
+      detourOptions: [detour],
+      hoveredDetourId: "place-1",
+    });
+    render(<MapContainer {...props} />);
+
+    expect(mockPinProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        background: "#e36a2e",
+        scale: 0.85,
+      })
+    );
+
+    const marker = screen.getByTestId("marker-1. Paris Mountain");
+    fireEvent.mouseEnter(marker);
+    expect(props.onDetourHover).toHaveBeenLastCalledWith("place-1");
+    expect(props.setDetourHighlight).not.toHaveBeenCalled();
+
+    fireEvent.mouseLeave(marker);
+    expect(props.onDetourHover).toHaveBeenLastCalledWith(null);
+  });
+
+  test("keeps click selection visually distinct from hover preview", () => {
+    const detour = {
+      name: "Paris Mountain",
+      place_id: "place-1",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const props = createProps({
+      detourOptions: [detour],
+      detourHighlight: [{ id: "place-1", highlight: true }],
+      hoveredDetourId: "place-1",
+    });
+    render(<MapContainer {...props} />);
+
+    expect(mockPinProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        background: "#b84a18",
+        scale: 1,
+      })
+    );
+
+    fireEvent.click(screen.getByTestId("marker-1. Paris Mountain"));
+    expect(props.setDetourHighlight).toHaveBeenCalledWith([
+      { id: "place-1", highlight: true },
+    ]);
   });
 });

--- a/frontend/src/components/planner/PlannerWorkspace.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.jsx
@@ -234,6 +234,7 @@ export default function PlannerWorkspace(props) {
   const [editingRoute, setEditingRoute] = useState(!props.showDetourButton);
   const [saveOperation, setSaveOperation] = useState("idle");
   const [plannerFeedback, setPlannerFeedback] = useState("");
+  const [hoveredDetourId, setHoveredDetourId] = useState(null);
   const previousSuggestedNameRef = useRef("");
   const previousTripNameRef = useRef(props.tripName);
   const tripNameRef = useRef(props.tripName);
@@ -251,6 +252,10 @@ export default function PlannerWorkspace(props) {
       setEditingRoute(true);
     }
   }, [props.showDetourButton]);
+
+  useEffect(() => {
+    setHoveredDetourId(null);
+  }, [props.detourOptions]);
 
   useEffect(() => {
     if (!plannerFeedback) {
@@ -471,6 +476,8 @@ export default function PlannerWorkspace(props) {
                 detourOptions={props.detourOptions}
                 detourList={props.detourList}
                 detourHighlight={props.detourHighlight}
+                hoveredDetourId={hoveredDetourId}
+                onDetourHover={setHoveredDetourId}
                 addDetour={props.addDetour}
                 setRoute={props.setRoute}
                 setTripSummary={props.setTripSummary}
@@ -537,6 +544,8 @@ export default function PlannerWorkspace(props) {
           detourSearchRadius={props.detourSearchRadius}
           detourOptions={props.detourOptions}
           detourHighlight={props.detourHighlight}
+          hoveredDetourId={hoveredDetourId}
+          onDetourHover={setHoveredDetourId}
           detourList={props.detourList}
           setDetourHighlight={props.setDetourHighlight}
           route={props.route}

--- a/frontend/src/components/planner/PlannerWorkspace.test.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.test.jsx
@@ -4,6 +4,9 @@ import { FluentProvider } from "@fluentui/react-components";
 import PlannerWorkspace from "./PlannerWorkspace";
 import { jauntDetourTheme } from "../../design-system/jauntDetourTheme";
 
+const mockDiscoverProps = jest.fn();
+const mockMapProps = jest.fn();
+
 jest.mock("./build-workflow/RouteForm", () => {
   const PropTypes = require("prop-types");
 
@@ -58,10 +61,20 @@ jest.mock("./build-workflow/BuildRouteDetails", () => {
 jest.mock("./discover-workflow/DiscoverWorkspace", () => {
   const PropTypes = require("prop-types");
 
-  function MockDiscoverWorkspace({ feedback, onAdded, onDismissFeedback }) {
+  function MockDiscoverWorkspace(props) {
+    mockDiscoverProps(props);
+    const {
+      feedback,
+      hoveredDetourId,
+      onAdded,
+      onDetourHover,
+      onDismissFeedback,
+    } = props;
     return (
       <div>
         Discover workspace instance
+        <span data-testid="discover-hovered">{hoveredDetourId || "none"}</span>
+        <button onClick={() => onDetourHover("place-1")}>Hover result</button>
         {feedback ? <span>{feedback}</span> : null}
         <button onClick={() => onAdded("Paris Mountain", 18)}>
           Complete add
@@ -75,7 +88,9 @@ jest.mock("./discover-workflow/DiscoverWorkspace", () => {
 
   MockDiscoverWorkspace.propTypes = {
     feedback: PropTypes.string,
+    hoveredDetourId: PropTypes.string,
     onAdded: PropTypes.func.isRequired,
+    onDetourHover: PropTypes.func.isRequired,
     onDismissFeedback: PropTypes.func.isRequired,
   };
 
@@ -93,8 +108,16 @@ jest.mock(
 jest.mock(
   "../MapContainer",
   () =>
-    function MockMap() {
-      return <div>Map instance</div>;
+    function MockMap(props) {
+      mockMapProps(props);
+      return (
+        <div>
+          Map instance
+          <span data-testid="map-hovered">
+            {props.hoveredDetourId || "none"}
+          </span>
+        </div>
+      );
     }
 );
 
@@ -146,6 +169,11 @@ function renderWorkspace(props) {
 }
 
 describe("PlannerWorkspace", () => {
+  beforeEach(() => {
+    mockDiscoverProps.mockClear();
+    mockMapProps.mockClear();
+  });
+
   it("shows only route entry before a route exists", () => {
     renderWorkspace(createProps());
 
@@ -184,6 +212,28 @@ describe("PlannerWorkspace", () => {
     expect(screen.getAllByText("Discover workspace instance")).toHaveLength(1);
     expect(screen.getAllByText("Map instance")).toHaveLength(1);
     expect(screen.getByText("Not saved")).toBeVisible();
+  });
+
+  it("synchronizes detour hover and clears it when results change", () => {
+    const props = createProps({
+      detourOptions: [{ place_id: "place-1" }],
+      showDetourButton: true,
+      showDetourForm: true,
+    });
+    const { rerender } = renderWorkspace(props);
+
+    fireEvent.click(screen.getByRole("button", { name: "Hover result" }));
+    expect(screen.getByTestId("discover-hovered")).toHaveTextContent("place-1");
+    expect(screen.getByTestId("map-hovered")).toHaveTextContent("place-1");
+
+    rerender(
+      <FluentProvider theme={jauntDetourTheme}>
+        <PlannerWorkspace {...props} detourOptions={[]} />
+      </FluentProvider>
+    );
+
+    expect(screen.getByTestId("discover-hovered")).toHaveTextContent("none");
+    expect(screen.getByTestId("map-hovered")).toHaveTextContent("none");
   });
 
   it("keeps Discover unavailable until a route exists", () => {

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
@@ -213,6 +213,10 @@ const useStyles = makeStyles({
     backgroundColor: jauntColors.brand.primarySubtle,
     ...shorthands.border("2px", "solid", jauntColors.brand.primary),
   },
+  hoveredResult: {
+    backgroundColor: jauntColors.brand.accentSubtle,
+    ...shorthands.border("2px", "solid", jauntColors.brand.accent),
+  },
   resultSelection: {
     position: "absolute",
     inset: 0,
@@ -614,6 +618,7 @@ export default function DiscoverWorkspace(props) {
           <ol className={styles.resultList}>
             {props.detourOptions.map((result, index) => {
               const selected = selectedId === result.place_id;
+              const hovered = props.hoveredDetourId === result.place_id;
               const added = props.detourList.some(
                 (detour) => detour.placeId === result.place_id
               );
@@ -624,9 +629,12 @@ export default function DiscoverWorkspace(props) {
                 <li
                   className={mergeClasses(
                     styles.result,
+                    hovered && styles.hoveredResult,
                     selected && styles.selectedResult
                   )}
                   key={result.place_id || result.id || result.name}
+                  onMouseEnter={() => props.onDetourHover(result.place_id)}
+                  onMouseLeave={() => props.onDetourHover(null)}
                 >
                   <button
                     className={styles.resultSelection}
@@ -687,7 +695,9 @@ DiscoverWorkspace.propTypes = {
   detourSearchRadius: PropTypes.number.isRequired,
   detourType: PropTypes.string.isRequired,
   feedback: PropTypes.string,
+  hoveredDetourId: PropTypes.string,
   onAdded: PropTypes.func.isRequired,
+  onDetourHover: PropTypes.func.isRequired,
   onDismissFeedback: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   route: PropTypes.object.isRequired,
@@ -703,4 +713,5 @@ DiscoverWorkspace.propTypes = {
 
 DiscoverWorkspace.defaultProps = {
   feedback: "",
+  hoveredDetourId: null,
 };

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
@@ -642,6 +642,8 @@ export default function DiscoverWorkspace(props) {
                     aria-label={`Select ${result.name}`}
                     aria-pressed={selected}
                     onClick={() => selectResult(result.place_id)}
+                    onFocus={() => props.onDetourHover(result.place_id)}
+                    onBlur={() => props.onDetourHover(null)}
                   />
                   <span className={styles.resultDetails}>
                     <span className={styles.resultNumber} aria-hidden="true">

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
@@ -42,6 +42,7 @@ function createProps(overrides = {}) {
     addDetour: jest.fn(),
     feedback: "",
     onAdded: jest.fn(),
+    onDetourHover: jest.fn(),
     onDismissFeedback: jest.fn(),
     ...overrides,
   };
@@ -281,6 +282,29 @@ describe("DiscoverWorkspace", () => {
     expect(props.setDetourOptions).toHaveBeenLastCalledWith([]);
     expect(props.setDetourHighlight).toHaveBeenLastCalledWith([]);
     expect(props.onAdded).toHaveBeenCalledWith("Paris Mountain", 18);
+  });
+
+  it("previews a result on hover without selecting it or showing Add", () => {
+    const result = {
+      name: "Paris Mountain",
+      place_id: "place-1",
+      type: "Hike",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const props = createProps({ detourOptions: [result] });
+    renderWorkspace(props);
+
+    const resultCard = screen.getByRole("listitem");
+    fireEvent.mouseEnter(resultCard);
+
+    expect(props.onDetourHover).toHaveBeenLastCalledWith("place-1");
+    expect(props.setDetourHighlight).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Add" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseLeave(resultCard);
+    expect(props.onDetourHover).toHaveBeenLastCalledWith(null);
   });
 
   it("keeps the result selected and offers retry when add rerouting fails", async () => {

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
@@ -307,6 +307,28 @@ describe("DiscoverWorkspace", () => {
     expect(props.onDetourHover).toHaveBeenLastCalledWith(null);
   });
 
+  it("previews a result on keyboard focus and clears it on blur", () => {
+    const result = {
+      name: "Paris Mountain",
+      place_id: "place-1",
+      type: "Hike",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const props = createProps({ detourOptions: [result] });
+    renderWorkspace(props);
+
+    const selectButton = screen.getByRole("button", {
+      name: "Select Paris Mountain",
+    });
+    fireEvent.focus(selectButton);
+
+    expect(props.onDetourHover).toHaveBeenLastCalledWith("place-1");
+    expect(props.setDetourHighlight).not.toHaveBeenCalled();
+
+    fireEvent.blur(selectButton);
+    expect(props.onDetourHover).toHaveBeenLastCalledWith(null);
+  });
+
   it("keeps the result selected and offers retry when add rerouting fails", async () => {
     const result = {
       name: "Paris Mountain",


### PR DESCRIPTION
## Summary

Adds synchronized hover previews between detour result cards and their map pins, making it easier to scan detour options without repeatedly clicking each result.

Hover remains separate from selection:

- Hovering a result card highlights the matching card and map pin.
- Hovering a map pin highlights the matching pin and result card.
- Hovering never displays the Add button or changes the selected detour.
- Clicking a card or pin still selects it and reveals the only Add button.
- A selected detour remains selected while another detour is previewed.

## Implementation

- Added transient `hoveredDetourId` state to `PlannerWorkspace`.
- Shared hover state between `DiscoverWorkspace` and `MapContainer`.
- Cleared stale hover state whenever the detour result set changes.
- Added pointer enter and leave handlers to result cards and map markers.
- Added a distinct accent treatment for hovered cards and pins.
- Kept the existing Redux-backed selection and Add behavior unchanged.
- Kept hovered marker dimensions stable to prevent marker movement from triggering an immediate pointer leave.

## Testing

- Added result-card hover coverage.
- Added map-marker hover and click-selection coverage.
- Added workspace-level synchronization and stale-state cleanup coverage.
- Updated the Playwright planner workflow to confirm hover alone does not display Add.
- Verified both card-to-pin and pin-to-card highlighting in the running application.

Validation completed:

- `34` focused component tests passed.
- ESLint passed.
- Prettier formatting checks passed.
- Production frontend build passed.
- `git diff --check` passed.
- Playwright discovered all `8` configured tests, but browser execution was blocked because the development container lacks the required Chromium system libraries.

## Scope

Frontend only. No backend, database, Redux schema, dependency, or design-token changes were required.

## Related Issue

Closes #112