### PR TITLE
Feature/detour map actions undo

### DIFF
--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -220,7 +220,7 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(page.getByText(/set what you want/i)).toBeVisible();
   await expect(page.getByRole("heading", { name: /places?$/ })).toHaveCount(0);
   await page
-    .getByRole("button", { name: "Dismiss added stop message" })
+    .getByRole("button", { name: "Dismiss added detour notification" })
     .click();
   await expect(page.getByText(/Paris Mountain added/)).toHaveCount(0);
   await page.getByRole("tab", { name: "Build" }).click();
@@ -232,8 +232,26 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(detourDetails).toContainText("Hike");
   await expect(detourDetails).toContainText("4.7 rating");
   await expect(detourDetails).toContainText("+ 18 min");
-  await page.keyboard.press("Escape");
-  await expect(detourDetails).toHaveCount(0);
+  await page
+    .getByRole("button", { name: "Actions for Paris Mountain" })
+    .click();
+  await page.getByRole("menuitem", { name: "Remove detour" }).click();
+  await expect(
+    page.getByText("Paris Mountain removed from this Jaunt")
+  ).toBeVisible();
+  await expect(page.getByTitle("Paris Mountain, added stop")).toHaveCount(0);
+  await expect(
+    page.getByRole("region", { name: "Itinerary" })
+  ).not.toContainText("Paris Mountain");
+
+  await page.getByRole("button", { name: "Undo" }).click();
+  await expect(page.getByTitle("Paris Mountain, added stop")).toHaveCount(1);
+  await expect(page.getByRole("region", { name: "Itinerary" })).toContainText(
+    "Paris Mountain"
+  );
+  await expect(
+    page.getByText("Paris Mountain removed from this Jaunt")
+  ).toHaveCount(0);
 
   const viewport = page.viewportSize();
   const showMap = page.getByRole("button", { name: "Show map" });

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -157,8 +157,11 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
   await expect(
     page.getByRole("button", { name: "Close", exact: true })
-  ).toHaveCount(0);
-  await page.getByRole("region", { name: "Route summary" }).hover();
+  ).toHaveCount(1);
+  await page
+    .getByLabel("Start details")
+    .getByRole("button", { name: "Close", exact: true })
+    .click();
   await expect(page.getByLabel("Start details")).toHaveCount(0);
   await startMarker.click();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
@@ -173,8 +176,11 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(page.getByRole("dialog")).toHaveCount(2);
   await expect(
     page.getByRole("button", { name: "Close", exact: true })
-  ).toHaveCount(1);
-  await page.getByRole("region", { name: "Route summary" }).hover();
+  ).toHaveCount(2);
+  await page
+    .getByLabel("Destination details")
+    .getByRole("button", { name: "Close", exact: true })
+    .click();
   await expect(page.getByLabel("Start details")).toContainText("Atlanta, GA");
   await expect(page.getByLabel("Destination details")).toHaveCount(0);
   await destinationMarker.focus();
@@ -216,17 +222,37 @@ test("mounts the current planner at its stable route", async ({ page }) => {
     "aria-selected",
     "true"
   );
-  await expect(page.getByText(/Paris Mountain added/)).toBeVisible();
+  const dismissAddedDetourToast = page.getByRole("button", {
+    name: "Dismiss added detour notification",
+  });
+  await expect(dismissAddedDetourToast).toBeVisible();
   await expect(page.getByText(/set what you want/i)).toBeVisible();
   await expect(page.getByRole("heading", { name: /places?$/ })).toHaveCount(0);
-  await page
-    .getByRole("button", { name: "Dismiss added detour notification" })
-    .click();
-  await expect(page.getByText(/Paris Mountain added/)).toHaveCount(0);
+  await dismissAddedDetourToast.click();
+  await expect(dismissAddedDetourToast).toHaveCount(0);
   await page.getByRole("tab", { name: "Build" }).click();
   await expect(page.getByRole("region", { name: "Itinerary" })).toContainText(
     "Adds 18 min"
   );
+  const viewport = page.viewportSize();
+  const showMap = page.getByRole("button", { name: "Show map" });
+  const usesCompactMap =
+    viewport && viewport.width <= 780 && viewport.height > 500;
+  if (usesCompactMap) {
+    await expect(showMap).toBeVisible();
+    await showMap.click();
+    await expect(
+      page.getByRole("button", { name: "Back to tools" })
+    ).toBeVisible();
+    await expect(
+      page.locator('[aria-label="Jaunt planning tools"]')
+    ).toBeHidden();
+    await expect(
+      page.getByRole("region", { name: "Jaunt route map" })
+    ).toBeVisible();
+  } else {
+    await expect(showMap).toBeHidden();
+  }
   await page.getByTitle("Paris Mountain, added stop").hover();
   const detourDetails = page.getByLabel("Paris Mountain details");
   await expect(detourDetails).toContainText("Hike");
@@ -237,7 +263,6 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   });
   await expect(detourActions).toBeVisible();
   await expect(page.getByRole("button", { name: "Close" })).toHaveCount(1);
-  await detourActions.hover();
   await expect(detourDetails).toBeVisible();
   await detourActions.click();
   await page.getByRole("menuitem", { name: "Remove detour" }).click();
