### PR TITLE
Feature/120 map endpoint markers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,7 +153,14 @@ submitButton.enabled = isValidEmail(user.email);
 ## Pull Requests
 
 - When asked for a PR description, provide a summary of the change, what files were modified, how to test the
-  changes, and any other relevant information or assumtpions. Provide all of this in markdown to be copy and pasted.
+  changes, and any other relevant information or assumptions. Provide all of this in markdown to be copied and pasted.
+- Generate PR descriptions directly from conversation and session context plus local Git history and diffs.
+- Local read-only Git commands such as `git log`, `git show`, `git status`, and `git diff` are allowed for gathering
+  PR context.
+- Do not invoke the `pr-reference` skill, PR-generation subagents, PR-description generators, or other external
+  workflows. This repository-specific rule overrides generic skill metadata that recommends those tools for PR
+  descriptions.
+- Do not create PR tracking artifacts or planning files when the user only asks for a PR description.
 - Once a PR is active, the user will review the changes with you based on feedback from a Github Copilot agent.
   For each comment, do not assume the comment is correct, but investigate if the feedback is accurate and within
   scope of this PR. If it is, work with the user to make changes based on the feedback.

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -72,6 +72,7 @@ jobs:
         run: npm run build
         env:
           CI: true
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
 
       - name: Install Playwright browser
         working-directory: ./frontend

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -147,6 +147,8 @@ test("mounts the current planner at its stable route", async ({ page }) => {
     "Atlanta, GA"
   );
   await expect(page.getByText("Not saved")).toBeVisible();
+  await expect(page.getByTitle("Jaunt start")).toHaveCount(1);
+  await expect(page.getByTitle("Jaunt destination")).toHaveCount(1);
   const jauntName = page.getByRole("textbox", { name: "Jaunt name" });
   await expect(jauntName).toHaveCount(1);
   await expect(jauntName).toHaveAttribute(

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -214,6 +214,76 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   }
 });
 
