### PR TITLE
Feature/selectable map marker details

### DIFF
--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -155,10 +155,16 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(destinationMarker).toHaveCount(1);
   await startMarker.hover();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(
+    page.getByRole("button", { name: "Close", exact: true })
+  ).toHaveCount(0);
   await page.getByRole("region", { name: "Route summary" }).hover();
   await expect(page.getByLabel("Start details")).toHaveCount(0);
   await startMarker.click();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(
+    page.getByRole("button", { name: "Close", exact: true })
+  ).toHaveCount(1);
   await destinationMarker.focus();
   await page.keyboard.press("Enter");
   await expect(page.getByLabel("Start details")).toHaveCount(0);

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -390,9 +390,13 @@ test("selects marker details on a saved Jaunt map", async ({ page }) => {
     page.getByRole("heading", { name: "Carolinas weekend" })
   ).toBeVisible();
 
-  await page.getByTitle("Jaunt start").click();
+  const savedStartMarker = page.getByTitle("Jaunt start");
+  await savedStartMarker.focus();
+  await page.keyboard.press("Enter");
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
-  await page.getByTitle("Paris Mountain, added stop").click();
+  const savedDetourMarker = page.getByTitle("Paris Mountain, added stop");
+  await savedDetourMarker.focus();
+  await page.keyboard.press("Enter");
   await expect(page.getByLabel("Start details")).toHaveCount(0);
   const details = page.getByLabel("Paris Mountain details");
   await expect(details).toContainText("Hike");

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -66,6 +66,8 @@ test("mounts the current planner at its stable route", async ({ page }) => {
               {
                 distance: { value: 394000 },
                 duration: { value: 13620 },
+                start_address: "Atlanta, GA",
+                end_address: "Charlotte, NC",
                 start_location: { lat: 33.749, lng: -84.388 },
                 end_location: { lat: 35.2271, lng: -80.8431 },
               },
@@ -147,8 +149,25 @@ test("mounts the current planner at its stable route", async ({ page }) => {
     "Atlanta, GA"
   );
   await expect(page.getByText("Not saved")).toBeVisible();
-  await expect(page.getByTitle("Jaunt start")).toHaveCount(1);
-  await expect(page.getByTitle("Jaunt destination")).toHaveCount(1);
+  const startMarker = page.getByTitle("Jaunt start");
+  const destinationMarker = page.getByTitle("Jaunt destination");
+  await expect(startMarker).toHaveCount(1);
+  await expect(destinationMarker).toHaveCount(1);
+  await startMarker.hover();
+  await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await page.getByRole("region", { name: "Route summary" }).hover();
+  await expect(page.getByLabel("Start details")).toHaveCount(0);
+  await startMarker.click();
+  await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await destinationMarker.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByLabel("Start details")).toHaveCount(0);
+  await expect(page.getByLabel("Destination details")).toContainText(
+    "Charlotte, NC"
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByLabel("Destination details")).toHaveCount(0);
+  await expect(destinationMarker).toBeFocused();
   const jauntName = page.getByRole("textbox", { name: "Jaunt name" });
   await expect(jauntName).toHaveCount(1);
   await expect(jauntName).toHaveAttribute(
@@ -190,6 +209,13 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(page.getByRole("region", { name: "Itinerary" })).toContainText(
     "Adds 18 min"
   );
+  await page.getByTitle("Paris Mountain, added stop").click();
+  const detourDetails = page.getByLabel("Paris Mountain details");
+  await expect(detourDetails).toContainText("Hike");
+  await expect(detourDetails).toContainText("4.7 rating");
+  await expect(detourDetails).toContainText("18 min added");
+  await page.keyboard.press("Escape");
+  await expect(detourDetails).toHaveCount(0);
 
   const viewport = page.viewportSize();
   const showMap = page.getByRole("button", { name: "Show map" });
@@ -282,6 +308,78 @@ test("renders endpoint markers on the saved Jaunt detail map", async ({
   ).toBeVisible();
   await expect(page.getByTitle("Jaunt start")).toHaveCount(1);
   await expect(page.getByTitle("Jaunt destination")).toHaveCount(1);
+});
+
+test("selects marker details on a saved Jaunt map", async ({ page }) => {
+  await page.route("**/auth/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { email: "traveler@example.com", display_name: "Avery Traveler" },
+      }),
+    })
+  );
+  await page.route("**/api/trips/trip-1", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        trip: {
+          tripId: "trip-1",
+          tripName: "Carolinas weekend",
+          origin: { address: "Atlanta, GA", lat: 33.749, lng: -84.388 },
+          destination: {
+            address: "Charlotte, NC",
+            lat: 35.2271,
+            lng: -80.8431,
+          },
+          updatedAt: "2026-08-01T12:00:00.000Z",
+          distanceMeters: 415000,
+          durationSeconds: 14700,
+        },
+        route: {
+          summary: { distance: 258, time: { hours: 4, min: 5 } },
+          bounds: {
+            northeast: { lat: 35.3, lng: -80.8 },
+            southwest: { lat: 33.7, lng: -84.4 },
+          },
+          overview_polyline: {
+            points: "saved-polyline",
+            complete_overview: [
+              [33.749, -84.388],
+              [35.2271, -80.8431],
+            ],
+          },
+        },
+        detours: [
+          {
+            name: "Paris Mountain",
+            type: "Hike",
+            lat: 34.94,
+            lng: -82.41,
+            placeId: "hike-1",
+            rating: 4.7,
+            addedTime: 18,
+          },
+        ],
+      }),
+    })
+  );
+
+  await page.goto("/trips/trip-1", { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("heading", { name: "Carolinas weekend" })
+  ).toBeVisible();
+
+  await page.getByTitle("Jaunt start").click();
+  await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await page.getByTitle("Paris Mountain, added stop").click();
+  await expect(page.getByLabel("Start details")).toHaveCount(0);
+  const details = page.getByLabel("Paris Mountain details");
+  await expect(details).toContainText("Hike");
+  await expect(details).toContainText("4.7 rating");
+  await expect(details).toContainText("18 min added");
 });
 
 test("protects saved Jaunts while preserving anonymous planning", async ({

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -155,10 +155,28 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(destinationMarker).toHaveCount(1);
   await startMarker.hover();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(
+    page.getByRole("button", { name: "Close", exact: true })
+  ).toHaveCount(0);
   await page.getByRole("region", { name: "Route summary" }).hover();
   await expect(page.getByLabel("Start details")).toHaveCount(0);
   await startMarker.click();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(
+    page.getByRole("button", { name: "Close", exact: true })
+  ).toHaveCount(1);
+  await destinationMarker.hover();
+  await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(page.getByLabel("Destination details")).toContainText(
+    "Charlotte, NC"
+  );
+  await expect(page.getByRole("dialog")).toHaveCount(2);
+  await expect(
+    page.getByRole("button", { name: "Close", exact: true })
+  ).toHaveCount(1);
+  await page.getByRole("region", { name: "Route summary" }).hover();
+  await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
+  await expect(page.getByLabel("Destination details")).toHaveCount(0);
   await destinationMarker.focus();
   await page.keyboard.press("Enter");
   await expect(page.getByLabel("Start details")).toHaveCount(0);
@@ -213,7 +231,7 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   const detourDetails = page.getByLabel("Paris Mountain details");
   await expect(detourDetails).toContainText("Hike");
   await expect(detourDetails).toContainText("4.7 rating");
-  await expect(detourDetails).toContainText("18 min added");
+  await expect(detourDetails).toContainText("+ 18 min");
   await page.keyboard.press("Escape");
   await expect(detourDetails).toHaveCount(0);
 
@@ -379,7 +397,7 @@ test("selects marker details on a saved Jaunt map", async ({ page }) => {
   const details = page.getByLabel("Paris Mountain details");
   await expect(details).toContainText("Hike");
   await expect(details).toContainText("4.7 rating");
-  await expect(details).toContainText("18 min added");
+  await expect(details).toContainText("+ 18 min");
 });
 
 test("protects saved Jaunts while preserving anonymous planning", async ({

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -440,6 +440,7 @@ function MapContainer(props) {
       <div className="jaunt-map" style={{ width: "100%", height: "100%" }}>
         <Map
           ref={mapRef}
+          cameraControl={props.cameraControl !== false}
           defaultBounds={CONTIGUOUS_US_BOUNDS}
           minZoom={MIN_ZOOM}
           restriction={{
@@ -452,11 +453,13 @@ function MapContainer(props) {
           }}
           fullscreenControl={false}
           mapId="DEMO_MAP_ID"
+          mapTypeControl={props.mapTypeControl !== false}
           onClick={() => {
             setHoveredFeatureId(null);
             setSelectedFeatureId(null);
           }}
           streetViewControl={false}
+          zoomControl={props.zoomControl !== false}
         >
           <MapResizeObserver />
 
@@ -612,6 +615,7 @@ function MapContainer(props) {
 }
 
 MapContainer.propTypes = {
+  cameraControl: PropTypes.bool,
   origin: PropTypes.shape({
     address: PropTypes.string,
     lat: PropTypes.number,
@@ -630,9 +634,11 @@ MapContainer.propTypes = {
   detourOptions: PropTypes.array,
   detourHighlight: PropTypes.array,
   hoveredDetourId: PropTypes.string,
+  mapTypeControl: PropTypes.bool,
   detourList: PropTypes.array,
   onDetourHover: PropTypes.func,
   setDetourHighlight: PropTypes.func,
+  zoomControl: PropTypes.bool,
 };
 
 MapBounds.propTypes = {

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -117,12 +117,6 @@ function SelectableMapMarker({
         position={feature.position}
         title={feature.accessibleName}
         onClick={() => onSelect(feature.id)}
-        onKeyDown={(event) => {
-          if (event.key === "Escape" && showDetails === "selected") {
-            onHover(null);
-            onClose(feature.id, "selected");
-          }
-        }}
         onMouseEnter={() => onHover(feature.id)}
         onMouseLeave={() => onHover(null)}
         zIndex={active ? zIndex + 10 : zIndex}
@@ -402,6 +396,20 @@ function MapContainer(props) {
       setHoveredFeatureId(null);
     }
   }, [hoveredFeatureId, visibleFeatureIdsKey]);
+
+  useEffect(() => {
+    if (!selectedFeatureId) return undefined;
+
+    const dismissSelectedFeature = (event) => {
+      if (event.key !== "Escape") return;
+      setHoveredFeatureId(null);
+      setSelectedFeatureId(null);
+    };
+
+    document.addEventListener("keydown", dismissSelectedFeature);
+    return () =>
+      document.removeEventListener("keydown", dismissSelectedFeature);
+  }, [selectedFeatureId]);
 
   const closeFeatureDetails = (featureId, detailsMode) => {
     if (

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import { Text } from "@fluentui/react-components";
 //import { Map, Circle , Polyline, Marker, GoogleApiWrapper } from 'google-maps-react';
 import {
   AdvancedMarker,
   APIProvider,
+  InfoWindow,
   Map,
   Pin,
   useMap,
@@ -33,6 +35,7 @@ const WORLD_BOUNDS = {
 };
 
 const MIN_ZOOM = 4;
+const MARKER_DETAILS_OFFSET = [0, -46];
 
 function normalizeCoordinates(location) {
   if (!Number.isFinite(location?.lat) || !Number.isFinite(location?.lng)) {
@@ -67,20 +70,94 @@ function getRouteEndpoints(route, origin, destination) {
   };
 }
 
-function RouteEndpointMarker({ position, title, type }) {
-  if (!position) return null;
+function formatAddedTime(addedTime) {
+  if (!Number.isFinite(addedTime) || addedTime < 0) return null;
 
+  const hours = Math.floor(addedTime / 60);
+  const minutes = addedTime % 60;
+  return `${hours ? `${hours} hr ` : ""}${minutes} min added`;
+}
+
+function MarkerDetails({ feature }) {
   return (
-    <AdvancedMarker position={position} title={title} zIndex={0}>
-      <Pin
-        scale={1.1}
-        background={jauntColors.map.endpoint}
-        borderColor={jauntColors.neutral.foregroundOnDark}
-        glyphColor={jauntColors.neutral.foregroundOnDark}
+    <div
+      style={{
+        display: "grid",
+        width: "12rem",
+        maxWidth: "100%",
+        minWidth: 0,
+        rowGap: "0.25rem",
+        color: jauntColors.neutral.foreground,
+      }}
+    >
+      {feature.address ? <Text size={200}>{feature.address}</Text> : null}
+      {feature.category ? <Text size={200}>{feature.category}</Text> : null}
+      {feature.rating ? <Text size={200}>{feature.rating} rating</Text> : null}
+      {feature.addedTimeText ? (
+        <Text size={200}>{feature.addedTimeText}</Text>
+      ) : null}
+    </div>
+  );
+}
+
+function SelectableMapMarker({
+  active,
+  background,
+  feature,
+  iconType,
+  onClose,
+  onHover,
+  onSelect,
+  showDetails,
+  zIndex,
+}) {
+  return (
+    <>
+      <AdvancedMarker
+        position={feature.position}
+        title={feature.accessibleName}
+        onClick={() => onSelect(feature.id)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && showDetails === "selected") {
+            onHover(null);
+            onClose(feature.id, "selected");
+          }
+        }}
+        onMouseEnter={() => onHover(feature.id)}
+        onMouseLeave={() => onHover(null)}
+        zIndex={active ? zIndex + 10 : zIndex}
       >
-        {getDetourIconComponent(type, "1.125rem")}
-      </Pin>
-    </AdvancedMarker>
+        <Pin
+          scale={active ? 1.25 : 1.1}
+          background={background}
+          borderColor={jauntColors.neutral.foregroundOnDark}
+          glyphColor={jauntColors.neutral.foregroundOnDark}
+        >
+          {getDetourIconComponent(iconType, "1.125rem")}
+        </Pin>
+      </AdvancedMarker>
+      {showDetails ? (
+        <InfoWindow
+          ariaLabel={`${feature.heading} details`}
+          disableAutoPan
+          headerContent={
+            <Text
+              style={{ display: "block", transform: "translateY(-0.3125rem)" }}
+              weight="semibold"
+            >
+              {feature.heading}
+            </Text>
+          }
+          maxWidth={280}
+          onClose={() => onClose(feature.id, showDetails)}
+          pixelOffset={MARKER_DETAILS_OFFSET}
+          position={feature.position}
+          shouldFocus={false}
+        >
+          <MarkerDetails feature={feature} />
+        </InfoWindow>
+      ) : null}
+    </>
   );
 }
 
@@ -247,6 +324,8 @@ function DetourCircle({
 // Main MapContainer component - TEST CHANGE
 function MapContainer(props) {
   const mapRef = useRef(null);
+  const [selectedFeatureId, setSelectedFeatureId] = useState(null);
+  const [hoveredFeatureId, setHoveredFeatureId] = useState(null);
   const routeEndpoints = getRouteEndpoints(
     props.route,
     props.origin,
@@ -257,6 +336,76 @@ function MapContainer(props) {
     props.showDetourSearchPoint && props.showRoute
       ? getRoutePoint(props.route, props.detourSearchLocation)
       : null;
+
+  const legs = Array.isArray(props.route?.legs) ? props.route.legs : [];
+  const firstLeg = legs[0];
+  const lastLeg = legs[legs.length - 1];
+  const endpointFeatures = {
+    start: routeEndpoints.start
+      ? {
+          id: "start",
+          accessibleName: "Jaunt start",
+          heading: "Start",
+          address: firstLeg?.start_address || props.origin?.address,
+          position: routeEndpoints.start,
+        }
+      : null,
+    destination: routeEndpoints.destination
+      ? {
+          id: "destination",
+          accessibleName: "Jaunt destination",
+          heading: "Destination",
+          address: lastLeg?.end_address || props.destination?.address,
+          position: routeEndpoints.destination,
+        }
+      : null,
+  };
+  const addedDetourFeatures = (props.detourList || []).map((detour, index) => ({
+    id: `detour-${detour.placeId || detour.id || index}`,
+    accessibleName: `${detour.name}, added stop`,
+    heading: detour.name,
+    category: detour.type,
+    rating: detour.rating,
+    addedTimeText: formatAddedTime(detour.addedTime),
+    position: { lat: detour.lat, lng: detour.lng },
+  }));
+  const visibleFeatureIds = [
+    ...(props.showRoute && endpointFeatures.start ? ["start"] : []),
+    ...(props.showRoute && endpointFeatures.destination ? ["destination"] : []),
+    ...addedDetourFeatures.map((feature) => feature.id),
+  ];
+  const visibleFeatureIdsKey = visibleFeatureIds.join("|");
+  const detailsFeatureId = hoveredFeatureId || selectedFeatureId;
+  const detailsFeatureIdRef = useRef(detailsFeatureId);
+  detailsFeatureIdRef.current = detailsFeatureId;
+
+  useEffect(() => {
+    if (
+      selectedFeatureId &&
+      !visibleFeatureIdsKey.split("|").includes(selectedFeatureId)
+    ) {
+      setSelectedFeatureId(null);
+    }
+  }, [selectedFeatureId, visibleFeatureIdsKey]);
+
+  useEffect(() => {
+    if (
+      hoveredFeatureId &&
+      !visibleFeatureIdsKey.split("|").includes(hoveredFeatureId)
+    ) {
+      setHoveredFeatureId(null);
+    }
+  }, [hoveredFeatureId, visibleFeatureIdsKey]);
+
+  const closeFeatureDetails = (featureId, detailsMode) => {
+    if (detailsFeatureIdRef.current !== featureId) return;
+    if (detailsMode === "selected" && selectedFeatureId === featureId) {
+      setSelectedFeatureId(null);
+    }
+    if (detailsMode === "hovered" && hoveredFeatureId === featureId) {
+      setHoveredFeatureId(null);
+    }
+  };
 
   const selectDetourOption = (placeId) => {
     props.setDetourHighlight?.(
@@ -269,141 +418,188 @@ function MapContainer(props) {
 
   return (
     <APIProvider apiKey={config.GOOGLE_API_KEY}>
-      <Map
-        ref={mapRef}
-        defaultBounds={CONTIGUOUS_US_BOUNDS}
-        minZoom={MIN_ZOOM}
-        restriction={{
-          latLngBounds: WORLD_BOUNDS,
-          strictBounds: true,
-        }}
-        style={{
-          width: "100%",
-          height: "100%",
-        }}
-        fullscreenControl={false}
-        mapId="DEMO_MAP_ID"
-        streetViewControl={false}
-      >
-        <MapResizeObserver />
+      <div className="jaunt-map" style={{ width: "100%", height: "100%" }}>
+        <Map
+          ref={mapRef}
+          defaultBounds={CONTIGUOUS_US_BOUNDS}
+          minZoom={MIN_ZOOM}
+          restriction={{
+            latLngBounds: WORLD_BOUNDS,
+            strictBounds: true,
+          }}
+          style={{
+            width: "100%",
+            height: "100%",
+          }}
+          fullscreenControl={false}
+          mapId="DEMO_MAP_ID"
+          onClick={() => {
+            setHoveredFeatureId(null);
+            setSelectedFeatureId(null);
+          }}
+          streetViewControl={false}
+        >
+          <MapResizeObserver />
 
-        {/* Map bounds adjustment - only fits bounds on new route */}
-        <MapBounds route={props.route} />
+          {/* Map bounds adjustment - only fits bounds on new route */}
+          <MapBounds route={props.route} />
 
-        {/* Route polyline */}
-        <RoutePolyline route={props.route} showRoute={props.showRoute} />
+          {/* Route polyline */}
+          <RoutePolyline route={props.route} showRoute={props.showRoute} />
 
-        {props.showRoute && (
-          <>
-            <RouteEndpointMarker
-              position={routeEndpoints.start}
-              title="Jaunt start"
-              type="origin"
-            />
-            <RouteEndpointMarker
-              position={routeEndpoints.destination}
-              title="Jaunt destination"
-              type="destination"
-            />
-          </>
-        )}
-
-        {/* Detour search point marker */}
-        {props.showDetourSearchPoint && detourPoint && (
-          <AdvancedMarker position={detourPoint}>
-            <Pin
-              scale={0.75}
-              background={jauntColors.map.searchArea}
-              borderColor={jauntColors.map.endpoint}
-              glyphColor={jauntColors.neutral.foregroundOnDark}
-            />
-          </AdvancedMarker>
-        )}
-
-        {/* Detour search circle */}
-        <DetourCircle
-          detourPoint={detourPoint}
-          detourSearchRadius={props.detourSearchRadius}
-          showDetourSearchPoint={props.showDetourSearchPoint}
-        />
-
-        {/* Detour options markers */}
-        {props.detourOptions?.length > 0 &&
-          getVisibleDetourOptions(props.detourOptions, props.detourList).map(
-            ({ option: detour, index }) => {
-              // Check if this detour should be highlighted
-              const highlight = props.detourHighlight?.some(
-                (detourHighlight) =>
-                  detourHighlight.id === detour.place_id &&
-                  detourHighlight.highlight
-              );
-              const hovered = props.hoveredDetourId === detour.place_id;
-
-              return (
-                <AdvancedMarker
-                  key={`detour-option-${detour.place_id || index}`}
-                  title={`${index + 1}. ${detour.name}`}
-                  onClick={() => selectDetourOption(detour.place_id)}
-                  onMouseEnter={() => props.onDetourHover?.(detour.place_id)}
-                  onMouseLeave={() => props.onDetourHover?.(null)}
-                  position={{
-                    lat: detour.geometry.location.lat,
-                    lng: detour.geometry.location.lng,
-                  }}
-                  zIndex={highlight ? 3 : hovered ? 2 : 1}
-                >
-                  <Pin
-                    scale={highlight ? 1 : 0.85}
-                    background={
-                      highlight
-                        ? jauntColors.map.selected
-                        : hovered
-                          ? jauntColors.brand.accent
-                          : jauntColors.map.result
-                    }
-                    glyphColor={
-                      highlight
-                        ? jauntColors.neutral.foregroundOnDark
-                        : jauntColors.map.endpoint
-                    }
-                    borderColor={jauntColors.map.endpoint}
-                    glyphText={`${index + 1}`}
-                  />
-                </AdvancedMarker>
-              );
-            }
+          {props.showRoute && (
+            <>
+              {endpointFeatures.start ? (
+                <SelectableMapMarker
+                  active={
+                    selectedFeatureId === "start" ||
+                    hoveredFeatureId === "start"
+                  }
+                  background={jauntColors.map.endpoint}
+                  feature={endpointFeatures.start}
+                  iconType="origin"
+                  onClose={closeFeatureDetails}
+                  onHover={setHoveredFeatureId}
+                  onSelect={setSelectedFeatureId}
+                  showDetails={
+                    detailsFeatureId === "start"
+                      ? selectedFeatureId === "start"
+                        ? "selected"
+                        : "hovered"
+                      : null
+                  }
+                  zIndex={0}
+                />
+              ) : null}
+              {endpointFeatures.destination ? (
+                <SelectableMapMarker
+                  active={
+                    selectedFeatureId === "destination" ||
+                    hoveredFeatureId === "destination"
+                  }
+                  background={jauntColors.map.endpoint}
+                  feature={endpointFeatures.destination}
+                  iconType="destination"
+                  onClose={closeFeatureDetails}
+                  onHover={setHoveredFeatureId}
+                  onSelect={setSelectedFeatureId}
+                  showDetails={
+                    detailsFeatureId === "destination"
+                      ? selectedFeatureId === "destination"
+                        ? "selected"
+                        : "hovered"
+                      : null
+                  }
+                  zIndex={0}
+                />
+              ) : null}
+            </>
           )}
 
-        {/* Detour list markers */}
-        {props.detourList?.length > 0 &&
-          props.detourList.map((detour, index) => (
-            <AdvancedMarker
-              key={`detour-${detour.placeId || detour.id || index}`}
-              title={`${detour.name}, added stop`}
-              position={{ lat: detour.lat, lng: detour.lng }}
-              zIndex={1}
-            >
+          {/* Detour search point marker */}
+          {props.showDetourSearchPoint && detourPoint && (
+            <AdvancedMarker position={detourPoint}>
               <Pin
-                scale={1.1}
-                background={jauntColors.map.stop}
-                borderColor={jauntColors.neutral.foregroundOnDark}
+                scale={0.75}
+                background={jauntColors.map.searchArea}
+                borderColor={jauntColors.map.endpoint}
                 glyphColor={jauntColors.neutral.foregroundOnDark}
-              >
-                {getDetourIconComponent(detour.type, "1.125rem")}
-              </Pin>
+              />
             </AdvancedMarker>
+          )}
+
+          {/* Detour search circle */}
+          <DetourCircle
+            detourPoint={detourPoint}
+            detourSearchRadius={props.detourSearchRadius}
+            showDetourSearchPoint={props.showDetourSearchPoint}
+          />
+
+          {/* Detour options markers */}
+          {props.detourOptions?.length > 0 &&
+            getVisibleDetourOptions(props.detourOptions, props.detourList).map(
+              ({ option: detour, index }) => {
+                // Check if this detour should be highlighted
+                const highlight = props.detourHighlight?.some(
+                  (detourHighlight) =>
+                    detourHighlight.id === detour.place_id &&
+                    detourHighlight.highlight
+                );
+                const hovered = props.hoveredDetourId === detour.place_id;
+
+                return (
+                  <AdvancedMarker
+                    key={`detour-option-${detour.place_id || index}`}
+                    title={`${index + 1}. ${detour.name}`}
+                    onClick={() => selectDetourOption(detour.place_id)}
+                    onMouseEnter={() => props.onDetourHover?.(detour.place_id)}
+                    onMouseLeave={() => props.onDetourHover?.(null)}
+                    position={{
+                      lat: detour.geometry.location.lat,
+                      lng: detour.geometry.location.lng,
+                    }}
+                    zIndex={highlight ? 3 : hovered ? 2 : 1}
+                  >
+                    <Pin
+                      scale={highlight ? 1 : 0.85}
+                      background={
+                        highlight
+                          ? jauntColors.map.selected
+                          : hovered
+                            ? jauntColors.brand.accent
+                            : jauntColors.map.result
+                      }
+                      glyphColor={
+                        highlight
+                          ? jauntColors.neutral.foregroundOnDark
+                          : jauntColors.map.endpoint
+                      }
+                      borderColor={jauntColors.map.endpoint}
+                      glyphText={`${index + 1}`}
+                    />
+                  </AdvancedMarker>
+                );
+              }
+            )}
+
+          {/* Detour list markers */}
+          {addedDetourFeatures.map((feature) => (
+            <SelectableMapMarker
+              key={feature.id}
+              active={
+                selectedFeatureId === feature.id ||
+                hoveredFeatureId === feature.id
+              }
+              background={jauntColors.map.stop}
+              feature={feature}
+              iconType={feature.category}
+              onClose={closeFeatureDetails}
+              onHover={setHoveredFeatureId}
+              onSelect={setSelectedFeatureId}
+              showDetails={
+                detailsFeatureId === feature.id
+                  ? selectedFeatureId === feature.id
+                    ? "selected"
+                    : "hovered"
+                  : null
+              }
+              zIndex={1}
+            />
           ))}
-      </Map>
+        </Map>
+      </div>
     </APIProvider>
   );
 }
 
 MapContainer.propTypes = {
   origin: PropTypes.shape({
+    address: PropTypes.string,
     lat: PropTypes.number,
     lng: PropTypes.number,
   }),
   destination: PropTypes.shape({
+    address: PropTypes.string,
     lat: PropTypes.number,
     lng: PropTypes.number,
   }),
@@ -435,13 +631,20 @@ DetourCircle.propTypes = {
   showDetourSearchPoint: PropTypes.bool,
 };
 
-RouteEndpointMarker.propTypes = {
-  position: PropTypes.shape({
-    lat: PropTypes.number.isRequired,
-    lng: PropTypes.number.isRequired,
-  }),
-  title: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(["origin", "destination"]).isRequired,
+MarkerDetails.propTypes = {
+  feature: PropTypes.object.isRequired,
+};
+
+SelectableMapMarker.propTypes = {
+  active: PropTypes.bool.isRequired,
+  background: PropTypes.string.isRequired,
+  feature: PropTypes.object.isRequired,
+  iconType: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onHover: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  showDetails: PropTypes.oneOf(["selected", "hovered"]),
+  zIndex: PropTypes.number.isRequired,
 };
 
 export default MapContainer;

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -139,6 +139,11 @@ function SelectableMapMarker({
       {showDetails ? (
         <InfoWindow
           ariaLabel={`${feature.heading} details`}
+          className={
+            showDetails === "hovered"
+              ? "jaunt-marker-details--hovered"
+              : "jaunt-marker-details--selected"
+          }
           disableAutoPan
           headerContent={
             <Text

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -75,7 +75,7 @@ function formatAddedTime(addedTime) {
 
   const hours = Math.floor(addedTime / 60);
   const minutes = addedTime % 60;
-  return `${hours ? `${hours} hr ` : ""}${minutes} min added`;
+  return `+ ${hours ? `${hours} hr ` : ""}${minutes} min`;
 }
 
 function MarkerDetails({ feature }) {
@@ -139,6 +139,11 @@ function SelectableMapMarker({
       {showDetails ? (
         <InfoWindow
           ariaLabel={`${feature.heading} details`}
+          className={
+            showDetails === "hovered"
+              ? "jaunt-marker-details--hovered"
+              : "jaunt-marker-details--selected"
+          }
           disableAutoPan
           headerContent={
             <Text
@@ -326,6 +331,10 @@ function MapContainer(props) {
   const mapRef = useRef(null);
   const [selectedFeatureId, setSelectedFeatureId] = useState(null);
   const [hoveredFeatureId, setHoveredFeatureId] = useState(null);
+  const selectedFeatureIdRef = useRef(selectedFeatureId);
+  const hoveredFeatureIdRef = useRef(hoveredFeatureId);
+  selectedFeatureIdRef.current = selectedFeatureId;
+  hoveredFeatureIdRef.current = hoveredFeatureId;
   const routeEndpoints = getRouteEndpoints(
     props.route,
     props.origin,
@@ -375,9 +384,6 @@ function MapContainer(props) {
     ...addedDetourFeatures.map((feature) => feature.id),
   ];
   const visibleFeatureIdsKey = visibleFeatureIds.join("|");
-  const detailsFeatureId = hoveredFeatureId || selectedFeatureId;
-  const detailsFeatureIdRef = useRef(detailsFeatureId);
-  detailsFeatureIdRef.current = detailsFeatureId;
 
   useEffect(() => {
     if (
@@ -398,11 +404,16 @@ function MapContainer(props) {
   }, [hoveredFeatureId, visibleFeatureIdsKey]);
 
   const closeFeatureDetails = (featureId, detailsMode) => {
-    if (detailsFeatureIdRef.current !== featureId) return;
-    if (detailsMode === "selected" && selectedFeatureId === featureId) {
+    if (
+      detailsMode === "selected" &&
+      selectedFeatureIdRef.current === featureId
+    ) {
       setSelectedFeatureId(null);
     }
-    if (detailsMode === "hovered" && hoveredFeatureId === featureId) {
+    if (
+      detailsMode === "hovered" &&
+      hoveredFeatureIdRef.current === featureId
+    ) {
       setHoveredFeatureId(null);
     }
   };
@@ -462,11 +473,11 @@ function MapContainer(props) {
                   onHover={setHoveredFeatureId}
                   onSelect={setSelectedFeatureId}
                   showDetails={
-                    detailsFeatureId === "start"
-                      ? selectedFeatureId === "start"
-                        ? "selected"
-                        : "hovered"
-                      : null
+                    selectedFeatureId === "start"
+                      ? "selected"
+                      : hoveredFeatureId === "start"
+                        ? "hovered"
+                        : null
                   }
                   zIndex={0}
                 />
@@ -484,11 +495,11 @@ function MapContainer(props) {
                   onHover={setHoveredFeatureId}
                   onSelect={setSelectedFeatureId}
                   showDetails={
-                    detailsFeatureId === "destination"
-                      ? selectedFeatureId === "destination"
-                        ? "selected"
-                        : "hovered"
-                      : null
+                    selectedFeatureId === "destination"
+                      ? "selected"
+                      : hoveredFeatureId === "destination"
+                        ? "hovered"
+                        : null
                   }
                   zIndex={0}
                 />
@@ -577,11 +588,11 @@ function MapContainer(props) {
               onHover={setHoveredFeatureId}
               onSelect={setSelectedFeatureId}
               showDetails={
-                detailsFeatureId === feature.id
-                  ? selectedFeatureId === feature.id
-                    ? "selected"
-                    : "hovered"
-                  : null
+                selectedFeatureId === feature.id
+                  ? "selected"
+                  : hoveredFeatureId === feature.id
+                    ? "hovered"
+                    : null
               }
               zIndex={1}
             />

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -300,7 +300,7 @@ describe("MapContainer", () => {
     ).toHaveTextContent("Charlotte, NC");
 
     fireEvent.mouseEnter(destinationMarker);
-    fireEvent.keyDown(destinationMarker, { key: "Escape" });
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(
       screen.queryByRole("dialog", { name: "Destination details" })
     ).not.toBeInTheDocument();

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -13,12 +13,18 @@ jest.mock("@vis.gl/react-google-maps", () => {
   function MockInfoWindow({
     ariaLabel,
     children,
+    className,
     headerContent,
     onClose,
     pixelOffset,
     shouldFocus,
   }) {
-    mockInfoWindowProps({ ariaLabel, pixelOffset, shouldFocus });
+    mockInfoWindowProps({
+      ariaLabel,
+      className,
+      pixelOffset,
+      shouldFocus,
+    });
     const onCloseRef = React.useRef(onClose);
     onCloseRef.current = onClose;
     React.useEffect(() => () => onCloseRef.current(), []);
@@ -31,7 +37,9 @@ jest.mock("@vis.gl/react-google-maps", () => {
       >
         <header>{headerContent}</header>
         {children}
-        <button onClick={onClose}>Close details</button>
+        {className === "jaunt-marker-details--hovered" ? null : (
+          <button onClick={onClose}>Close details</button>
+        )}
       </section>
     );
   }
@@ -235,8 +243,14 @@ describe("MapContainer", () => {
       screen.getByRole("dialog", { name: "Start details" })
     ).toHaveAttribute("data-should-focus", "false");
     expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pixelOffset: [0, -46] })
+      expect.objectContaining({
+        className: "jaunt-marker-details--hovered",
+        pixelOffset: [0, -46],
+      })
     );
+    expect(
+      screen.queryByRole("button", { name: "Close details" })
+    ).not.toBeInTheDocument();
     expect(
       mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
     ).toBe(true);
@@ -252,18 +266,30 @@ describe("MapContainer", () => {
     expect(
       screen.getByRole("dialog", { name: "Start details" })
     ).toHaveTextContent("Atlanta, GA");
+    expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        className: "jaunt-marker-details--selected",
+      })
+    );
+    expect(
+      screen.getByRole("button", { name: "Close details" })
+    ).toBeInTheDocument();
 
     fireEvent.mouseEnter(destinationMarker);
     expect(
-      screen.queryByRole("dialog", { name: "Start details" })
-    ).not.toBeInTheDocument();
+      screen.getByRole("dialog", { name: "Start details" })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("dialog", { name: "Destination details" })
     ).toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
     fireEvent.mouseLeave(destinationMarker);
     expect(
       screen.getByRole("dialog", { name: "Start details" })
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Destination details" })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(destinationMarker);
     expect(
@@ -471,7 +497,10 @@ describe("MapContainer", () => {
       screen.getByRole("dialog", { name: "Paris Mountain details" })
     ).toHaveAttribute("data-should-focus", "false");
     expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pixelOffset: [0, -46] })
+      expect.objectContaining({
+        className: "jaunt-marker-details--hovered",
+        pixelOffset: [0, -46],
+      })
     );
     fireEvent.mouseLeave(detourMarker);
     expect(
@@ -485,7 +514,7 @@ describe("MapContainer", () => {
     expect(screen.getByText("Paris Mountain")).toBeInTheDocument();
     expect(details).toHaveTextContent("Hike");
     expect(details).toHaveTextContent("4.7 rating");
-    expect(details).toHaveTextContent("18 min added");
+    expect(details).toHaveTextContent("+ 18 min");
     fireEvent.click(screen.getByRole("button", { name: "Close details" }));
     expect(details).not.toBeInTheDocument();
 

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -13,12 +13,18 @@ jest.mock("@vis.gl/react-google-maps", () => {
   function MockInfoWindow({
     ariaLabel,
     children,
+    className,
     headerContent,
     onClose,
     pixelOffset,
     shouldFocus,
   }) {
-    mockInfoWindowProps({ ariaLabel, pixelOffset, shouldFocus });
+    mockInfoWindowProps({
+      ariaLabel,
+      className,
+      pixelOffset,
+      shouldFocus,
+    });
     const onCloseRef = React.useRef(onClose);
     onCloseRef.current = onClose;
     React.useEffect(() => () => onCloseRef.current(), []);
@@ -31,7 +37,9 @@ jest.mock("@vis.gl/react-google-maps", () => {
       >
         <header>{headerContent}</header>
         {children}
-        <button onClick={onClose}>Close details</button>
+        {className === "jaunt-marker-details--hovered" ? null : (
+          <button onClick={onClose}>Close details</button>
+        )}
       </section>
     );
   }
@@ -235,8 +243,14 @@ describe("MapContainer", () => {
       screen.getByRole("dialog", { name: "Start details" })
     ).toHaveAttribute("data-should-focus", "false");
     expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pixelOffset: [0, -46] })
+      expect.objectContaining({
+        className: "jaunt-marker-details--hovered",
+        pixelOffset: [0, -46],
+      })
     );
+    expect(
+      screen.queryByRole("button", { name: "Close details" })
+    ).not.toBeInTheDocument();
     expect(
       mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
     ).toBe(true);
@@ -252,6 +266,14 @@ describe("MapContainer", () => {
     expect(
       screen.getByRole("dialog", { name: "Start details" })
     ).toHaveTextContent("Atlanta, GA");
+    expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        className: "jaunt-marker-details--selected",
+      })
+    );
+    expect(
+      screen.getByRole("button", { name: "Close details" })
+    ).toBeInTheDocument();
 
     fireEvent.mouseEnter(destinationMarker);
     expect(
@@ -471,7 +493,10 @@ describe("MapContainer", () => {
       screen.getByRole("dialog", { name: "Paris Mountain details" })
     ).toHaveAttribute("data-should-focus", "false");
     expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pixelOffset: [0, -46] })
+      expect.objectContaining({
+        className: "jaunt-marker-details--hovered",
+        pixelOffset: [0, -46],
+      })
     );
     fireEvent.mouseLeave(detourMarker);
     expect(

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -119,6 +119,7 @@ describe("MapContainer", () => {
 
     expect(mockMapProps).toHaveBeenCalledWith(
       expect.objectContaining({
+        cameraControl: true,
         defaultBounds: {
           north: 49.384358,
           south: 24.396308,
@@ -126,6 +127,7 @@ describe("MapContainer", () => {
           west: -124.848974,
           padding: 24,
         },
+        mapTypeControl: true,
         minZoom: 4,
         restriction: {
           latLngBounds: {
@@ -136,6 +138,7 @@ describe("MapContainer", () => {
           },
           strictBounds: true,
         },
+        zoomControl: true,
       })
     );
   });

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -3,32 +3,72 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import MapContainer from "./MapContainer";
 
 const mockMapProps = jest.fn();
+const mockInfoWindowProps = jest.fn();
 const mockPinProps = jest.fn();
 const mockUseMap = jest.fn();
 
 jest.mock("@vis.gl/react-google-maps", () => {
   const React = require("react");
 
-  return {
-    AdvancedMarker: ({
-      children,
-      onClick,
-      onMouseEnter,
-      onMouseLeave,
-      position,
-      title,
-    }) => (
-      <div
-        data-testid={title ? `marker-${title}` : undefined}
-        data-position={position ? `${position.lat},${position.lng}` : undefined}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
+  function MockInfoWindow({
+    ariaLabel,
+    children,
+    headerContent,
+    onClose,
+    pixelOffset,
+    shouldFocus,
+  }) {
+    mockInfoWindowProps({ ariaLabel, pixelOffset, shouldFocus });
+    const onCloseRef = React.useRef(onClose);
+    onCloseRef.current = onClose;
+    React.useEffect(() => () => onCloseRef.current(), []);
+
+    return (
+      <section
+        aria-label={ariaLabel}
+        data-should-focus={`${shouldFocus}`}
+        role="dialog"
       >
+        <header>{headerContent}</header>
         {children}
-      </div>
-    ),
+        <button onClick={onClose}>Close details</button>
+      </section>
+    );
+  }
+
+  return {
+    AdvancedMarker: React.forwardRef(function MockAdvancedMarker(
+      {
+        children,
+        onClick,
+        onKeyDown,
+        onMouseEnter,
+        onMouseLeave,
+        position,
+        title,
+      },
+      ref
+    ) {
+      React.useImperativeHandle(ref, () => ({ title }), [title]);
+      return (
+        <div
+          aria-label={title || undefined}
+          data-testid={title ? `marker-${title}` : undefined}
+          data-position={
+            position ? `${position.lat},${position.lng}` : undefined
+          }
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          role={title ? "button" : undefined}
+        >
+          {children}
+        </div>
+      );
+    }),
     APIProvider: ({ children }) => <>{children}</>,
+    InfoWindow: MockInfoWindow,
     Map: React.forwardRef(function MockMap({ children, ...props }, ref) {
       mockMapProps(props);
       return <div ref={ref}>{children}</div>;
@@ -61,6 +101,7 @@ function createProps(overrides = {}) {
 describe("MapContainer", () => {
   beforeEach(() => {
     mockMapProps.mockClear();
+    mockInfoWindowProps.mockClear();
     mockPinProps.mockClear();
     mockUseMap.mockReturnValue(null);
   });
@@ -142,10 +183,12 @@ describe("MapContainer", () => {
           route: {
             legs: [
               {
+                start_address: "Atlanta, GA",
                 start_location: { lat: 0, lng: -84.388 },
                 end_location: { lat: 34.9, lng: -82.4 },
               },
               {
+                end_address: "Charlotte, NC",
                 start_location: { lat: 34.9, lng: -82.4 },
                 end_location: { lat: 35.2271, lng: 0 },
               },
@@ -181,6 +224,66 @@ describe("MapContainer", () => {
         scale: 1.1,
       })
     );
+
+    const startMarker = screen.getByRole("button", { name: "Jaunt start" });
+    const destinationMarker = screen.getByRole("button", {
+      name: "Jaunt destination",
+    });
+
+    fireEvent.mouseEnter(startMarker);
+    expect(
+      screen.getByRole("dialog", { name: "Start details" })
+    ).toHaveAttribute("data-should-focus", "false");
+    expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pixelOffset: [0, -46] })
+    );
+    expect(
+      mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
+    ).toBe(true);
+    fireEvent.mouseLeave(startMarker);
+    expect(
+      screen.queryByRole("dialog", { name: "Start details" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(startMarker);
+    expect(
+      mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
+    ).toBe(true);
+    expect(
+      screen.getByRole("dialog", { name: "Start details" })
+    ).toHaveTextContent("Atlanta, GA");
+
+    fireEvent.mouseEnter(destinationMarker);
+    expect(
+      screen.queryByRole("dialog", { name: "Start details" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Destination details" })
+    ).toBeInTheDocument();
+    fireEvent.mouseLeave(destinationMarker);
+    expect(
+      screen.getByRole("dialog", { name: "Start details" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(destinationMarker);
+    expect(
+      screen.queryByRole("dialog", { name: "Start details" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Destination details" })
+    ).toHaveTextContent("Charlotte, NC");
+
+    fireEvent.mouseEnter(destinationMarker);
+    fireEvent.keyDown(destinationMarker, { key: "Escape" });
+    expect(
+      screen.queryByRole("dialog", { name: "Destination details" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(destinationMarker);
+    act(() => mockMapProps.mock.lastCall[0].onClick());
+    expect(
+      screen.queryByRole("dialog", { name: "Destination details" })
+    ).not.toBeInTheDocument();
   });
 
   test("falls back to persisted endpoints when saved routes have no legs", () => {
@@ -333,21 +436,20 @@ describe("MapContainer", () => {
   });
 
   test("anchors added detours with category icons in stop-colored pins", () => {
-    render(
-      <MapContainer
-        {...createProps({
-          detourList: [
-            {
-              name: "Paris Mountain",
-              placeId: "place-1",
-              type: "Hike",
-              lat: 34.9,
-              lng: -82.4,
-            },
-          ],
-        })}
-      />
-    );
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          rating: 4.7,
+          addedTime: 18,
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+    });
+    const { rerender } = render(<MapContainer {...props} />);
 
     expect(
       screen.getByTestId("marker-Paris Mountain, added stop")
@@ -360,6 +462,38 @@ describe("MapContainer", () => {
         scale: 1.1,
       })
     );
+
+    const detourMarker = screen.getByRole("button", {
+      name: "Paris Mountain, added stop",
+    });
+    fireEvent.mouseEnter(detourMarker);
+    expect(
+      screen.getByRole("dialog", { name: "Paris Mountain details" })
+    ).toHaveAttribute("data-should-focus", "false");
+    expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pixelOffset: [0, -46] })
+    );
+    fireEvent.mouseLeave(detourMarker);
+    expect(
+      screen.queryByRole("dialog", { name: "Paris Mountain details" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(detourMarker);
+    const details = screen.getByRole("dialog", {
+      name: "Paris Mountain details",
+    });
+    expect(screen.getByText("Paris Mountain")).toBeInTheDocument();
+    expect(details).toHaveTextContent("Hike");
+    expect(details).toHaveTextContent("4.7 rating");
+    expect(details).toHaveTextContent("18 min added");
+    fireEvent.click(screen.getByRole("button", { name: "Close details" }));
+    expect(details).not.toBeInTheDocument();
+
+    fireEvent.click(detourMarker);
+    rerender(<MapContainer {...props} detourList={[]} />);
+    expect(
+      screen.queryByRole("dialog", { name: "Paris Mountain details" })
+    ).not.toBeInTheDocument();
   });
 
   test("previews a detour marker on hover without selecting it", () => {

--- a/frontend/src/components/planner/PlannerWorkspace.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.jsx
@@ -541,7 +541,9 @@ export default function PlannerWorkspace(props) {
           origin={props.currentTrip?.origin}
           destination={props.currentTrip?.destination}
           showRoute={props.showRoute}
-          showDetourSearchPoint={props.showDetourSearchPoint}
+          showDetourSearchPoint={
+            selectedTask === "discover" && props.showDetourSearchPoint
+          }
           detourSearchLocation={props.detourSearchLocation}
           detourSearchRadius={props.detourSearchRadius}
           detourOptions={props.detourOptions}

--- a/frontend/src/components/planner/PlannerWorkspace.test.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.test.jsx
@@ -214,6 +214,26 @@ describe("PlannerWorkspace", () => {
     expect(screen.getByText("Not saved")).toBeVisible();
   });
 
+  it("shows the detour search area only while Discover is active", () => {
+    renderWorkspace(
+      createProps({
+        showDetourButton: true,
+        showDetourSearchPoint: true,
+      })
+    );
+
+    expect(mockMapProps.mock.lastCall[0].showDetourSearchPoint).toBe(false);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Discover" }));
+    expect(mockMapProps.mock.lastCall[0].showDetourSearchPoint).toBe(true);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Export" }));
+    expect(mockMapProps.mock.lastCall[0].showDetourSearchPoint).toBe(false);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Build" }));
+    expect(mockMapProps.mock.lastCall[0].showDetourSearchPoint).toBe(false);
+  });
+
   it("synchronizes detour hover and clears it when results change", () => {
     const props = createProps({
       detourOptions: [{ place_id: "place-1" }],

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,3 +23,11 @@ code {
 .jaunt-map .gm-style-iw-tc {
   display: none;
 }
+
+/* Keep preview and selected card geometry identical without a preview action. */
+.jaunt-map
+  .gm-style-iw:has(.jaunt-marker-details--hovered)
+  .gm-ui-hover-effect {
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,3 +18,8 @@ code {
   font-family:
     source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+
+/* Google Maps does not expose an InfoWindow tail visibility option. */
+.jaunt-map .gm-style-iw-tc {
+  display: none;
+}

--- a/frontend/src/pages/JauntDetailPage.jsx
+++ b/frontend/src/pages/JauntDetailPage.jsx
@@ -535,14 +535,17 @@ export default function JauntDetailPage() {
         <div className={styles.map} aria-label="Saved route preview">
           {route ? (
             <MapContainer
+              cameraControl={false}
               origin={trip.origin}
               destination={trip.destination}
               detourHighlight={[]}
               detourList={detours}
               detourOptions={[]}
+              mapTypeControl={false}
               route={route}
               showDetourSearchPoint={false}
               showRoute
+              zoomControl={false}
             />
           ) : (
             <div className={styles.state}>Map preview unavailable</div>

--- a/frontend/src/pages/SavedJauntsPages.test.jsx
+++ b/frontend/src/pages/SavedJauntsPages.test.jsx
@@ -247,8 +247,11 @@ describe("JauntDetailPage", () => {
     expect(screen.getByText("Saved route map")).toBeVisible();
     expect(mockMapProps).toHaveBeenCalledWith(
       expect.objectContaining({
+        cameraControl: false,
         origin: detailView.trip.origin,
         destination: detailView.trip.destination,
+        mapTypeControl: false,
+        zoomControl: false,
       })
     );
     expect(store.getState().origin).toBe("Current route");


### PR DESCRIPTION
## Summary

Adds interactive details cards to route endpoint and added-detour map pins.

- Shows transient details cards when hovering over Start, Destination, and added-stop pins.
- Keeps a selected pin’s card open until it is closed, another pin is selected, or the map background is clicked.
- Allows a selected card and a different hovered card to remain visible simultaneously.
- Shows the close control only on selected cards while preserving identical card dimensions and text wrapping.
- Supports keyboard marker activation and Escape dismissal while preserving marker focus.
- Displays detour time using compact copy such as `+ 18 min`.
- Shows the detour search marker and radius only while Discover is active.
- Simplifies saved Jaunt map previews by hiding Map/Satellite, Camera, and zoom controls.

## Implementation Details

- Uses the native Google Maps `InfoWindow` implementation.
- Keeps hover and selected marker state independent.
- Guards against stale Google Maps close events clearing newer interactions.
- Handles Escape dismissal at the document level because `AdvancedMarker` does not support React’s `onKeyDown` prop.
- Preserves endpoint coordinates from live routes and saved Jaunts.
- Keeps one responsive map component shared by planning and saved previews.
- Adds configurable map-type, camera, and zoom controls with planner-safe defaults.
- Applies narrowly scoped Google Maps compatibility styles for the InfoWindow tail and hover-only close control.

## Files Modified

- `frontend/e2e/foundation.spec.js`
- `frontend/src/components/MapContainer.jsx`
- `frontend/src/components/MapContainer.test.jsx`
- `frontend/src/components/planner/PlannerWorkspace.jsx`
- `frontend/src/components/planner/PlannerWorkspace.test.jsx`
- `frontend/src/index.css`
- `frontend/src/pages/JauntDetailPage.jsx`
- `frontend/src/pages/SavedJauntsPages.test.jsx`

## Testing

- `cd frontend && npm run lint`
- `cd frontend && CI=true npm test`
  - 30 suites passed
  - 210 tests passed
- `npm run build:frontend`
- `cd frontend && npx playwright test --list`
  - 12 scenarios discovered across desktop and compact Chromium
- `npx lint-staged`
- `git diff --check`

## Manual Verification

Verified in desktop and compact browser viewports:

- Hover previews open without a close control.
- Selected cards remain open and display a close control.
- Hovering another pin does not dismiss the selected card.
- Keyboard activation opens marker details.
- Escape closes selected details while preserving marker focus.
- Detour search marker and radius appear only in Discover.
- Saved Jaunt previews hide Map/Satellite, Camera, and zoom controls.
- Planner maps retain all standard map controls.