@@ -245,6 +270,12 @@ test("mounts the current planner at its stable route", async ({ page }) => {
     page.getByText("Paris Mountain removed from this Jaunt")
   ).toBeVisible();
   await expect(page.getByTitle("Paris Mountain, added stop")).toHaveCount(0);
+  if (usesCompactMap) {
+    await page.getByRole("button", { name: "Back to tools" }).click();
+    await expect(
+      page.getByRole("complementary", { name: "Jaunt planning tools" })
+    ).toBeVisible();
+  }
   await expect(
     page.getByRole("region", { name: "Itinerary" })
   ).not.toContainText("Paris Mountain");
@@ -257,28 +288,6 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(
     page.getByText("Paris Mountain removed from this Jaunt")
   ).toHaveCount(0);
-
-  const viewport = page.viewportSize();
-  const showMap = page.getByRole("button", { name: "Show map" });
-  if (viewport && viewport.width <= 780 && viewport.height > 500) {
-    await expect(showMap).toBeVisible();
-    await showMap.click();
-    await expect(
-      page.getByRole("button", { name: "Back to tools" })
-    ).toBeVisible();
-    await expect(
-      page.locator('[aria-label="Jaunt planning tools"]')
-    ).toBeHidden();
-    await expect(
-      page.getByRole("region", { name: "Jaunt route map" })
-    ).toBeVisible();
-    await page.getByRole("button", { name: "Back to tools" }).click();
-    await expect(
-      page.getByRole("complementary", { name: "Jaunt planning tools" })
-    ).toBeVisible();
-  } else {
-    await expect(showMap).toBeHidden();
-  }
 });
 
 test("renders endpoint markers on the saved Jaunt detail map", async ({

--- a/frontend/e2e/foundation.spec.js
+++ b/frontend/e2e/foundation.spec.js
@@ -227,14 +227,19 @@ test("mounts the current planner at its stable route", async ({ page }) => {
   await expect(page.getByRole("region", { name: "Itinerary" })).toContainText(
     "Adds 18 min"
   );
-  await page.getByTitle("Paris Mountain, added stop").click();
+  await page.getByTitle("Paris Mountain, added stop").hover();
   const detourDetails = page.getByLabel("Paris Mountain details");
   await expect(detourDetails).toContainText("Hike");
   await expect(detourDetails).toContainText("4.7 rating");
   await expect(detourDetails).toContainText("+ 18 min");
-  await page
-    .getByRole("button", { name: "Actions for Paris Mountain" })
-    .click();
+  const detourActions = page.getByRole("button", {
+    name: "Actions for Paris Mountain",
+  });
+  await expect(detourActions).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close" })).toHaveCount(1);
+  await detourActions.hover();
+  await expect(detourDetails).toBeVisible();
+  await detourActions.click();
   await page.getByRole("menuitem", { name: "Remove detour" }).click();
   await expect(
     page.getByText("Paris Mountain removed from this Jaunt")

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -789,7 +789,9 @@ function MapContainer(props) {
               onHover={setHoveredFeatureId}
               onRemoveDetour={props.onRemoveDetour}
               onSelect={setSelectedFeatureId}
-              pending={props.detourMutationPending != null}
+              pending={
+                props.detourMutationPending != null || props.detourActionsBusy
+              }
               showDetails={
                 selectedFeatureId === feature.id
                   ? "selected"
@@ -832,6 +834,7 @@ MapContainer.propTypes = {
   onDetourHover: PropTypes.func,
   setDetourHighlight: PropTypes.func,
   detourMutationPending: PropTypes.object,
+  detourActionsBusy: PropTypes.bool,
   zoomControl: PropTypes.bool,
 };
 

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -17,7 +17,6 @@ import {
   InfoWindow,
   Map,
   Pin,
-  useAdvancedMarkerRef,
   useMap,
   useMapsLibrary,
 } from "@vis.gl/react-google-maps";
@@ -46,6 +45,7 @@ const WORLD_BOUNDS = {
 
 const MIN_ZOOM = 4;
 const MARKER_DETAILS_OFFSET = [0, -46];
+const MARKER_HOVER_DISMISS_DELAY = 400;
 
 function normalizeCoordinates(location) {
   if (!Number.isFinite(location?.lat) || !Number.isFinite(location?.lng)) {
@@ -124,60 +124,103 @@ function SelectableMapMarker({
   zIndex,
 }) {
   const [actionMenuOpen, setActionMenuOpen] = useState(false);
-  const [contextMenuRequested, setContextMenuRequested] = useState(false);
-  const [markerRef, marker] = useAdvancedMarkerRef();
+  const [actionMenuRequested, setActionMenuRequested] = useState(false);
+  const detailsContentRef = useRef(null);
+  const hoverDismissTimeoutRef = useRef(null);
+  const infoWindowHoveredRef = useRef(false);
 
-  useEffect(() => {
-    if (showDetails === "selected" && contextMenuRequested) {
-      setActionMenuOpen(true);
-      setContextMenuRequested(false);
-    } else if (showDetails !== "selected") {
-      setActionMenuOpen(false);
-    }
-  }, [contextMenuRequested, showDetails]);
+  const cancelHoverDismissal = () => {
+    window.clearTimeout(hoverDismissTimeoutRef.current);
+    hoverDismissTimeoutRef.current = null;
+  };
 
-  const openContextMenu = (event) => {
-    if (feature.detourIndex == null || !onRemoveDetour) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (pending) return;
-    onSelect(feature.id);
-    setContextMenuRequested(true);
+  const beginHover = () => {
+    cancelHoverDismissal();
+    onHover(feature.id);
+  };
+
+  const scheduleHoverDismissal = () => {
+    cancelHoverDismissal();
+    if (infoWindowHoveredRef.current) return;
+    hoverDismissTimeoutRef.current = window.setTimeout(() => {
+      onHover(null);
+    }, MARKER_HOVER_DISMISS_DELAY);
+  };
+
+  const enterInfoWindow = () => {
+    infoWindowHoveredRef.current = true;
+    cancelHoverDismissal();
+  };
+
+  const leaveInfoWindow = () => {
+    infoWindowHoveredRef.current = false;
+    scheduleHoverDismissal();
   };
 
   useEffect(() => {
-    if (!marker || feature.detourIndex == null || !onRemoveDetour) {
-      return undefined;
+    if (showDetails === "selected" && actionMenuRequested) {
+      setActionMenuOpen(true);
+      setActionMenuRequested(false);
+    } else if (showDetails !== "selected") {
+      setActionMenuOpen(false);
     }
-    marker.addEventListener("contextmenu", openContextMenu);
-    return () => marker.removeEventListener("contextmenu", openContextMenu);
+  }, [actionMenuRequested, showDetails]);
+
+  useEffect(
+    () => () => window.clearTimeout(hoverDismissTimeoutRef.current),
+    []
+  );
+
+  useEffect(() => {
+    if (!showDetails) return undefined;
+    const infoWindowElement =
+      detailsContentRef.current?.closest(".gm-style-iw");
+    if (!infoWindowElement) return undefined;
+
+    infoWindowElement.addEventListener("mouseenter", enterInfoWindow);
+    infoWindowElement.addEventListener("mouseleave", leaveInfoWindow);
+    return () => {
+      infoWindowElement.removeEventListener("mouseenter", enterInfoWindow);
+      infoWindowElement.removeEventListener("mouseleave", leaveInfoWindow);
+    };
   });
+
+  const handleMenuOpenChange = (event, data) => {
+    if (data.open && showDetails !== "selected") {
+      cancelHoverDismissal();
+      onSelect(feature.id);
+      setActionMenuRequested(true);
+      return;
+    }
+    setActionMenuOpen(data.open);
+  };
+
+  const handleClose = () => {
+    cancelHoverDismissal();
+    if (showDetails === "hovered") {
+      onHover(null);
+    }
+    onClose(feature.id, showDetails);
+  };
 
   return (
     <>
       <AdvancedMarker
-        ref={markerRef}
         position={feature.position}
         title={feature.accessibleName}
         onClick={() => onSelect(feature.id)}
-        onMouseEnter={() => onHover(feature.id)}
-        onMouseLeave={() => onHover(null)}
+        onMouseEnter={beginHover}
+        onMouseLeave={scheduleHoverDismissal}
         zIndex={active ? zIndex + 10 : zIndex}
       >
-        <span
-          data-testid={`marker-context-${feature.id}`}
-          onContextMenu={openContextMenu}
-          style={{ display: "contents" }}
+        <Pin
+          scale={active ? 1.25 : 1.1}
+          background={background}
+          borderColor={jauntColors.neutral.foregroundOnDark}
+          glyphColor={jauntColors.neutral.foregroundOnDark}
         >
-          <Pin
-            scale={active ? 1.25 : 1.1}
-            background={background}
-            borderColor={jauntColors.neutral.foregroundOnDark}
-            glyphColor={jauntColors.neutral.foregroundOnDark}
-          >
-            {getDetourIconComponent(iconType, "1.125rem")}
-          </Pin>
-        </span>
+          {getDetourIconComponent(iconType, "1.125rem")}
+        </Pin>
       </AdvancedMarker>
       {showDetails ? (
         <InfoWindow
@@ -190,6 +233,7 @@ function SelectableMapMarker({
           disableAutoPan
           headerContent={
             <div
+              data-testid={`marker-details-header-${feature.id}`}
               style={{
                 display: "flex",
                 alignItems: "flex-start",
@@ -198,13 +242,15 @@ function SelectableMapMarker({
                 width: "100%",
                 transform: "translateY(-0.3125rem)",
               }}
+              onMouseEnter={enterInfoWindow}
+              onMouseLeave={leaveInfoWindow}
             >
               <Text weight="semibold">{feature.heading}</Text>
               {feature.detourIndex != null ? (
-                showDetails === "selected" && onRemoveDetour ? (
+                onRemoveDetour ? (
                   <Menu
                     open={actionMenuOpen}
-                    onOpenChange={(event, data) => setActionMenuOpen(data.open)}
+                    onOpenChange={handleMenuOpenChange}
                   >
                     <MenuTrigger disableButtonEnhancement>
                       <Button
@@ -236,12 +282,19 @@ function SelectableMapMarker({
             </div>
           }
           maxWidth={280}
-          onClose={() => onClose(feature.id, showDetails)}
+          onClose={handleClose}
           pixelOffset={MARKER_DETAILS_OFFSET}
           position={feature.position}
           shouldFocus={false}
         >
-          <MarkerDetails feature={feature} />
+          <div
+            data-testid={`marker-details-body-${feature.id}`}
+            ref={detailsContentRef}
+            onMouseEnter={enterInfoWindow}
+            onMouseLeave={leaveInfoWindow}
+          >
+            <MarkerDetails feature={feature} />
+          </div>
         </InfoWindow>
       ) : null}
     </>

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -152,7 +152,21 @@ function SelectableMapMarker({
     cancelHoverDismissal();
   };
 
-  const leaveInfoWindow = () => {
+  const leaveInfoWindow = (event) => {
+    const infoWindowElement =
+      detailsContentRef.current?.closest(".gm-style-iw");
+    const bounds = infoWindowElement?.getBoundingClientRect();
+    if (
+      bounds?.width > 0 &&
+      bounds?.height > 0 &&
+      event.clientX >= bounds.left &&
+      event.clientX <= bounds.right &&
+      event.clientY >= bounds.top &&
+      event.clientY <= bounds.bottom
+    ) {
+      enterInfoWindow();
+      return;
+    }
     infoWindowHoveredRef.current = false;
     scheduleHoverDismissal();
   };
@@ -173,15 +187,43 @@ function SelectableMapMarker({
 
   useEffect(() => {
     if (!showDetails) return undefined;
-    const infoWindowElement =
-      detailsContentRef.current?.closest(".gm-style-iw");
-    if (!infoWindowElement) return undefined;
+    let infoWindowElement = null;
+    const handleMouseMove = (event) => {
+      const bounds = infoWindowElement?.getBoundingClientRect();
+      if (
+        bounds?.width > 0 &&
+        bounds?.height > 0 &&
+        event.clientX >= bounds.left &&
+        event.clientX <= bounds.right &&
+        event.clientY >= bounds.top &&
+        event.clientY <= bounds.bottom
+      ) {
+        enterInfoWindow();
+      }
+    };
+    const attachInfoWindowListeners = () => {
+      infoWindowElement =
+        detailsContentRef.current?.closest(".gm-style-iw") || null;
+      if (!infoWindowElement) return false;
+      infoWindowElement.addEventListener("mouseenter", enterInfoWindow);
+      infoWindowElement.addEventListener("mouseleave", leaveInfoWindow);
+      document.addEventListener("mousemove", handleMouseMove);
+      return true;
+    };
+    const observer = new MutationObserver(() => {
+      if (attachInfoWindowListeners()) {
+        observer.disconnect();
+      }
+    });
 
-    infoWindowElement.addEventListener("mouseenter", enterInfoWindow);
-    infoWindowElement.addEventListener("mouseleave", leaveInfoWindow);
+    if (!attachInfoWindowListeners()) {
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
     return () => {
-      infoWindowElement.removeEventListener("mouseenter", enterInfoWindow);
-      infoWindowElement.removeEventListener("mouseleave", leaveInfoWindow);
+      observer.disconnect();
+      infoWindowElement?.removeEventListener("mouseenter", enterInfoWindow);
+      infoWindowElement?.removeEventListener("mouseleave", leaveInfoWindow);
+      document.removeEventListener("mousemove", handleMouseMove);
     };
   });
 
@@ -216,7 +258,11 @@ function SelectableMapMarker({
         <Pin
           scale={active ? 1.25 : 1.1}
           background={background}
-          borderColor={jauntColors.neutral.foregroundOnDark}
+          borderColor={
+            showDetails === "selected"
+              ? jauntColors.brand.primary
+              : jauntColors.neutral.foregroundOnDark
+          }
           glyphColor={jauntColors.neutral.foregroundOnDark}
         >
           {getDetourIconComponent(iconType, "1.125rem")}

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -141,7 +141,6 @@ function SelectableMapMarker({
 
   const scheduleHoverDismissal = () => {
     cancelHoverDismissal();
-    if (infoWindowHoveredRef.current) return;
     hoverDismissTimeoutRef.current = window.setTimeout(() => {
       onHover(null);
     }, MARKER_HOVER_DISMISS_DELAY);
@@ -190,15 +189,18 @@ function SelectableMapMarker({
     let infoWindowElement = null;
     const handleMouseMove = (event) => {
       const bounds = infoWindowElement?.getBoundingClientRect();
-      if (
+      const isInsideInfoWindow =
         bounds?.width > 0 &&
         bounds?.height > 0 &&
         event.clientX >= bounds.left &&
         event.clientX <= bounds.right &&
         event.clientY >= bounds.top &&
-        event.clientY <= bounds.bottom
-      ) {
+        event.clientY <= bounds.bottom;
+      if (isInsideInfoWindow) {
         enterInfoWindow();
+      } else if (infoWindowHoveredRef.current) {
+        infoWindowHoveredRef.current = false;
+        scheduleHoverDismissal();
       }
     };
     const attachInfoWindowListeners = () => {

--- a/frontend/src/components/MapContainer.jsx
+++ b/frontend/src/components/MapContainer.jsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { Text } from "@fluentui/react-components";
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Text,
+} from "@fluentui/react-components";
+import { DeleteRegular, MoreHorizontalRegular } from "@fluentui/react-icons";
 //import { Map, Circle , Polyline, Marker, GoogleApiWrapper } from 'google-maps-react';
 import {
   AdvancedMarker,
@@ -8,6 +17,7 @@ import {
   InfoWindow,
   Map,
   Pin,
+  useAdvancedMarkerRef,
   useMap,
   useMapsLibrary,
 } from "@vis.gl/react-google-maps";
@@ -107,13 +117,46 @@ function SelectableMapMarker({
   iconType,
   onClose,
   onHover,
+  onRemoveDetour,
   onSelect,
+  pending,
   showDetails,
   zIndex,
 }) {
+  const [actionMenuOpen, setActionMenuOpen] = useState(false);
+  const [contextMenuRequested, setContextMenuRequested] = useState(false);
+  const [markerRef, marker] = useAdvancedMarkerRef();
+
+  useEffect(() => {
+    if (showDetails === "selected" && contextMenuRequested) {
+      setActionMenuOpen(true);
+      setContextMenuRequested(false);
+    } else if (showDetails !== "selected") {
+      setActionMenuOpen(false);
+    }
+  }, [contextMenuRequested, showDetails]);
+
+  const openContextMenu = (event) => {
+    if (feature.detourIndex == null || !onRemoveDetour) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (pending) return;
+    onSelect(feature.id);
+    setContextMenuRequested(true);
+  };
+
+  useEffect(() => {
+    if (!marker || feature.detourIndex == null || !onRemoveDetour) {
+      return undefined;
+    }
+    marker.addEventListener("contextmenu", openContextMenu);
+    return () => marker.removeEventListener("contextmenu", openContextMenu);
+  });
+
   return (
     <>
       <AdvancedMarker
+        ref={markerRef}
         position={feature.position}
         title={feature.accessibleName}
         onClick={() => onSelect(feature.id)}
@@ -121,14 +164,20 @@ function SelectableMapMarker({
         onMouseLeave={() => onHover(null)}
         zIndex={active ? zIndex + 10 : zIndex}
       >
-        <Pin
-          scale={active ? 1.25 : 1.1}
-          background={background}
-          borderColor={jauntColors.neutral.foregroundOnDark}
-          glyphColor={jauntColors.neutral.foregroundOnDark}
+        <span
+          data-testid={`marker-context-${feature.id}`}
+          onContextMenu={openContextMenu}
+          style={{ display: "contents" }}
         >
-          {getDetourIconComponent(iconType, "1.125rem")}
-        </Pin>
+          <Pin
+            scale={active ? 1.25 : 1.1}
+            background={background}
+            borderColor={jauntColors.neutral.foregroundOnDark}
+            glyphColor={jauntColors.neutral.foregroundOnDark}
+          >
+            {getDetourIconComponent(iconType, "1.125rem")}
+          </Pin>
+        </span>
       </AdvancedMarker>
       {showDetails ? (
         <InfoWindow
@@ -140,12 +189,51 @@ function SelectableMapMarker({
           }
           disableAutoPan
           headerContent={
-            <Text
-              style={{ display: "block", transform: "translateY(-0.3125rem)" }}
-              weight="semibold"
+            <div
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: "0.25rem",
+                width: "100%",
+                transform: "translateY(-0.3125rem)",
+              }}
             >
-              {feature.heading}
-            </Text>
+              <Text weight="semibold">{feature.heading}</Text>
+              {feature.detourIndex != null ? (
+                showDetails === "selected" && onRemoveDetour ? (
+                  <Menu
+                    open={actionMenuOpen}
+                    onOpenChange={(event, data) => setActionMenuOpen(data.open)}
+                  >
+                    <MenuTrigger disableButtonEnhancement>
+                      <Button
+                        appearance="transparent"
+                        aria-label={`Actions for ${feature.heading}`}
+                        disabled={pending}
+                        icon={<MoreHorizontalRegular />}
+                        size="small"
+                      />
+                    </MenuTrigger>
+                    <MenuPopover>
+                      <MenuList>
+                        <MenuItem
+                          icon={<DeleteRegular />}
+                          onClick={() => onRemoveDetour(feature.detourIndex)}
+                        >
+                          Remove detour
+                        </MenuItem>
+                      </MenuList>
+                    </MenuPopover>
+                  </Menu>
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    style={{ display: "block", width: "2rem" }}
+                  />
+                )
+              ) : null}
+            </div>
           }
           maxWidth={280}
           onClose={() => onClose(feature.id, showDetails)}
@@ -370,6 +458,7 @@ function MapContainer(props) {
     category: detour.type,
     rating: detour.rating,
     addedTimeText: formatAddedTime(detour.addedTime),
+    detourIndex: index,
     position: { lat: detour.lat, lng: detour.lng },
   }));
   const visibleFeatureIds = [
@@ -597,7 +686,9 @@ function MapContainer(props) {
               iconType={feature.category}
               onClose={closeFeatureDetails}
               onHover={setHoveredFeatureId}
+              onRemoveDetour={props.onRemoveDetour}
               onSelect={setSelectedFeatureId}
+              pending={props.detourMutationPending != null}
               showDetails={
                 selectedFeatureId === feature.id
                   ? "selected"
@@ -635,9 +726,11 @@ MapContainer.propTypes = {
   detourHighlight: PropTypes.array,
   hoveredDetourId: PropTypes.string,
   mapTypeControl: PropTypes.bool,
+  onRemoveDetour: PropTypes.func,
   detourList: PropTypes.array,
   onDetourHover: PropTypes.func,
   setDetourHighlight: PropTypes.func,
+  detourMutationPending: PropTypes.object,
   zoomControl: PropTypes.bool,
 };
 
@@ -667,7 +760,9 @@ SelectableMapMarker.propTypes = {
   iconType: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   onHover: PropTypes.func.isRequired,
+  onRemoveDetour: PropTypes.func,
   onSelect: PropTypes.func.isRequired,
+  pending: PropTypes.bool,
   showDetails: PropTypes.oneOf(["selected", "hovered"]),
   zIndex: PropTypes.number.isRequired,
 };

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -57,9 +57,9 @@ jest.mock("@vis.gl/react-google-maps", () => {
       },
       ref
     ) {
-      React.useImperativeHandle(ref, () => ({ title }), [title]);
       return (
         <div
+          ref={ref}
           aria-label={title || undefined}
           data-testid={title ? `marker-${title}` : undefined}
           data-position={
@@ -86,6 +86,10 @@ jest.mock("@vis.gl/react-google-maps", () => {
       return null;
     },
     useMap: () => mockUseMap(),
+    useAdvancedMarkerRef: () => {
+      const [marker, setMarker] = React.useState(null);
+      return [setMarker, marker];
+    },
     useMapsLibrary: () => ({}),
   };
 });
@@ -100,6 +104,7 @@ function createProps(overrides = {}) {
     detourOptions: [],
     detourHighlight: [],
     detourList: [],
+    onRemoveDetour: jest.fn(),
     onDetourHover: jest.fn(),
     setDetourHighlight: jest.fn(),
     ...overrides,
@@ -518,6 +523,11 @@ describe("MapContainer", () => {
     expect(details).toHaveTextContent("Hike");
     expect(details).toHaveTextContent("4.7 rating");
     expect(details).toHaveTextContent("+ 18 min");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Paris Mountain" })
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Remove detour" }));
+    expect(props.onRemoveDetour).toHaveBeenCalledWith(0);
     fireEvent.click(screen.getByRole("button", { name: "Close details" }));
     expect(details).not.toBeInTheDocument();
 
@@ -526,6 +536,85 @@ describe("MapContainer", () => {
     expect(
       screen.queryByRole("dialog", { name: "Paris Mountain details" })
     ).not.toBeInTheDocument();
+  });
+
+  test("shows detour actions only for selected added stops", () => {
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+    });
+    render(<MapContainer {...props} />);
+    const marker = screen.getByRole("button", {
+      name: "Paris Mountain, added stop",
+    });
+
+    fireEvent.mouseEnter(marker);
+    expect(
+      screen.queryByRole("button", { name: "Actions for Paris Mountain" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseLeave(marker);
+    fireEvent.click(marker);
+    expect(
+      screen.getByRole("button", { name: "Actions for Paris Mountain" })
+    ).toBeInTheDocument();
+  });
+
+  test("opens the selected detour action menu on right click", () => {
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+    });
+    render(<MapContainer {...props} />);
+
+    fireEvent.contextMenu(
+      screen.getAllByTestId("marker-context-detour-place-1")[0]
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Paris Mountain details" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Remove detour" })
+    ).toBeVisible();
+  });
+
+  test("disables detour actions while a route mutation is pending", () => {
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+      detourMutationPending: { kind: "remove", index: 0 },
+    });
+    render(<MapContainer {...props} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Paris Mountain, added stop" })
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Actions for Paris Mountain" })
+    ).toBeDisabled();
   });
 
   test("previews a detour marker on hover without selecting it", () => {

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -261,6 +261,12 @@ describe("MapContainer", () => {
     expect(
       mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
     ).toBe(true);
+    expect(
+      mockPinProps.mock.calls.some(
+        ([pinProps]) =>
+          pinProps.borderColor === "#ffffff" && pinProps.scale === 1.25
+      )
+    ).toBe(true);
     fireEvent.mouseLeave(startMarker);
     act(() => jest.advanceTimersByTime(450));
     expect(
@@ -270,6 +276,12 @@ describe("MapContainer", () => {
     fireEvent.click(startMarker);
     expect(
       mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
+    ).toBe(true);
+    expect(
+      mockPinProps.mock.calls.some(
+        ([pinProps]) =>
+          pinProps.borderColor === "#12664f" && pinProps.scale === 1.25
+      )
     ).toBe(true);
     expect(
       screen.getByRole("dialog", { name: "Start details" })

--- a/frontend/src/components/MapContainer.test.jsx
+++ b/frontend/src/components/MapContainer.test.jsx
@@ -37,9 +37,7 @@ jest.mock("@vis.gl/react-google-maps", () => {
       >
         <header>{headerContent}</header>
         {children}
-        {className === "jaunt-marker-details--hovered" ? null : (
-          <button onClick={onClose}>Close details</button>
-        )}
+        <button onClick={onClose}>Close details</button>
       </section>
     );
   }
@@ -192,6 +190,7 @@ describe("MapContainer", () => {
   });
 
   test("shows itinerary-consistent endpoints from a live multi-leg route", () => {
+    jest.useFakeTimers();
     render(
       <MapContainer
         {...createProps({
@@ -257,12 +256,13 @@ describe("MapContainer", () => {
       })
     );
     expect(
-      screen.queryByRole("button", { name: "Close details" })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "Close details" })
+    ).toBeInTheDocument();
     expect(
       mockPinProps.mock.calls.some(([pinProps]) => pinProps.scale === 1.25)
     ).toBe(true);
     fireEvent.mouseLeave(startMarker);
+    act(() => jest.advanceTimersByTime(450));
     expect(
       screen.queryByRole("dialog", { name: "Start details" })
     ).not.toBeInTheDocument();
@@ -292,6 +292,7 @@ describe("MapContainer", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByRole("dialog")).toHaveLength(2);
     fireEvent.mouseLeave(destinationMarker);
+    act(() => jest.advanceTimersByTime(450));
     expect(
       screen.getByRole("dialog", { name: "Start details" })
     ).toBeInTheDocument();
@@ -318,6 +319,7 @@ describe("MapContainer", () => {
     expect(
       screen.queryByRole("dialog", { name: "Destination details" })
     ).not.toBeInTheDocument();
+    jest.useRealTimers();
   });
 
   test("falls back to persisted endpoints when saved routes have no legs", () => {
@@ -470,6 +472,7 @@ describe("MapContainer", () => {
   });
 
   test("anchors added detours with category icons in stop-colored pins", () => {
+    jest.useFakeTimers();
     const props = createProps({
       detourList: [
         {
@@ -511,6 +514,7 @@ describe("MapContainer", () => {
       })
     );
     fireEvent.mouseLeave(detourMarker);
+    act(() => jest.advanceTimersByTime(450));
     expect(
       screen.queryByRole("dialog", { name: "Paris Mountain details" })
     ).not.toBeInTheDocument();
@@ -536,9 +540,10 @@ describe("MapContainer", () => {
     expect(
       screen.queryByRole("dialog", { name: "Paris Mountain details" })
     ).not.toBeInTheDocument();
+    jest.useRealTimers();
   });
 
-  test("shows detour actions only for selected added stops", () => {
+  test("shows detour actions and close controls on hover and selection", () => {
     const props = createProps({
       detourList: [
         {
@@ -557,8 +562,11 @@ describe("MapContainer", () => {
 
     fireEvent.mouseEnter(marker);
     expect(
-      screen.queryByRole("button", { name: "Actions for Paris Mountain" })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "Actions for Paris Mountain" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Close details" })
+    ).toBeInTheDocument();
 
     fireEvent.mouseLeave(marker);
     fireEvent.click(marker);
@@ -567,7 +575,48 @@ describe("MapContainer", () => {
     ).toBeInTheDocument();
   });
 
-  test("opens the selected detour action menu on right click", () => {
+  test("keeps a hover preview open while moving from marker to card", () => {
+    jest.useFakeTimers();
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+    });
+    render(<MapContainer {...props} />);
+    const marker = screen.getByRole("button", {
+      name: "Paris Mountain, added stop",
+    });
+
+    fireEvent.mouseEnter(marker);
+    fireEvent.mouseLeave(marker);
+    act(() => jest.advanceTimersByTime(100));
+    fireEvent.mouseEnter(
+      screen.getByTestId("marker-details-header-detour-place-1")
+    );
+    act(() => jest.advanceTimersByTime(450));
+
+    expect(
+      screen.getByRole("dialog", { name: "Paris Mountain details" })
+    ).toBeInTheDocument();
+
+    fireEvent.mouseLeave(
+      screen.getByTestId("marker-details-header-detour-place-1")
+    );
+    act(() => jest.advanceTimersByTime(450));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Paris Mountain details" })
+    ).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  test("promotes a hover preview when its actions menu opens", () => {
     const props = createProps({
       detourList: [
         {
@@ -581,8 +630,11 @@ describe("MapContainer", () => {
     });
     render(<MapContainer {...props} />);
 
-    fireEvent.contextMenu(
-      screen.getAllByTestId("marker-context-detour-place-1")[0]
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "Paris Mountain, added stop" })
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Paris Mountain" })
     );
 
     expect(
@@ -591,6 +643,40 @@ describe("MapContainer", () => {
     expect(
       screen.getByRole("menuitem", { name: "Remove detour" })
     ).toBeVisible();
+    expect(mockInfoWindowProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        className: "jaunt-marker-details--selected",
+      })
+    );
+  });
+
+  test("closes a hover preview until the marker is entered again", () => {
+    const props = createProps({
+      detourList: [
+        {
+          name: "Paris Mountain",
+          placeId: "place-1",
+          type: "Hike",
+          lat: 34.9,
+          lng: -82.4,
+        },
+      ],
+    });
+    render(<MapContainer {...props} />);
+    const marker = screen.getByRole("button", {
+      name: "Paris Mountain, added stop",
+    });
+
+    fireEvent.mouseEnter(marker);
+    fireEvent.click(screen.getByRole("button", { name: "Close details" }));
+    expect(
+      screen.queryByRole("dialog", { name: "Paris Mountain details" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(marker);
+    expect(
+      screen.getByRole("dialog", { name: "Paris Mountain details" })
+    ).toBeInTheDocument();
   });
 
   test("disables detour actions while a route mutation is pending", () => {

--- a/frontend/src/components/planner/PlannerWorkspace.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.jsx
@@ -5,15 +5,23 @@ import {
   Button,
   Field,
   Input,
+  Toast,
+  Toaster,
+  ToastFooter,
+  ToastTitle,
+  ToastTrigger,
   Tab,
   TabList,
   Text,
   makeStyles,
   shorthands,
   tokens,
+  useId,
+  useToastController,
 } from "@fluentui/react-components";
 import {
   ArrowLeftRegular,
+  DismissRegular,
   MapRegular,
   OpenRegular,
   SparkleRegular,
@@ -23,6 +31,7 @@ import RouteForm from "./build-workflow/RouteForm";
 import BuildRouteDetails from "./build-workflow/BuildRouteDetails";
 import DiscoverWorkspace from "./discover-workflow/DiscoverWorkspace";
 import ExportWorkspace from "./export-workflow/ExportWorkspace";
+import useDetourMutations from "./build-workflow/useDetourMutations";
 import MapContainer from "../MapContainer";
 import {
   createPlannerFingerprint,
@@ -227,17 +236,204 @@ const useStyles = makeStyles({
   },
 });
 
+const PLANNER_TOAST_TIMEOUT = 5000;
+
 export default function PlannerWorkspace(props) {
   const styles = useStyles();
   const [selectedTask, setSelectedTask] = useState("build");
   const [mapExpanded, setMapExpanded] = useState(false);
   const [editingRoute, setEditingRoute] = useState(!props.showDetourButton);
   const [saveOperation, setSaveOperation] = useState("idle");
-  const [plannerFeedback, setPlannerFeedback] = useState("");
   const [hoveredDetourId, setHoveredDetourId] = useState(null);
   const previousSuggestedNameRef = useRef("");
   const previousTripNameRef = useRef(props.tripName);
   const tripNameRef = useRef(props.tripName);
+  const addedToastTimeoutRef = useRef(null);
+  const removalToastTimeoutRef = useRef(null);
+  const toasterId = useId("detour-mutation-toaster");
+  const mutationErrorToastId = useId("detour-mutation-error-toast");
+  const addedDetourToastId = useId("detour-added-toast");
+  const removalToastId = useId("detour-removal-toast");
+  const { dismissToast, dispatchToast } = useToastController(toasterId);
+  const detourMutations = useDetourMutations({
+    destination: props.destination,
+    detourList: props.detourList,
+    origin: props.origin,
+    setDetourList: props.setDetourList,
+    setRoute: props.setRoute,
+    setTripSummary: props.setTripSummary,
+  });
+
+  const dismissRemovalToast = () => {
+    window.clearTimeout(removalToastTimeoutRef.current);
+    removalToastTimeoutRef.current = null;
+    detourMutations.clearUndoRemoval();
+    dismissToast(removalToastId);
+  };
+
+  const dismissAddedDetourToast = () => {
+    window.clearTimeout(addedToastTimeoutRef.current);
+    addedToastTimeoutRef.current = null;
+    dismissToast(addedDetourToastId);
+  };
+
+  const undoRemoval = async () => {
+    window.clearTimeout(removalToastTimeoutRef.current);
+    removalToastTimeoutRef.current = null;
+    const undoPromise = detourMutations.undoLastRemoval();
+    dismissToast(removalToastId);
+    const result = await undoPromise;
+    if (result.status === "failed") {
+      showMutationFailureToast(result.mutation);
+    }
+  };
+
+  const showMutationFailureToast = (mutation) => {
+    dispatchToast(
+      <Toast>
+        <ToastTitle>
+          {mutation?.kind === "restore"
+            ? "Could not restore the detour."
+            : "Could not remove the detour."}
+        </ToastTitle>
+        <ToastFooter>
+          <Button
+            appearance="transparent"
+            onClick={retryPlannerMutation}
+            style={{ minWidth: "auto", paddingLeft: 0, paddingRight: 0 }}
+          >
+            Retry
+          </Button>
+        </ToastFooter>
+      </Toast>,
+      {
+        intent: "error",
+        toastId: mutationErrorToastId,
+      }
+    );
+  };
+
+  const showRemovalToast = (detourName) => {
+    window.clearTimeout(removalToastTimeoutRef.current);
+    dispatchToast(
+      <Toast>
+        <ToastTitle
+          action={
+            <ToastTrigger>
+              <Button
+                appearance="transparent"
+                aria-label="Dismiss removal notification"
+                icon={<DismissRegular />}
+                onClick={dismissRemovalToast}
+                size="small"
+              />
+            </ToastTrigger>
+          }
+        >
+          {detourName} removed from this Jaunt
+        </ToastTitle>
+        <ToastFooter>
+          <Button
+            appearance="transparent"
+            onClick={undoRemoval}
+            style={{ minWidth: "auto", paddingLeft: 0, paddingRight: 0 }}
+          >
+            Undo
+          </Button>
+        </ToastFooter>
+      </Toast>,
+      {
+        intent: "success",
+        onStatusChange: (event, data) => {
+          if (data.status === "unmounted") {
+            detourMutations.clearUndoRemoval();
+          }
+        },
+        pauseOnHover: true,
+        pauseOnWindowBlur: false,
+        timeout: PLANNER_TOAST_TIMEOUT,
+        toastId: removalToastId,
+      }
+    );
+    removalToastTimeoutRef.current = window.setTimeout(
+      dismissRemovalToast,
+      PLANNER_TOAST_TIMEOUT
+    );
+  };
+
+  const showAddedDetourToast = (name, addedTime) => {
+    window.clearTimeout(addedToastTimeoutRef.current);
+    dispatchToast(
+      <Toast>
+        <ToastTitle
+          action={
+            <ToastTrigger>
+              <Button
+                appearance="transparent"
+                aria-label="Dismiss added detour notification"
+                icon={<DismissRegular />}
+                onClick={dismissAddedDetourToast}
+                size="small"
+              />
+            </ToastTrigger>
+          }
+        >
+          {name} added. The route is {addedTime} minutes longer.
+        </ToastTitle>
+      </Toast>,
+      {
+        intent: "success",
+        pauseOnHover: true,
+        pauseOnWindowBlur: false,
+        timeout: PLANNER_TOAST_TIMEOUT,
+        toastId: addedDetourToastId,
+      }
+    );
+    addedToastTimeoutRef.current = window.setTimeout(
+      dismissAddedDetourToast,
+      PLANNER_TOAST_TIMEOUT
+    );
+  };
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(addedToastTimeoutRef.current);
+      window.clearTimeout(removalToastTimeoutRef.current);
+    },
+    []
+  );
+
+  const runPlannerMutation = async (mutation) => {
+    const detourName =
+      mutation.kind === "remove"
+        ? props.detourList[mutation.index]?.name
+        : null;
+    const result = await detourMutations.runMutation(mutation);
+    if (result.status === "success" && detourName) {
+      showRemovalToast(detourName);
+    } else if (result.status === "failed" && mutation.source === "map") {
+      showMutationFailureToast(result.mutation);
+    }
+    return result;
+  };
+
+  const retryPlannerMutation = async () => {
+    const failedMutation = detourMutations.failedMutation;
+    const detourName =
+      failedMutation?.kind === "remove"
+        ? props.detourList[failedMutation.index]?.name
+        : null;
+    const result = await detourMutations.retryMutation();
+    if (result.status === "success" && detourName) {
+      showRemovalToast(detourName);
+    } else if (
+      result.status === "failed" &&
+      (failedMutation?.source === "map" || failedMutation?.kind === "restore")
+    ) {
+      showMutationFailureToast(result.mutation);
+    }
+    return result;
+  };
 
   useEffect(() => {
     if (props.showDetourForm) {
@@ -256,14 +452,6 @@ export default function PlannerWorkspace(props) {
   useEffect(() => {
     setHoveredDetourId(null);
   }, [props.detourOptions]);
-
-  useEffect(() => {
-    if (!plannerFeedback) {
-      return undefined;
-    }
-    const timeoutId = window.setTimeout(() => setPlannerFeedback(""), 10000);
-    return () => window.clearTimeout(timeoutId);
-  }, [plannerFeedback]);
 
   const openDiscover = () => {
     if (!props.showDetourForm) {
@@ -450,10 +638,10 @@ export default function PlannerWorkspace(props) {
                 destination={props.destination}
                 tripSummary={props.tripSummary}
                 detourList={props.detourList}
-                removeDetour={props.removeDetour}
-                setRoute={props.setRoute}
-                setTripSummary={props.setTripSummary}
-                setDetourList={props.setDetourList}
+                failedMutation={detourMutations.failedMutation}
+                pending={detourMutations.pending}
+                retryMutation={retryPlannerMutation}
+                runMutation={runPlannerMutation}
                 onClear={props.clearAll}
                 onDiscover={openDiscover}
                 onEditRoute={() => setEditingRoute(true)}
@@ -490,13 +678,7 @@ export default function PlannerWorkspace(props) {
                 detourSearchLocation={props.detourSearchLocation}
                 detourSearchRadius={props.detourSearchRadius}
                 route={props.route}
-                feedback={plannerFeedback}
-                onDismissFeedback={() => setPlannerFeedback("")}
-                onAdded={(name, addedTime) => {
-                  setPlannerFeedback(
-                    `${name} added. The route is ${addedTime} minutes longer.`
-                  );
-                }}
+                onAdded={showAddedDetourToast}
               />
             ) : (
               <div className={styles.discoverEmpty}>
@@ -551,10 +733,15 @@ export default function PlannerWorkspace(props) {
           hoveredDetourId={hoveredDetourId}
           onDetourHover={setHoveredDetourId}
           detourList={props.detourList}
+          detourMutationPending={detourMutations.pending}
+          onRemoveDetour={(index) =>
+            runPlannerMutation({ kind: "remove", index, source: "map" })
+          }
           setDetourHighlight={props.setDetourHighlight}
           route={props.route}
         />
       </section>
+      <Toaster toasterId={toasterId} />
     </div>
   );
 }
@@ -589,7 +776,6 @@ PlannerWorkspace.propTypes = {
   setDetourHighlight: PropTypes.func,
   setDetourList: PropTypes.func,
   addDetour: PropTypes.func,
-  removeDetour: PropTypes.func,
   getDetourForm: PropTypes.func,
   clearAll: PropTypes.func,
   clearDetourOptions: PropTypes.func,

--- a/frontend/src/components/planner/PlannerWorkspace.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.jsx
@@ -245,11 +245,10 @@ export default function PlannerWorkspace(props) {
   const [editingRoute, setEditingRoute] = useState(!props.showDetourButton);
   const [saveOperation, setSaveOperation] = useState("idle");
   const [hoveredDetourId, setHoveredDetourId] = useState(null);
+  const [discoverAdding, setDiscoverAdding] = useState(false);
   const previousSuggestedNameRef = useRef("");
   const previousTripNameRef = useRef(props.tripName);
   const tripNameRef = useRef(props.tripName);
-  const addedToastTimeoutRef = useRef(null);
-  const removalToastTimeoutRef = useRef(null);
   const toasterId = useId("detour-mutation-toaster");
   const mutationErrorToastId = useId("detour-mutation-error-toast");
   const addedDetourToastId = useId("detour-added-toast");
@@ -264,22 +263,19 @@ export default function PlannerWorkspace(props) {
     setTripSummary: props.setTripSummary,
   });
 
+  const mutationInFlight = detourMutations.pending != null;
+  const anyMutationBusy = mutationInFlight || discoverAdding;
+
   const dismissRemovalToast = () => {
-    window.clearTimeout(removalToastTimeoutRef.current);
-    removalToastTimeoutRef.current = null;
     detourMutations.clearUndoRemoval();
     dismissToast(removalToastId);
   };
 
   const dismissAddedDetourToast = () => {
-    window.clearTimeout(addedToastTimeoutRef.current);
-    addedToastTimeoutRef.current = null;
     dismissToast(addedDetourToastId);
   };
 
   const undoRemoval = async () => {
-    window.clearTimeout(removalToastTimeoutRef.current);
-    removalToastTimeoutRef.current = null;
     const undoPromise = detourMutations.undoLastRemoval();
     dismissToast(removalToastId);
     const result = await undoPromise;
@@ -299,7 +295,7 @@ export default function PlannerWorkspace(props) {
         <ToastFooter>
           <Button
             appearance="transparent"
-            onClick={retryPlannerMutation}
+            onClick={() => retryPlannerMutation(mutation)}
             style={{ minWidth: "auto", paddingLeft: 0, paddingRight: 0 }}
           >
             Retry
@@ -314,7 +310,6 @@ export default function PlannerWorkspace(props) {
   };
 
   const showRemovalToast = (detourName) => {
-    window.clearTimeout(removalToastTimeoutRef.current);
     dispatchToast(
       <Toast>
         <ToastTitle
@@ -355,14 +350,9 @@ export default function PlannerWorkspace(props) {
         toastId: removalToastId,
       }
     );
-    removalToastTimeoutRef.current = window.setTimeout(
-      dismissRemovalToast,
-      PLANNER_TOAST_TIMEOUT
-    );
   };
 
   const showAddedDetourToast = (name, addedTime) => {
-    window.clearTimeout(addedToastTimeoutRef.current);
     dispatchToast(
       <Toast>
         <ToastTitle
@@ -389,19 +379,7 @@ export default function PlannerWorkspace(props) {
         toastId: addedDetourToastId,
       }
     );
-    addedToastTimeoutRef.current = window.setTimeout(
-      dismissAddedDetourToast,
-      PLANNER_TOAST_TIMEOUT
-    );
   };
-
-  useEffect(
-    () => () => {
-      window.clearTimeout(addedToastTimeoutRef.current);
-      window.clearTimeout(removalToastTimeoutRef.current);
-    },
-    []
-  );
 
   const runPlannerMutation = async (mutation) => {
     const detourName =
@@ -417,13 +395,13 @@ export default function PlannerWorkspace(props) {
     return result;
   };
 
-  const retryPlannerMutation = async () => {
-    const failedMutation = detourMutations.failedMutation;
+  const retryPlannerMutation = async (mutation) => {
+    const failedMutation = mutation || detourMutations.failedMutation;
     const detourName =
       failedMutation?.kind === "remove"
         ? props.detourList[failedMutation.index]?.name
         : null;
-    const result = await detourMutations.retryMutation();
+    const result = await detourMutations.retryMutation(failedMutation);
     if (result.status === "success" && detourName) {
       showRemovalToast(detourName);
     } else if (
@@ -640,6 +618,7 @@ export default function PlannerWorkspace(props) {
                 detourList={props.detourList}
                 failedMutation={detourMutations.failedMutation}
                 pending={detourMutations.pending}
+                actionsBusy={anyMutationBusy}
                 retryMutation={retryPlannerMutation}
                 runMutation={runPlannerMutation}
                 onClear={props.clearAll}
@@ -667,6 +646,8 @@ export default function PlannerWorkspace(props) {
                 hoveredDetourId={hoveredDetourId}
                 onDetourHover={setHoveredDetourId}
                 addDetour={props.addDetour}
+                mutationPending={mutationInFlight}
+                onAddingChange={setDiscoverAdding}
                 setRoute={props.setRoute}
                 setTripSummary={props.setTripSummary}
                 setDetourSearchLocation={props.setDetourSearchLocation}
@@ -734,6 +715,7 @@ export default function PlannerWorkspace(props) {
           onDetourHover={setHoveredDetourId}
           detourList={props.detourList}
           detourMutationPending={detourMutations.pending}
+          detourActionsBusy={anyMutationBusy}
           onRemoveDetour={(index) =>
             runPlannerMutation({ kind: "remove", index, source: "map" })
           }

--- a/frontend/src/components/planner/PlannerWorkspace.test.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.test.jsx
@@ -1,11 +1,20 @@
-import React from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { FluentProvider } from "@fluentui/react-components";
 import PlannerWorkspace from "./PlannerWorkspace";
 import { jauntDetourTheme } from "../../design-system/jauntDetourTheme";
+import RouteRequester from "../../scripts/RouteRequester";
 
 const mockDiscoverProps = jest.fn();
 const mockMapProps = jest.fn();
+
+jest.mock("../../scripts/RouteRequester");
 
 jest.mock("./build-workflow/RouteForm", () => {
   const PropTypes = require("prop-types");
@@ -63,35 +72,23 @@ jest.mock("./discover-workflow/DiscoverWorkspace", () => {
 
   function MockDiscoverWorkspace(props) {
     mockDiscoverProps(props);
-    const {
-      feedback,
-      hoveredDetourId,
-      onAdded,
-      onDetourHover,
-      onDismissFeedback,
-    } = props;
+    const { hoveredDetourId, onAdded, onDetourHover } = props;
     return (
       <div>
         Discover workspace instance
         <span data-testid="discover-hovered">{hoveredDetourId || "none"}</span>
         <button onClick={() => onDetourHover("place-1")}>Hover result</button>
-        {feedback ? <span>{feedback}</span> : null}
         <button onClick={() => onAdded("Paris Mountain", 18)}>
           Complete add
         </button>
-        {feedback ? (
-          <button onClick={onDismissFeedback}>Dismiss feedback</button>
-        ) : null}
       </div>
     );
   }
 
   MockDiscoverWorkspace.propTypes = {
-    feedback: PropTypes.string,
     hoveredDetourId: PropTypes.string,
     onAdded: PropTypes.func.isRequired,
     onDetourHover: PropTypes.func.isRequired,
-    onDismissFeedback: PropTypes.func.isRequired,
   };
 
   return MockDiscoverWorkspace;
@@ -113,9 +110,15 @@ jest.mock(
       return (
         <div>
           Map instance
+          <span data-testid="map-detour-count">{props.detourList.length}</span>
           <span data-testid="map-hovered">
             {props.hoveredDetourId || "none"}
           </span>
+          {props.onRemoveDetour ? (
+            <button onClick={() => props.onRemoveDetour(0)}>
+              Remove map detour
+            </button>
+          ) : null}
         </div>
       );
     }
@@ -172,6 +175,7 @@ describe("PlannerWorkspace", () => {
   beforeEach(() => {
     mockDiscoverProps.mockClear();
     mockMapProps.mockClear();
+    RouteRequester.mockReset();
   });
 
   it("shows only route entry before a route exists", () => {
@@ -232,6 +236,118 @@ describe("PlannerWorkspace", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Build" }));
     expect(mockMapProps.mock.lastCall[0].showDetourSearchPoint).toBe(false);
+  });
+
+  it("removes a map detour and restores it from the Undo toast", async () => {
+    const detour = {
+      name: "Paris Mountain",
+      placeId: "place-1",
+      type: "Hike",
+    };
+    const getRoute = jest
+      .fn()
+      .mockResolvedValueOnce({ routes: [{ summary: { distance: 180 } }] })
+      .mockResolvedValueOnce({ routes: [{ summary: { distance: 205 } }] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+
+    function MutationHarness() {
+      const [detourList, setDetourList] = useState([detour]);
+      return (
+        <PlannerWorkspace
+          {...createProps({
+            destination: "Charlotte",
+            detourList,
+            origin: "Atlanta",
+            setDetourList,
+            showDetourButton: true,
+            showRoute: true,
+            tripSummary: { distance: 205 },
+          })}
+        />
+      );
+    }
+
+    render(
+      <FluentProvider theme={jauntDetourTheme}>
+        <MutationHarness />
+      </FluentProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove map detour" }));
+
+    expect(
+      await screen.findByText("Paris Mountain removed from this Jaunt")
+    ).toBeVisible();
+    expect(screen.getByTestId("map-detour-count")).toHaveTextContent("0");
+    expect(screen.getByRole("button", { name: "Undo" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Undo" })).toHaveStyle({
+      minWidth: "auto",
+      paddingLeft: 0,
+      paddingRight: 0,
+    });
+    expect(
+      screen.getByRole("button", { name: "Dismiss removal notification" })
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-detour-count")).toHaveTextContent("1")
+    );
+    expect(getRoute).toHaveBeenLastCalledWith(
+      "Atlanta",
+      "Charlotte",
+      "Address",
+      { waypoints: ["place-1"] }
+    );
+  });
+
+  it("allows the removal toast to be dismissed early", async () => {
+    RouteRequester.mockImplementation(() => ({
+      getRoute: jest.fn().mockResolvedValue({
+        routes: [{ summary: { distance: 180 } }],
+      }),
+    }));
+    const detour = {
+      name: "Paris Mountain",
+      placeId: "place-1",
+      type: "Hike",
+    };
+
+    function MutationHarness() {
+      const [detourList, setDetourList] = useState([detour]);
+      return (
+        <PlannerWorkspace
+          {...createProps({
+            destination: "Charlotte",
+            detourList,
+            origin: "Atlanta",
+            setDetourList,
+            showDetourButton: true,
+            showRoute: true,
+            tripSummary: { distance: 205 },
+          })}
+        />
+      );
+    }
+
+    render(
+      <FluentProvider theme={jauntDetourTheme}>
+        <MutationHarness />
+      </FluentProvider>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove map detour" }));
+    await screen.findByText("Paris Mountain removed from this Jaunt");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss removal notification" })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Paris Mountain removed from this Jaunt")
+      ).not.toBeInTheDocument()
+    );
   });
 
   it("synchronizes detour hover and clears it when results change", () => {
@@ -462,7 +578,7 @@ describe("PlannerWorkspace", () => {
     expect(props.clearAll).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps Discover active and dismisses add feedback manually", () => {
+  it("keeps Discover active and dismisses the add toast manually", async () => {
     renderWorkspace(
       createProps({
         showDetourButton: true,
@@ -477,15 +593,22 @@ describe("PlannerWorkspace", () => {
       "aria-selected",
       "true"
     );
-    expect(
-      screen.getByText("Paris Mountain added. The route is 18 minutes longer.")
-    ).toBeVisible();
+    const dismissButton = screen.getByRole("button", {
+      name: "Dismiss added detour notification",
+    });
+    expect(dismissButton).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss feedback" }));
-    expect(screen.queryByText(/Paris Mountain added/)).not.toBeInTheDocument();
+    fireEvent.click(dismissButton);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", {
+          name: "Dismiss added detour notification",
+        })
+      ).not.toBeInTheDocument()
+    );
   });
 
-  it("clears add feedback automatically after ten seconds", () => {
+  it("clears the add toast automatically after five seconds", async () => {
     jest.useFakeTimers();
     try {
       renderWorkspace(
@@ -497,11 +620,15 @@ describe("PlannerWorkspace", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: "Complete add" }));
 
-      act(() => jest.advanceTimersByTime(10000));
+      act(() => jest.advanceTimersByTime(6000));
 
-      expect(
-        screen.queryByText(/Paris Mountain added/)
-      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", {
+            name: "Dismiss added detour notification",
+          })
+        ).not.toBeInTheDocument()
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/components/planner/PlannerWorkspace.test.jsx
+++ b/frontend/src/components/planner/PlannerWorkspace.test.jsx
@@ -1,11 +1,5 @@
 import React, { useState } from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { FluentProvider } from "@fluentui/react-components";
 import PlannerWorkspace from "./PlannerWorkspace";
 import { jauntDetourTheme } from "../../design-system/jauntDetourTheme";
@@ -300,6 +294,116 @@ describe("PlannerWorkspace", () => {
       "Address",
       { waypoints: ["place-1"] }
     );
+  });
+
+  it("retries a failed map removal from the error toast", async () => {
+    const detour = {
+      name: "Paris Mountain",
+      placeId: "place-1",
+      type: "Hike",
+    };
+    const getRoute = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce({ routes: [{ summary: { distance: 180 } }] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+
+    function MutationHarness() {
+      const [detourList, setDetourList] = useState([detour]);
+      return (
+        <PlannerWorkspace
+          {...createProps({
+            destination: "Charlotte",
+            detourList,
+            origin: "Atlanta",
+            setDetourList,
+            showDetourButton: true,
+            showRoute: true,
+            tripSummary: { distance: 205 },
+          })}
+        />
+      );
+    }
+
+    render(
+      <FluentProvider theme={jauntDetourTheme}>
+        <MutationHarness />
+      </FluentProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove map detour" }));
+
+    expect(
+      await screen.findByText("Could not remove the detour.")
+    ).toBeVisible();
+    expect(screen.getByTestId("map-detour-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      await screen.findByText("Paris Mountain removed from this Jaunt")
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByTestId("map-detour-count")).toHaveTextContent("0")
+    );
+    expect(getRoute).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a failed Undo restore from the error toast", async () => {
+    const detour = {
+      name: "Paris Mountain",
+      placeId: "place-1",
+      type: "Hike",
+    };
+    const getRoute = jest
+      .fn()
+      .mockResolvedValueOnce({ routes: [{ summary: { distance: 180 } }] })
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce({ routes: [{ summary: { distance: 205 } }] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+
+    function MutationHarness() {
+      const [detourList, setDetourList] = useState([detour]);
+      return (
+        <PlannerWorkspace
+          {...createProps({
+            destination: "Charlotte",
+            detourList,
+            origin: "Atlanta",
+            setDetourList,
+            showDetourButton: true,
+            showRoute: true,
+            tripSummary: { distance: 205 },
+          })}
+        />
+      );
+    }
+
+    render(
+      <FluentProvider theme={jauntDetourTheme}>
+        <MutationHarness />
+      </FluentProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove map detour" }));
+    await screen.findByText("Paris Mountain removed from this Jaunt");
+    await waitFor(() =>
+      expect(screen.getByTestId("map-detour-count")).toHaveTextContent("0")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(
+      await screen.findByText("Could not restore the detour.")
+    ).toBeVisible();
+    expect(screen.getByTestId("map-detour-count")).toHaveTextContent("0");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("map-detour-count")).toHaveTextContent("1")
+    );
+    expect(getRoute).toHaveBeenCalledTimes(3);
   });
 
   it("allows the removal toast to be dismissed early", async () => {
@@ -608,30 +712,31 @@ describe("PlannerWorkspace", () => {
     );
   });
 
-  it("clears the add toast automatically after five seconds", async () => {
-    jest.useFakeTimers();
-    try {
-      renderWorkspace(
-        createProps({
-          showDetourButton: true,
-          showDetourForm: true,
-          tripSummary: { distance: 245 },
-        })
-      );
-      fireEvent.click(screen.getByRole("button", { name: "Complete add" }));
+  it("delegates the add toast lifetime to Fluent without an early forced dismiss", async () => {
+    renderWorkspace(
+      createProps({
+        showDetourButton: true,
+        showDetourForm: true,
+        tripSummary: { distance: 245 },
+      })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Complete add" }));
 
-      act(() => jest.advanceTimersByTime(6000));
+    expect(
+      screen.getByRole("button", {
+        name: "Dismiss added detour notification",
+      })
+    ).toBeVisible();
 
-      await waitFor(() =>
-        expect(
-          screen.queryByRole("button", {
-            name: "Dismiss added detour notification",
-          })
-        ).not.toBeInTheDocument()
-      );
-    } finally {
-      jest.useRealTimers();
-    }
+    // The previous implementation force-dismissed via a native 5s timer. Fluent
+    // now owns the timeout (unverifiable in jsdom), so the toast must remain
+    // until Fluent dismisses it rather than being torn down by our own timer.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(
+      screen.getByRole("button", {
+        name: "Dismiss added detour notification",
+      })
+    ).toBeVisible();
   });
 
   it("keeps the map mounted while compact tools are hidden", () => {

--- a/frontend/src/components/planner/build-workflow/BuildRouteDetails.jsx
+++ b/frontend/src/components/planner/build-workflow/BuildRouteDetails.jsx
@@ -33,10 +33,11 @@ export default function BuildRouteDetails(props) {
         origin={props.origin}
         destination={props.destination}
         detourList={props.detourList}
+        failedMutation={props.failedMutation}
         onDiscover={props.onDiscover}
-        setDetourList={props.setDetourList}
-        setRoute={props.setRoute}
-        setTripSummary={props.setTripSummary}
+        pending={props.pending}
+        retryMutation={props.retryMutation}
+        runMutation={props.runMutation}
       />
       <div className={styles.saveSection}>
         <SaveTrip
@@ -52,13 +53,14 @@ export default function BuildRouteDetails(props) {
 BuildRouteDetails.propTypes = {
   destination: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   detourList: PropTypes.array.isRequired,
+  failedMutation: PropTypes.object,
   onClear: PropTypes.func.isRequired,
   onDiscover: PropTypes.func.isRequired,
   onEditRoute: PropTypes.func.isRequired,
   onSaveStateChange: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  setDetourList: PropTypes.func.isRequired,
-  setRoute: PropTypes.func.isRequired,
-  setTripSummary: PropTypes.func.isRequired,
+  pending: PropTypes.object,
+  retryMutation: PropTypes.func.isRequired,
+  runMutation: PropTypes.func.isRequired,
   tripSummary: PropTypes.object,
 };

--- a/frontend/src/components/planner/build-workflow/BuildRouteDetails.jsx
+++ b/frontend/src/components/planner/build-workflow/BuildRouteDetails.jsx
@@ -36,6 +36,7 @@ export default function BuildRouteDetails(props) {
         failedMutation={props.failedMutation}
         onDiscover={props.onDiscover}
         pending={props.pending}
+        actionsBusy={props.actionsBusy}
         retryMutation={props.retryMutation}
         runMutation={props.runMutation}
       />
@@ -60,6 +61,7 @@ BuildRouteDetails.propTypes = {
   onSaveStateChange: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   pending: PropTypes.object,
+  actionsBusy: PropTypes.bool,
   retryMutation: PropTypes.func.isRequired,
   runMutation: PropTypes.func.isRequired,
   tripSummary: PropTypes.object,

--- a/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
+++ b/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import {
   Button,
@@ -18,9 +18,7 @@ import {
   DeleteRegular,
   SearchRegular,
 } from "@fluentui/react-icons";
-import { moveDetour, recalculateItinerary } from "./routeMutations";
 import { getDetourIconComponent } from "../../../utils/detourIcons";
-import { trackEvent } from "../../../telemetry/telemetry";
 import {
   jauntColors,
   jauntRadius,
@@ -129,74 +127,31 @@ function formatAddedTime(detour) {
 export default function JauntItinerary({
   destination,
   detourList,
+  failedMutation,
   onDiscover,
   origin,
-  setDetourList,
-  setRoute,
-  setTripSummary,
+  pending,
+  retryMutation,
+  runMutation,
 }) {
   const styles = useStyles();
-  const [pending, setPending] = useState(null);
-  const [failedMutation, setFailedMutation] = useState(null);
-  const requestIdRef = useRef(0);
   const actionRefs = useRef(new Map());
   const headingRef = useRef(null);
 
-  const runMutation = async (mutation) => {
-    const nextDetours =
-      mutation.kind === "remove"
-        ? detourList.filter((detour, index) => index !== mutation.index)
-        : moveDetour(detourList, mutation.index, mutation.toIndex);
-
-    if (nextDetours === detourList) {
-      return;
-    }
-
-    const requestId = requestIdRef.current + 1;
-    requestIdRef.current = requestId;
-    setPending(mutation);
-    setFailedMutation(null);
-
-    try {
-      const route = await recalculateItinerary({
-        destination,
-        detours: nextDetours,
-        origin,
+  const runItineraryMutation = async (mutation) => {
+    const result = await runMutation(mutation);
+    if (result.status === "success" && mutation.kind === "remove") {
+      const focusIndex = Math.min(
+        mutation.index,
+        result.nextDetours.length - 1
+      );
+      window.setTimeout(() => {
+        if (focusIndex >= 0) {
+          actionRefs.current.get(focusIndex)?.focus();
+        } else {
+          headingRef.current?.focus();
+        }
       });
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-      setRoute(route);
-      setTripSummary(route.summary);
-      setDetourList(nextDetours);
-      setPending(null);
-
-      if (mutation.kind === "remove") {
-        trackEvent("detour_removed", {
-          category: detourList[mutation.index]?.type || "Unspecified",
-          countBucket:
-            nextDetours.length === 0
-              ? "0"
-              : nextDetours.length <= 5
-                ? "1-5"
-                : "6+",
-          feature: "detour",
-        });
-        const focusIndex = Math.min(mutation.index, nextDetours.length - 1);
-        window.setTimeout(() => {
-          if (focusIndex >= 0) {
-            actionRefs.current.get(focusIndex)?.focus();
-          } else {
-            headingRef.current?.focus();
-          }
-        });
-      }
-    } catch {
-      if (requestId !== requestIdRef.current) {
-        return;
-      }
-      setPending(null);
-      setFailedMutation(mutation);
     }
   };
 
@@ -222,7 +177,7 @@ export default function JauntItinerary({
             The route could not be recalculated. Your itinerary was not changed.
           </MessageBarBody>
           <MessageBarActions>
-            <Button onClick={() => runMutation(failedMutation)}>Retry</Button>
+            <Button onClick={retryMutation}>Retry</Button>
           </MessageBarActions>
         </MessageBar>
       ) : null}
@@ -273,7 +228,11 @@ export default function JauntItinerary({
                     icon={<ArrowUpRegular />}
                     disabled={pending != null || index === 0}
                     onClick={() =>
-                      runMutation({ kind: "move", index, toIndex: index - 1 })
+                      runItineraryMutation({
+                        kind: "move",
+                        index,
+                        toIndex: index - 1,
+                      })
                     }
                   />
                 </Tooltip>
@@ -286,7 +245,11 @@ export default function JauntItinerary({
                       pending != null || index === detourList.length - 1
                     }
                     onClick={() =>
-                      runMutation({ kind: "move", index, toIndex: index + 1 })
+                      runItineraryMutation({
+                        kind: "move",
+                        index,
+                        toIndex: index + 1,
+                      })
                     }
                   />
                 </Tooltip>
@@ -303,7 +266,9 @@ export default function JauntItinerary({
                       itemPending ? <Spinner size="tiny" /> : <DeleteRegular />
                     }
                     disabled={pending != null}
-                    onClick={() => runMutation({ kind: "remove", index })}
+                    onClick={() =>
+                      runItineraryMutation({ kind: "remove", index })
+                    }
                   />
                 </Tooltip>
               </span>
@@ -339,9 +304,10 @@ export default function JauntItinerary({
 JauntItinerary.propTypes = {
   destination: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   detourList: PropTypes.array.isRequired,
+  failedMutation: PropTypes.object,
   onDiscover: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  setDetourList: PropTypes.func.isRequired,
-  setRoute: PropTypes.func.isRequired,
-  setTripSummary: PropTypes.func.isRequired,
+  pending: PropTypes.object,
+  retryMutation: PropTypes.func.isRequired,
+  runMutation: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
+++ b/frontend/src/components/planner/build-workflow/JauntItinerary.jsx
@@ -131,6 +131,7 @@ export default function JauntItinerary({
   onDiscover,
   origin,
   pending,
+  actionsBusy,
   retryMutation,
   runMutation,
 }) {
@@ -177,7 +178,7 @@ export default function JauntItinerary({
             The route could not be recalculated. Your itinerary was not changed.
           </MessageBarBody>
           <MessageBarActions>
-            <Button onClick={retryMutation}>Retry</Button>
+            <Button onClick={() => retryMutation()}>Retry</Button>
           </MessageBarActions>
         </MessageBar>
       ) : null}
@@ -226,7 +227,7 @@ export default function JauntItinerary({
                     appearance="subtle"
                     aria-label={`Move ${detour.name} earlier`}
                     icon={<ArrowUpRegular />}
-                    disabled={pending != null || index === 0}
+                    disabled={pending != null || actionsBusy || index === 0}
                     onClick={() =>
                       runItineraryMutation({
                         kind: "move",
@@ -242,7 +243,9 @@ export default function JauntItinerary({
                     aria-label={`Move ${detour.name} later`}
                     icon={<ArrowDownRegular />}
                     disabled={
-                      pending != null || index === detourList.length - 1
+                      pending != null ||
+                      actionsBusy ||
+                      index === detourList.length - 1
                     }
                     onClick={() =>
                       runItineraryMutation({
@@ -265,7 +268,7 @@ export default function JauntItinerary({
                     icon={
                       itemPending ? <Spinner size="tiny" /> : <DeleteRegular />
                     }
-                    disabled={pending != null}
+                    disabled={pending != null || actionsBusy}
                     onClick={() =>
                       runItineraryMutation({ kind: "remove", index })
                     }
@@ -308,6 +311,7 @@ JauntItinerary.propTypes = {
   onDiscover: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   pending: PropTypes.object,
+  actionsBusy: PropTypes.bool,
   retryMutation: PropTypes.func.isRequired,
   runMutation: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/planner/build-workflow/JauntItinerary.test.jsx
+++ b/frontend/src/components/planner/build-workflow/JauntItinerary.test.jsx
@@ -59,6 +59,20 @@ describe("JauntItinerary", () => {
     trackEvent.mockReset();
   });
 
+  it("disables itinerary actions while another mutation is in flight", () => {
+    renderItinerary(createProps({ actionsBusy: true }));
+
+    expect(
+      screen.getByRole("button", { name: "Move Falls Park earlier" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Move Paris Mountain later" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove Paris Mountain" })
+    ).toBeDisabled();
+  });
+
   it("renders a complete non-map route sequence", () => {
     renderItinerary(createProps());
 

--- a/frontend/src/components/planner/build-workflow/JauntItinerary.test.jsx
+++ b/frontend/src/components/planner/build-workflow/JauntItinerary.test.jsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { FluentProvider } from "@fluentui/react-components";
 import JauntItinerary from "./JauntItinerary";
+import useDetourMutations from "./useDetourMutations";
 import RouteRequester from "../../../scripts/RouteRequester";
 import { jauntDetourTheme } from "../../../design-system/jauntDetourTheme";
 import { trackEvent } from "../../../telemetry/telemetry";
@@ -40,9 +41,14 @@ function createProps(overrides = {}) {
 }
 
 function renderItinerary(props) {
+  function ItineraryHarness() {
+    const mutations = useDetourMutations(props);
+    return <JauntItinerary {...props} {...mutations} />;
+  }
+
   return render(
     <FluentProvider theme={jauntDetourTheme}>
-      <JauntItinerary {...props} />
+      <ItineraryHarness />
     </FluentProvider>
   );
 }

--- a/frontend/src/components/planner/build-workflow/useDetourMutations.js
+++ b/frontend/src/components/planner/build-workflow/useDetourMutations.js
@@ -1,0 +1,130 @@
+import { useCallback, useRef, useState } from "react";
+import { trackEvent } from "../../../telemetry/telemetry";
+import { moveDetour, recalculateItinerary } from "./routeMutations";
+
+function getDetourIdentity(detour) {
+  return detour?.placeId || detour?.id || null;
+}
+
+export default function useDetourMutations(options) {
+  const [pending, setPending] = useState(null);
+  const [failedMutation, setFailedMutation] = useState(null);
+  const [undoRemoval, setUndoRemoval] = useState(null);
+  const requestIdRef = useRef(0);
+  const optionsRef = useRef(options);
+  const undoRemovalRef = useRef(null);
+  optionsRef.current = options;
+
+  const updateUndoRemoval = useCallback((nextUndoRemoval) => {
+    undoRemovalRef.current = nextUndoRemoval;
+    setUndoRemoval(nextUndoRemoval);
+  }, []);
+
+  const runMutation = useCallback(
+    async (mutation) => {
+      const {
+        destination,
+        detourList,
+        origin,
+        setDetourList,
+        setRoute,
+        setTripSummary,
+      } = optionsRef.current;
+      const nextDetours =
+        mutation.kind === "remove"
+          ? detourList.filter((detour, index) => index !== mutation.index)
+          : mutation.kind === "restore"
+            ? (() => {
+                const identity = getDetourIdentity(mutation.detour);
+                if (
+                  identity &&
+                  detourList.some(
+                    (detour) => getDetourIdentity(detour) === identity
+                  )
+                ) {
+                  return detourList;
+                }
+                const restoredDetours = detourList.slice();
+                const insertionIndex = Math.min(
+                  Math.max(mutation.index, 0),
+                  restoredDetours.length
+                );
+                restoredDetours.splice(insertionIndex, 0, mutation.detour);
+                return restoredDetours;
+              })()
+            : moveDetour(detourList, mutation.index, mutation.toIndex);
+
+      if (nextDetours === detourList) {
+        return { status: "unchanged" };
+      }
+
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      setPending(mutation);
+      setFailedMutation(null);
+
+      try {
+        const route = await recalculateItinerary({
+          destination,
+          detours: nextDetours,
+          origin,
+        });
+        if (requestId !== requestIdRef.current) {
+          return { status: "stale" };
+        }
+
+        setRoute(route);
+        setTripSummary(route.summary);
+        setDetourList(nextDetours);
+        setPending(null);
+
+        if (mutation.kind === "remove") {
+          const removedDetour = detourList[mutation.index];
+          updateUndoRemoval(
+            removedDetour
+              ? { detour: removedDetour, index: mutation.index }
+              : null
+          );
+          trackEvent("detour_removed", {
+            category: detourList[mutation.index]?.type || "Unspecified",
+            countBucket:
+              nextDetours.length === 0
+                ? "0"
+                : nextDetours.length <= 5
+                  ? "1-5"
+                  : "6+",
+            feature: "detour",
+          });
+        } else if (mutation.kind === "restore") {
+          updateUndoRemoval(null);
+        }
+
+        return { mutation, nextDetours, route, status: "success" };
+      } catch {
+        if (requestId !== requestIdRef.current) {
+          return { status: "stale" };
+        }
+        setPending(null);
+        setFailedMutation(mutation);
+        return { mutation, status: "failed" };
+      }
+    },
+    [updateUndoRemoval]
+  );
+
+  return {
+    clearUndoRemoval: () => updateUndoRemoval(null),
+    failedMutation,
+    pending,
+    retryMutation: () =>
+      failedMutation
+        ? runMutation(failedMutation)
+        : Promise.resolve({ status: "unchanged" }),
+    runMutation,
+    undoLastRemoval: () =>
+      undoRemovalRef.current
+        ? runMutation({ kind: "restore", ...undoRemovalRef.current })
+        : Promise.resolve({ status: "unchanged" }),
+    undoRemoval,
+  };
+}

--- a/frontend/src/components/planner/build-workflow/useDetourMutations.js
+++ b/frontend/src/components/planner/build-workflow/useDetourMutations.js
@@ -116,10 +116,12 @@ export default function useDetourMutations(options) {
     clearUndoRemoval: () => updateUndoRemoval(null),
     failedMutation,
     pending,
-    retryMutation: () =>
-      failedMutation
-        ? runMutation(failedMutation)
-        : Promise.resolve({ status: "unchanged" }),
+    retryMutation: (mutation) => {
+      const target = mutation || failedMutation;
+      return target
+        ? runMutation(target)
+        : Promise.resolve({ status: "unchanged" });
+    },
     runMutation,
     undoLastRemoval: () =>
       undoRemovalRef.current

--- a/frontend/src/components/planner/build-workflow/useDetourMutations.test.js
+++ b/frontend/src/components/planner/build-workflow/useDetourMutations.test.js
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import RouteRequester from "../../../scripts/RouteRequester";
+import { trackEvent } from "../../../telemetry/telemetry";
+import useDetourMutations from "./useDetourMutations";
+
+jest.mock("../../../scripts/RouteRequester");
+jest.mock("../../../telemetry/telemetry", () => ({ trackEvent: jest.fn() }));
+
+const detours = [
+  { name: "Paris Mountain", placeId: "one", type: "Hike" },
+  { name: "Falls Park", placeId: "two", type: "Landmark" },
+];
+
+function createProps(overrides = {}) {
+  return {
+    destination: "Charlotte",
+    detourList: detours,
+    origin: "Atlanta",
+    setDetourList: jest.fn(),
+    setRoute: jest.fn(),
+    setTripSummary: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("useDetourMutations", () => {
+  beforeEach(() => {
+    RouteRequester.mockReset();
+    trackEvent.mockReset();
+  });
+
+  it("captures a successful removal and restores it into the current route", async () => {
+    const removedRoute = { summary: { distance: 180 } };
+    const restoredRoute = { summary: { distance: 205 } };
+    const getRoute = jest
+      .fn()
+      .mockResolvedValueOnce({ routes: [removedRoute] })
+      .mockResolvedValueOnce({ routes: [restoredRoute] });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+    const props = createProps();
+    const { result, rerender } = renderHook(
+      (hookProps) => useDetourMutations(hookProps),
+      { initialProps: props }
+    );
+
+    await act(() => result.current.runMutation({ kind: "remove", index: 0 }));
+
+    expect(props.setDetourList).toHaveBeenLastCalledWith([detours[1]]);
+    expect(result.current.undoRemoval).toEqual({
+      detour: detours[0],
+      index: 0,
+    });
+
+    rerender({ ...props, detourList: [detours[1]] });
+    await act(() => result.current.undoLastRemoval());
+
+    expect(props.setDetourList).toHaveBeenLastCalledWith(detours);
+    expect(props.setRoute).toHaveBeenLastCalledWith(restoredRoute);
+    expect(result.current.undoRemoval).toBeNull();
+    expect(getRoute).toHaveBeenLastCalledWith(
+      "Atlanta",
+      "Charlotte",
+      "Address",
+      { waypoints: ["one", "two"] }
+    );
+  });
+
+  it("does not duplicate a detour that is already present when Undo runs", async () => {
+    RouteRequester.mockImplementation(() => ({
+      getRoute: jest.fn().mockResolvedValue({
+        routes: [{ summary: { distance: 180 } }],
+      }),
+    }));
+    const props = createProps();
+    const { result, rerender } = renderHook(
+      (hookProps) => useDetourMutations(hookProps),
+      { initialProps: props }
+    );
+
+    await act(() => result.current.runMutation({ kind: "remove", index: 0 }));
+    rerender(props);
+    const setDetourListCalls = props.setDetourList.mock.calls.length;
+
+    await act(() => result.current.undoLastRemoval());
+
+    expect(props.setDetourList).toHaveBeenCalledTimes(setDetourListCalls);
+  });
+});

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
@@ -15,7 +15,6 @@ import {
 import {
   BuildingBankRegular,
   BuildingRegular,
-  DismissRegular,
   DrinkBeerRegular,
   DrinkCoffeeRegular,
   FoodRegular,
@@ -442,20 +441,6 @@ export default function DiscoverWorkspace(props) {
 
   return (
     <section className={styles.root} aria-labelledby="discover-title">
-      {props.feedback ? (
-        <MessageBar intent="success">
-          <MessageBarBody>{props.feedback}</MessageBarBody>
-          <MessageBarActions>
-            <Button
-              appearance="transparent"
-              aria-label="Dismiss added stop message"
-              icon={<DismissRegular />}
-              onClick={props.onDismissFeedback}
-            />
-          </MessageBarActions>
-        </MessageBar>
-      ) : null}
-
       <div className={styles.heading}>
         <Text className={styles.eyebrow}>Along this route</Text>
         <h3 className={styles.title} id="discover-title">
@@ -696,11 +681,9 @@ DiscoverWorkspace.propTypes = {
   detourSearchLocation: PropTypes.number.isRequired,
   detourSearchRadius: PropTypes.number.isRequired,
   detourType: PropTypes.string.isRequired,
-  feedback: PropTypes.string,
   hoveredDetourId: PropTypes.string,
   onAdded: PropTypes.func.isRequired,
   onDetourHover: PropTypes.func.isRequired,
-  onDismissFeedback: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   route: PropTypes.object.isRequired,
   setRoute: PropTypes.func.isRequired,

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.jsx
@@ -373,8 +373,12 @@ export default function DiscoverWorkspace(props) {
   };
 
   const addResult = async (result) => {
+    if (props.mutationPending) {
+      return;
+    }
     setAddingId(result.place_id);
     setAddErrorId(null);
+    props.onAddingChange?.(true);
     trackEvent("detour_add_started", {
       category: result.type,
       feature: "detour",
@@ -415,6 +419,7 @@ export default function DiscoverWorkspace(props) {
       props.setDetourHighlight([]);
       setStatus("idle");
       setAddingId(null);
+      props.onAddingChange?.(false);
       props.onAdded(result.name, addedTime);
       trackEvent("detour_added", {
         category: result.type,
@@ -423,6 +428,7 @@ export default function DiscoverWorkspace(props) {
       });
     } catch {
       setAddingId(null);
+      props.onAddingChange?.(false);
       setAddErrorId(result.place_id);
       trackEvent("detour_add_failed", {
         category: result.type,
@@ -655,7 +661,7 @@ export default function DiscoverWorkspace(props) {
                     <Button
                       className={styles.resultAction}
                       appearance="primary"
-                      disabled={addingId != null}
+                      disabled={addingId != null || props.mutationPending}
                       icon={adding ? <Spinner size="tiny" /> : null}
                       onClick={() => addResult(result)}
                     >
@@ -683,6 +689,8 @@ DiscoverWorkspace.propTypes = {
   detourType: PropTypes.string.isRequired,
   hoveredDetourId: PropTypes.string,
   onAdded: PropTypes.func.isRequired,
+  onAddingChange: PropTypes.func,
+  mutationPending: PropTypes.bool,
   onDetourHover: PropTypes.func.isRequired,
   origin: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   route: PropTypes.object.isRequired,

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
@@ -269,6 +269,63 @@ describe("DiscoverWorkspace", () => {
     expect(props.onAdded).toHaveBeenCalledWith("Paris Mountain", 18);
   });
 
+  it("disables Add and stays inert while a shared mutation is pending", () => {
+    const result = {
+      id: "one",
+      name: "Paris Mountain",
+      place_id: "place-1",
+      rating: 4.7,
+      type: "Hike",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const getRoute = jest.fn();
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+    const props = createProps({
+      detourOptions: [result],
+      detourHighlight: [{ id: "place-1", highlight: true }],
+      mutationPending: true,
+      onAddingChange: jest.fn(),
+    });
+    renderWorkspace(props);
+
+    const addButton = screen.getByRole("button", { name: "Add" });
+    expect(addButton).toBeDisabled();
+
+    fireEvent.click(addButton);
+
+    expect(getRoute).not.toHaveBeenCalled();
+    expect(props.addDetour).not.toHaveBeenCalled();
+    expect(props.onAddingChange).not.toHaveBeenCalled();
+  });
+
+  it("signals adding state to coordinate with other mutations", async () => {
+    const result = {
+      id: "one",
+      name: "Paris Mountain",
+      place_id: "place-1",
+      rating: 4.7,
+      type: "Hike",
+      geometry: { location: { lat: 34.9, lng: -82.4 } },
+    };
+    const getRoute = jest.fn().mockResolvedValue({
+      routes: [{ summary: { distance: 258, time: { hours: 4, min: 5 } } }],
+    });
+    RouteRequester.mockImplementation(() => ({ getRoute }));
+    const onAddingChange = jest.fn();
+    const props = createProps({
+      detourOptions: [result],
+      detourHighlight: [{ id: "place-1", highlight: true }],
+      onAddingChange,
+    });
+    renderWorkspace(props);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAddingChange).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(props.addDetour).toHaveBeenCalledTimes(1));
+    expect(onAddingChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("previews a result on hover without selecting it or showing Add", () => {
     const result = {
       name: "Paris Mountain",

--- a/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
+++ b/frontend/src/components/planner/discover-workflow/DiscoverWorkspace.test.jsx
@@ -40,10 +40,8 @@ function createProps(overrides = {}) {
     setRoute: jest.fn(),
     setTripSummary: jest.fn(),
     addDetour: jest.fn(),
-    feedback: "",
     onAdded: jest.fn(),
     onDetourHover: jest.fn(),
-    onDismissFeedback: jest.fn(),
     ...overrides,
   };
 }
@@ -114,19 +112,6 @@ describe("DiscoverWorkspace", () => {
       screen.getByRole("slider", { name: "Where along the route?" })
     ).toHaveValue("63.4");
     expect(screen.getByText("Later in the drive · 63%")).toBeVisible();
-  });
-
-  it("shows dismissible add feedback at the top", () => {
-    const props = createProps({
-      feedback: "Paris Mountain added. The route is 18 minutes longer.",
-    });
-    renderWorkspace(props);
-
-    expect(screen.getByText(/Paris Mountain added/)).toBeVisible();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Dismiss added stop message" })
-    );
-    expect(props.onDismissFeedback).toHaveBeenCalledTimes(1);
   });
 
   it("restores persisted results and clears them when criteria changes", () => {

--- a/frontend/src/containers/MainContainer.js
+++ b/frontend/src/containers/MainContainer.js
@@ -92,13 +92,6 @@ let matchDispatchToProps = (dispatch) => {
           detour: detour,
         },
       }),
-    removeDetour: (index) =>
-      dispatch({
-        type: "REMOVE_DETOUR",
-        data: {
-          index: index,
-        },
-      }),
     setDetourList: (detourList) =>
       dispatch({
         type: "SET_DETOUR_LIST",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,11 +23,3 @@ code {
 .jaunt-map .gm-style-iw-tc {
   display: none;
 }
-
-/* Keep preview and selected card geometry identical without a preview action. */
-.jaunt-map
-  .gm-style-iw:has(.jaunt-marker-details--hovered)
-  .gm-ui-hover-effect {
-  visibility: hidden;
-  pointer-events: none;
-}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,3 +23,17 @@ code {
 .jaunt-map .gm-style-iw-tc {
   display: none;
 }
+
+.jaunt-map .gm-style-iw:has(.jaunt-marker-details--selected) {
+  position: absolute;
+}
+
+.jaunt-map .gm-style-iw:has(.jaunt-marker-details--selected)::after {
+  position: absolute;
+  z-index: 1;
+  border: 2px solid #12664f;
+  border-radius: 8px;
+  pointer-events: none;
+  content: "";
+  inset: 0;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,7 +31,7 @@ code {
 .jaunt-map .gm-style-iw:has(.jaunt-marker-details--selected)::after {
   position: absolute;
   z-index: 1;
-  border: 2px solid #12664f;
+  border: 2px solid var(--colorBrandStroke1);
   border-radius: 8px;
   pointer-events: none;
   content: "";

--- a/frontend/src/reducers/main-reducer.js
+++ b/frontend/src/reducers/main-reducer.js
@@ -123,14 +123,6 @@ const mainReducer = (state = initialState, action) => {
         ...state,
         detourList: [...state.detourList, action.data.detour],
       };
-    case "REMOVE_DETOUR":
-      var newDetourList = state.detourList.filter(function (detour, index) {
-        return index !== action.data.index;
-      });
-      return {
-        ...state,
-        detourList: newDetourList,
-      };
     case "SET_DETOUR_LIST":
       return {
         ...state,


### PR DESCRIPTION
## Summary

Adds scalable detour actions to map detail cards and centralizes detour
mutations so the map and itinerary use the same rerouting, retry, and recovery
behavior.

## Changes

* Added an ellipsis menu to added-detour map cards with a **Remove detour**
  action
* Made hover cards interactive while moving between a marker and its details
  card
* Kept the ellipsis and close controls visible on hover and selected cards
* Added a short hover-dismiss delay to prevent cards from disappearing during
  pointer transitions
* Added Jaunt green borders to selected pins and detail cards without changing
  marker size
* Centralized detour removal, movement, restoration, and retry behavior in a
  shared mutation hook
* Reroutes before committing detour changes and preserves the current route when
  rerouting fails
* Added a five-second Fluent toast after detour removal with **Undo** and early
  dismissal
* Added retry feedback for failed map removals and failed Undo operations
* Replaced the Discover inline success message with a consistent five-second
  Fluent toast
* Removed the obsolete index-only Redux detour removal action
* Added `detour_removed` telemetry for successful removals

## Files Modified

* Map interactions and presentation:
  `frontend/src/components/MapContainer.jsx` and `frontend/src/index.css`
* Shared mutation handling:
  `frontend/src/components/planner/build-workflow/useDetourMutations.js`
* Planner, itinerary, and Discover integration:
  `PlannerWorkspace.jsx`, `JauntItinerary.jsx`, and `DiscoverWorkspace.jsx`
* Redux cleanup:
  `frontend/src/containers/MainContainer.js` and
  `frontend/src/reducers/main-reducer.js`
* Unit and Playwright coverage for map actions, hover behavior, removal, Undo,
  retry, and toast dismissal

## Testing

* Frontend Jest suite: 31 suites and 218 tests passed
* Frontend ESLint passed
* Production frontend build passed
* Playwright discovered 12 desktop and compact scenarios
* Playwright browser execution remains unverified because the dev container is
  missing required browser system libraries

## Assumptions

* The PR targets `development`
* Undo restores the latest removed detour into the current itinerary and
  reroutes from the current route state
* Add and removal notifications dismiss after five seconds unless dismissed or
  acted on earlier