+test("renders endpoint markers on the saved Jaunt detail map", async ({
+  page,
+}) => {
+  await page.route("**/auth/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { email: "traveler@example.com", display_name: "Avery Traveler" },
+      }),
+    })
+  );
+  await page.route("**/api/trips/trip-1", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        trip: {
+          tripId: "trip-1",
+          tripName: "Carolinas weekend",
+          origin: { address: "Atlanta, GA", lat: 33.749, lng: -84.388 },
+          destination: {
+            address: "Charlotte, NC",
+            lat: 35.2271,
+            lng: -80.8431,
+          },
+          updatedAt: "2026-08-01T12:00:00.000Z",
+          distanceMeters: 415000,
+          durationSeconds: 14700,
+        },
+        route: {
+          summary: { distance: 258, time: { hours: 4, min: 5 } },
+          bounds: {
+            northeast: { lat: 35.3, lng: -80.8 },
+            southwest: { lat: 33.7, lng: -84.4 },
+          },
+          overview_polyline: {
+            points: "saved-polyline",
+            complete_overview: [
+              [33.749, -84.388],
+              [35.2271, -80.8431],
+            ],
+          },
+        },
+        detours: [
+          {
+            name: "Paris Mountain",
+            type: "Hike",
+            lat: 34.94,
+            lng: -82.41,
+            placeId: "hike-1",
+            rating: 4.7,
+          },
+        ],
+      }),
+    })
+  );
+
+  await page.goto("/trips/trip-1", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("heading", { name: "Carolinas weekend" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Saved Jaunt details" })
+  ).toBeVisible();
+  await expect(page.getByTitle("Jaunt start")).toHaveCount(1);
+  await expect(page.getByTitle("Jaunt destination")).toHaveCount(1);
+});
+
 test("protects saved Jaunts while preserving anonymous planning", async ({
   page,
 }) => {

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -34,6 +34,46 @@ const WORLD_BOUNDS = {
 
 const MIN_ZOOM = 4;
 
+function normalizeCoordinates(location) {
+  if (!Number.isFinite(location?.lat) || !Number.isFinite(location?.lng)) {
+    return null;
+  }
+
+  return { lat: location.lat, lng: location.lng };
+}
+
+function getRouteEndpoints(route, origin, destination) {
+  const legs = Array.isArray(route?.legs) ? route.legs : [];
+  const firstLeg = legs[0];
+  const lastLeg = legs[legs.length - 1];
+
+  return {
+    start:
+      normalizeCoordinates(firstLeg?.start_location) ||
+      normalizeCoordinates(origin),
+    destination:
+      normalizeCoordinates(lastLeg?.end_location) ||
+      normalizeCoordinates(destination),
+  };
+}
+
+function RouteEndpointMarker({ position, title, type }) {
+  if (!position) return null;
+
+  return (
+    <AdvancedMarker position={position} title={title} zIndex={0}>
+      <Pin
+        scale={1.1}
+        background={jauntColors.map.endpoint}
+        borderColor={jauntColors.neutral.foregroundOnDark}
+        glyphColor={jauntColors.neutral.foregroundOnDark}
+      >
+        {getDetourIconComponent(type, "1.125rem")}
+      </Pin>
+    </AdvancedMarker>
+  );
+}
+
 // Custom hook for map bounds adjustment - only on route change
 function useMapBounds(map, route) {
   const mapsLibrary = useMapsLibrary("maps");
@@ -197,6 +237,11 @@ function DetourCircle({
 // Main MapContainer component - TEST CHANGE
 function MapContainer(props) {
   const mapRef = useRef(null);
+  const routeEndpoints = getRouteEndpoints(
+    props.route,
+    props.origin,
+    props.destination
+  );
 
   const detourPoint =
     props.showDetourSearchPoint && props.showRoute
@@ -237,6 +282,21 @@ function MapContainer(props) {
 
         {/* Route polyline */}
         <RoutePolyline route={props.route} showRoute={props.showRoute} />
+
+        {props.showRoute && (
+          <>
+            <RouteEndpointMarker
+              position={routeEndpoints.start}
+              title="Jaunt start"
+              type="origin"
+            />
+            <RouteEndpointMarker
+              position={routeEndpoints.destination}
+              title="Jaunt destination"
+              type="destination"
+            />
+          </>
+        )}
 
         {/* Detour search point marker */}
         {props.showDetourSearchPoint && detourPoint && (
@@ -311,23 +371,16 @@ function MapContainer(props) {
               key={`detour-${detour.placeId || detour.id || index}`}
               title={`${detour.name}, added stop`}
               position={{ lat: detour.lat, lng: detour.lng }}
+              zIndex={1}
             >
-              <span
-                style={{
-                  display: "grid",
-                  width: "2.25rem",
-                  height: "2.25rem",
-                  placeItems: "center",
-                  border: `2px solid ${jauntColors.map.endpoint}`,
-                  borderRadius: "999px",
-                  color: jauntColors.neutral.foregroundOnDark,
-                  backgroundColor: jauntColors.map.stop,
-                  boxShadow: "0 2px 8px #14282f33",
-                }}
-                aria-hidden="true"
+              <Pin
+                scale={1.1}
+                background={jauntColors.map.stop}
+                borderColor={jauntColors.neutral.foregroundOnDark}
+                glyphColor={jauntColors.neutral.foregroundOnDark}
               >
-                {getDetourIconComponent(detour.type, "1.375rem")}
-              </span>
+                {getDetourIconComponent(detour.type, "1.125rem")}
+              </Pin>
             </AdvancedMarker>
           ))}
       </Map>
@@ -336,6 +389,14 @@ function MapContainer(props) {
 }
 
 MapContainer.propTypes = {
+  origin: PropTypes.shape({
+    lat: PropTypes.number,
+    lng: PropTypes.number,
+  }),
+  destination: PropTypes.shape({
+    lat: PropTypes.number,
+    lng: PropTypes.number,
+  }),
   route: PropTypes.object,
   showRoute: PropTypes.bool,
   detourSearchLocation: PropTypes.number,
@@ -362,6 +423,15 @@ DetourCircle.propTypes = {
   detourPoint: PropTypes.object,
   detourSearchRadius: PropTypes.number,
   showDetourSearchPoint: PropTypes.bool,
+};
+
+RouteEndpointMarker.propTypes = {
+  position: PropTypes.shape({
+    lat: PropTypes.number.isRequired,
+    lng: PropTypes.number.isRequired,
+  }),
+  title: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(["origin", "destination"]).isRequired,
 };
 
 export default MapContainer;

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -39,6 +39,16 @@ function normalizeCoordinates(location) {
     return null;
   }
 
+  const { north, south, east, west } = WORLD_BOUNDS;
+  if (
+    location.lat > north ||
+    location.lat < south ||
+    location.lng > east ||
+    location.lng < west
+  ) {
+    return null;
+  }
+
   return { lat: location.lat, lng: location.lng };
 }
 

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -315,6 +315,23 @@ describe("MapContainer", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("hides endpoints whose coordinates fall outside the map bounds", () => {
+    render(
+      <MapContainer
+        {...createProps({
+          showRoute: true,
+          origin: { lat: 999, lng: 181 },
+          destination: { lat: -90, lng: -200 },
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId("marker-Jaunt start")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("marker-Jaunt destination")
+    ).not.toBeInTheDocument();
+  });
+
   test("anchors added detours with category icons in stop-colored pins", () => {
     render(
       <MapContainer

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -15,10 +15,12 @@ jest.mock("@vis.gl/react-google-maps", () => {
       onClick,
       onMouseEnter,
       onMouseLeave,
+      position,
       title,
     }) => (
       <div
         data-testid={title ? `marker-${title}` : undefined}
+        data-position={position ? `${position.lat},${position.lng}` : undefined}
         onClick={onClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
@@ -130,6 +132,217 @@ describe("MapContainer", () => {
 
     delete window.google;
     jest.useRealTimers();
+  });
+
+  test("shows itinerary-consistent endpoints from a live multi-leg route", () => {
+    render(
+      <MapContainer
+        {...createProps({
+          showRoute: true,
+          route: {
+            legs: [
+              {
+                start_location: { lat: 0, lng: -84.388 },
+                end_location: { lat: 34.9, lng: -82.4 },
+              },
+              {
+                start_location: { lat: 34.9, lng: -82.4 },
+                end_location: { lat: 35.2271, lng: 0 },
+              },
+            ],
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("marker-Jaunt start")).toHaveAttribute(
+      "data-position",
+      "0,-84.388"
+    );
+    expect(screen.getByTestId("marker-Jaunt destination")).toHaveAttribute(
+      "data-position",
+      "35.2271,0"
+    );
+    expect(mockPinProps).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        background: "#14282f",
+        borderColor: "#ffffff",
+        glyphColor: "#ffffff",
+        scale: 1.1,
+      })
+    );
+    expect(mockPinProps).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        background: "#14282f",
+        borderColor: "#ffffff",
+        glyphColor: "#ffffff",
+        scale: 1.1,
+      })
+    );
+  });
+
+  test("falls back to persisted endpoints when saved routes have no legs", () => {
+    render(
+      <MapContainer
+        {...createProps({
+          showRoute: true,
+          route: { overview_polyline: { complete_overview: [] } },
+          origin: { lat: 33.749, lng: -84.388 },
+          destination: { lat: 35.2271, lng: -80.8431 },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("marker-Jaunt start")).toHaveAttribute(
+      "data-position",
+      "33.749,-84.388"
+    );
+    expect(screen.getByTestId("marker-Jaunt destination")).toHaveAttribute(
+      "data-position",
+      "35.2271,-80.8431"
+    );
+  });
+
+  test("prefers live endpoints and updates them after route recalculation", () => {
+    const fallbackProps = {
+      origin: { lat: 1, lng: 2 },
+      destination: { lat: 3, lng: 4 },
+    };
+    const { rerender } = render(
+      <MapContainer
+        {...createProps({
+          ...fallbackProps,
+          showRoute: true,
+          route: {
+            legs: [
+              {
+                start_location: { lat: 10, lng: 20 },
+                end_location: { lat: 30, lng: 40 },
+              },
+            ],
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("marker-Jaunt start")).toHaveAttribute(
+      "data-position",
+      "10,20"
+    );
+
+    rerender(
+      <MapContainer
+        {...createProps({
+          ...fallbackProps,
+          showRoute: true,
+          route: {
+            legs: [
+              {
+                start_location: { lat: 50, lng: 60 },
+                end_location: { lat: 70, lng: 80 },
+              },
+            ],
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("marker-Jaunt start")).toHaveAttribute(
+      "data-position",
+      "50,60"
+    );
+    expect(screen.getByTestId("marker-Jaunt destination")).toHaveAttribute(
+      "data-position",
+      "70,80"
+    );
+  });
+
+  test("uses a valid persisted endpoint when a route leg endpoint is invalid", () => {
+    render(
+      <MapContainer
+        {...createProps({
+          showRoute: true,
+          route: {
+            legs: [
+              {
+                start_location: { lat: null, lng: -84.388 },
+                end_location: { lat: 35.2271, lng: -80.8431 },
+              },
+            ],
+          },
+          origin: { lat: 33.749, lng: -84.388 },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("marker-Jaunt start")).toHaveAttribute(
+      "data-position",
+      "33.749,-84.388"
+    );
+  });
+
+  test("hides endpoints with the route and ignores unusable coordinates", () => {
+    const { rerender } = render(
+      <MapContainer
+        {...createProps({
+          showRoute: false,
+          origin: { lat: 33.749, lng: -84.388 },
+          destination: { lat: 35.2271, lng: -80.8431 },
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId("marker-Jaunt start")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("marker-Jaunt destination")
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <MapContainer
+        {...createProps({
+          showRoute: true,
+          origin: { lat: Number.NaN, lng: -84.388 },
+          destination: { lat: 35.2271 },
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId("marker-Jaunt start")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("marker-Jaunt destination")
+    ).not.toBeInTheDocument();
+  });
+
+  test("anchors added detours with category icons in stop-colored pins", () => {
+    render(
+      <MapContainer
+        {...createProps({
+          detourList: [
+            {
+              name: "Paris Mountain",
+              placeId: "place-1",
+              type: "Hike",
+              lat: 34.9,
+              lng: -82.4,
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(
+      screen.getByTestId("marker-Paris Mountain, added stop")
+    ).toHaveAttribute("data-position", "34.9,-82.4");
+    expect(mockPinProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        background: "#b84a18",
+        borderColor: "#ffffff",
+        glyphColor: "#ffffff",
+        scale: 1.1,
+      })
+    );
   });
 
   test("previews a detour marker on hover without selecting it", () => {

--- a/frontend/src/components/planner/PlannerWorkspace.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.jsx
@@ -538,6 +538,8 @@ export default function PlannerWorkspace(props) {
           </Button>
         ) : null}
         <MapContainer
+          origin={props.currentTrip?.origin}
+          destination={props.currentTrip?.destination}
           showRoute={props.showRoute}
           showDetourSearchPoint={props.showDetourSearchPoint}
           detourSearchLocation={props.detourSearchLocation}

--- a/frontend/src/components/planner/PlannerWorkspace.test.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.test.jsx
@@ -252,9 +252,20 @@ describe("PlannerWorkspace", () => {
   });
 
   it("shows a resumed saved Jaunt name and status in the panel header", () => {
+    const origin = { address: "Atlanta, GA", lat: 33.749, lng: -84.388 };
+    const destination = {
+      address: "Charlotte, NC",
+      lat: 35.2271,
+      lng: -80.8431,
+    };
     renderWorkspace(
       createProps({
-        currentTrip: { tripId: "trip-1", tripName: "Saved weekend" },
+        currentTrip: {
+          tripId: "trip-1",
+          tripName: "Saved weekend",
+          origin,
+          destination,
+        },
         tripName: "Saved weekend",
         showDetourButton: true,
         tripSummary: { distance: 245 },
@@ -265,6 +276,9 @@ describe("PlannerWorkspace", () => {
       "Saved weekend"
     );
     expect(screen.getByText("Loaded")).toBeVisible();
+    expect(mockMapProps).toHaveBeenCalledWith(
+      expect.objectContaining({ origin, destination })
+    );
   });
 
   it("edits the Jaunt name once in the panel header", () => {

--- a/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
+++ b/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
@@ -16,8 +16,6 @@ import {
   ArrowDownRegular,
   ArrowUpRegular,
   DeleteRegular,
-  LocationRegular,
-  NavigationRegular,
   SearchRegular,
 } from "@fluentui/react-icons";
 import { moveDetour, recalculateItinerary } from "./routeMutations";
@@ -88,9 +86,6 @@ const useStyles = makeStyles({
   },
   stopMarker: {
     backgroundColor: jauntColors.map.stop,
-  },
-  destinationIcon: {
-    fontSize: "1.25rem",
   },
   itemCopy: {
     display: "grid",
@@ -241,7 +236,7 @@ export default function JauntItinerary({
       <ol className={styles.list}>
         <li className={styles.item}>
           <span className={styles.marker} aria-hidden="true">
-            <NavigationRegular />
+            {getDetourIconComponent("origin", "1.25rem")}
           </span>
           <span className={styles.itemCopy}>
             <Text className={styles.itemTitle}>{origin}</Text>
@@ -318,10 +313,9 @@ export default function JauntItinerary({
 
         <li className={styles.item}>
           <span className={styles.marker} aria-hidden="true">
-            <LocationRegular
-              className={styles.destinationIcon}
-              data-testid="destination-marker-icon"
-            />
+            {getDetourIconComponent("destination", "1.25rem", {
+              "data-testid": "destination-marker-icon",
+            })}
           </span>
           <span className={styles.itemCopy}>
             <Text className={styles.itemTitle}>{destination}</Text>

--- a/frontend/src/pages/JauntDetailPage.jsx
+++ b/frontend/src/pages/JauntDetailPage.jsx
@@ -535,6 +535,8 @@ export default function JauntDetailPage() {
         <div className={styles.map} aria-label="Saved route preview">
           {route ? (
             <MapContainer
+              origin={trip.origin}
+              destination={trip.destination}
               detourHighlight={[]}
               detourList={detours}
               detourOptions={[]}

--- a/frontend/src/pages/SavedJauntsPages.test.jsx
+++ b/frontend/src/pages/SavedJauntsPages.test.jsx
@@ -12,13 +12,16 @@ import { exportToGoogleMaps } from "../utils/googleMapsExport";
 import JauntDetailPage from "./JauntDetailPage";
 import MyJauntsPage from "./MyJauntsPage";
 
+const mockMapProps = jest.fn();
+
 jest.mock("../scripts/TripRequester");
 jest.mock("../telemetry/telemetry", () => ({ trackEvent: jest.fn() }));
 jest.mock("../utils/googleMapsExport");
 jest.mock(
   "../components/MapContainer",
   () =>
-    function MockMap() {
+    function MockMap(props) {
+      mockMapProps(props);
       return <div>Saved route map</div>;
     }
 );
@@ -242,6 +245,12 @@ describe("JauntDetailPage", () => {
       screen.getByRole("img", { name: "Destination marker" })
     ).toBeVisible();
     expect(screen.getByText("Saved route map")).toBeVisible();
+    expect(mockMapProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: detailView.trip.origin,
+        destination: detailView.trip.destination,
+      })
+    );
     expect(store.getState().origin).toBe("Current route");
     expect(trackEvent).toHaveBeenCalledWith("trip_detail_viewed", {
       countBucket: "1-5",

--- a/frontend/src/utils/detourIcons.js
+++ b/frontend/src/utils/detourIcons.js
@@ -7,6 +7,7 @@ import {
   FoodRegular,
   GasPumpRegular,
   LocationRegular,
+  NavigationRegular,
   PersonWalkingRegular,
   PlugConnectedRegular,
 } from "@fluentui/react-icons";
@@ -22,7 +23,7 @@ const DETOUR_ICON_MAP = {
   "gas-station": GasPumpRegular,
   "charging station": PlugConnectedRegular,
   "charging-station": PlugConnectedRegular,
-  origin: LocationRegular,
+  origin: NavigationRegular,
   destination: LocationRegular,
   default: LocationRegular,
 };
@@ -51,11 +52,12 @@ function getIconComponent(type) {
  * Get a detour icon for React compositions and map markers.
  * @param {string} type - The detour type
  * @param {string|number} size - Optional icon font size
+ * @param {object} props - Optional icon props
  * @returns {React.Component} Fluent icon element
  */
-export function getDetourIconComponent(type, size = undefined) {
+export function getDetourIconComponent(type, size = undefined, props = {}) {
   const IconComponent = getIconComponent(type);
-  return <IconComponent aria-hidden="true" fontSize={size} />;
+  return <IconComponent {...props} aria-hidden="true" fontSize={size} />;
 }
 
 /**

--- a/frontend/src/utils/detourIcons.test.js
+++ b/frontend/src/utils/detourIcons.test.js
@@ -1,5 +1,9 @@
 import { getDetourIconComponent, getAvailableDetourTypes } from "./detourIcons";
-import { PersonWalkingRegular } from "@fluentui/react-icons";
+import {
+  LocationRegular,
+  NavigationRegular,
+  PersonWalkingRegular,
+} from "@fluentui/react-icons";
 
 describe("detourIcons", () => {
   describe("getAvailableDetourTypes", () => {
@@ -37,6 +41,11 @@ describe("detourIcons", () => {
       const coffeeIcon = getDetourIconComponent("coffee");
       expect(hikeIcon).toBeDefined();
       expect(coffeeIcon).toBeDefined();
+    });
+
+    it("uses the itinerary icons for route endpoints", () => {
+      expect(getDetourIconComponent("origin").type).toBe(NavigationRegular);
+      expect(getDetourIconComponent("destination").type).toBe(LocationRegular);
     });
 
     it("should return default icon for unknown types", () => {


### PR DESCRIPTION
## Summary

Adds clear, anchored map markers for Jaunt route endpoints and added detours.

- Displays a dark teardrop pin for the Jaunt start using `NavigationRegular`
- Displays a dark teardrop pin for the destination using `LocationRegular`
- Displays added detours as orange teardrop pins with category-specific icons
- Resolves endpoint coordinates from live route legs when available
- Falls back to persisted endpoint coordinates for saved Jaunt previews and resumed planning
- Hides endpoint markers when the route is hidden or coordinates are invalid
- Keeps map and itinerary endpoint icon semantics synchronized
- Supplies the Google Maps API key during the CI frontend build so Advanced Markers render in Playwright
- Clarifies the repository-specific PR description workflow in Copilot instructions

Closes #120.

## Files Modified

- `.github/copilot-instructions.md`
  - Clarifies that PR descriptions use session context and local Git commands without PR-generation skills or subagents

- `.github/workflows/lint-and-test.yml`
  - Adds `REACT_APP_GOOGLE_API_KEY` to the frontend build environment used by Playwright

- `frontend/src/components/MapContainer.jsx`
  - Resolves live and persisted endpoint coordinates
  - Renders accessible start and destination pins
  - Converts added-detour circles to anchored pins

- `frontend/src/components/planner/PlannerWorkspace.jsx`
  - Passes persisted endpoint coordinates when resuming a saved Jaunt

- `frontend/src/components/planner/build-workflow/JauntItinerary.jsx`
  - Uses the shared endpoint icon mapping

- `frontend/src/pages/JauntDetailPage.jsx`
  - Passes persisted endpoint coordinates to the saved Jaunt map preview

- `frontend/src/utils/detourIcons.js`
  - Maps the origin to `NavigationRegular`
  - Supports forwarding icon properties for shared compositions

- Related unit, integration, and Playwright tests
  - Covers live routes, saved routes, resumed planning, coordinate validation, recalculation, marker visibility, icon mappings, and pin styling

## Testing

- `cd frontend && npm run lint`
- `cd frontend && CI=true npm test`
  - 30 test suites passed
  - 208 tests passed
- `npm run build:frontend`
  - Production build completed successfully
- `cd frontend && npx playwright test --list`
  - All 8 desktop and compact browser tests discovered
- `git diff --check`
- Manually verified endpoint and added-detour pins on the planner map

## Notes

- Live route-leg coordinates take precedence over persisted coordinates.
- Persisted coordinates are used when saved routes do not contain route legs.
- Map markers are informational and are not clickable or draggable.
- Google Maps browser keys remain protected through Google Cloud API and HTTP-referrer restrictions.